### PR TITLE
create MirKBD for InfinityBook Pro 15 (Gen9)

### DIFF
--- a/InfinityBook Pro 15 (Gen9)/TUXEDO - InfinityBookPro15-Gen9 - MirKBD ISO.svg
+++ b/InfinityBook Pro 15 (Gen9)/TUXEDO - InfinityBookPro15-Gen9 - MirKBD ISO.svg
@@ -1,0 +1,5515 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg1"
+   width="1436.2267"
+   height="604.724"
+   viewBox="0 0 1436.2267 604.724"
+   sodipodi:docname="TUXEDO - InfinityBookPro15-Gen9 - MirKBD ISO.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <!--
+	Abstand 1.4 mm
+	Fonts:	 9pt kleinste Tasten
+		11pt wo Platz eng ist
+		13pt kleine Tasten/Zeichen
+		16pt große Zeichen
+		20pt Ctrl, Alt, …
+		24pt Tab, Backspace
+
+	Ausrichten von Buchstaben via bc(1): erst li/re an den Kasten, dann:
+
+	scale=4
+	define l(x,w) {
+		return x+1.4+(4.718-w)/2+0.0004
+	}
+	define r(x,w) {
+		return (x+w)-1.4-(4.718-w)/2-w-0.0004
+	}
+  -->
+  <metadata
+     id="metadata4228">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs1">
+    <rect
+       x="1115.559"
+       y="-50.35616"
+       width="233.3519"
+       height="79.36306"
+       id="rect2969" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath104">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-154.95111,-299.22661)"
+         id="path104" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath106">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-206.80461,-297.46681)"
+         id="path106" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath108">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-264.59461,-297.46681)"
+         id="path108" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath110">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-313.83881,-302.89061)"
+         id="path110" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath112">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-368.79481,-297.46681)"
+         id="path112" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath114">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-417.86421,-297.80271)"
+         id="path114" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath116">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-476.23821,-307.75491)"
+         id="path116" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath118">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-528.58001,-307.41891)"
+         id="path118" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath120">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-580.13761,-299.22661)"
+         id="path120" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath122">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-632.87102,-302.77881)"
+         id="path122" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath124">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-687.58781,-309.11471)"
+         id="path124" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath126">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-168.7851,-252.65821)"
+         id="path126" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath128">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-218.43061,-246.9307)"
+         id="path128" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath130">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-273.93151,-246.0664)"
+         id="path130" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath132">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-327.39251,-244.3066)"
+         id="path132" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath134">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-382.26161,-244.3066)"
+         id="path134" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath136">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-432.68351,-244.3066)"
+         id="path136" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath138">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-489.23231,-254.59471)"
+         id="path138" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath140">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-539.12591,-244.3066)"
+         id="path140" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath142">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-597.05071,-244.3066)"
+         id="path142" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath144">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-647.72942,-255.95511)"
+         id="path144" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath146">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-196.0624,-191.16111)"
+         id="path146" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath148">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-246.4198,-191.16111)"
+         id="path148" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath150">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-302.64051,-191.16111)"
+         id="path150" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath152">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-355.89441,-191.16111)"
+         id="path152" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath154">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-406.78701,-192.8574)"
+         id="path154" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath156">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-459.15231,-191.16111)"
+         id="path156" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath158">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-516.34171,-201.4492)"
+         id="path158" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath160">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-700.87792,-255.95511)"
+         id="path160" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath162">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-79.103402,-356.40431)"
+         id="path162" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath164">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-713.24022,-360.86041)"
+         id="path164" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath166">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-741.01652,-303.43461)"
+         id="path166" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath168">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-754.11422,-248.1787)"
+         id="path168" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath170">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-145.63371,-199.17681)"
+         id="path170" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath172">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-568.45111,-193.46481)"
+         id="path172" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath174">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-621.60052,-193.46481)"
+         id="path174" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath176">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-675.24602,-195.4492)"
+         id="path176" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath178">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-660.58391,-356.56451)"
+         id="path178" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath180">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-126.63471,-358.03611)"
+         id="path180" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath182">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-178.8964,-350.94821)"
+         id="path182" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath184">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-234.66891,-356.59621)"
+         id="path184" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath186">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-289.1464,-354.24411)"
+         id="path186" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath188">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-341.85541,-355.84421)"
+         id="path188" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath190">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-394.27731,-352.37211)"
+         id="path190" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath192">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-447.09071,-350.61231)"
+         id="path192" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath194">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-500.43941,-352.35641)"
+         id="path194" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath196">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-553.59761,-356.03611)"
+         id="path196" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath198">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-606.81932,-352.37211)"
+         id="path198" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath200">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-914.12012,-281.86261)"
+         id="path200" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath202">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-906.4213,-177.3796)"
+         id="path202" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath204">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-869.3017,-233.12641)"
+         id="path204" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath206">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-951.934,-226.12341)"
+         id="path206" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath208">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-867.0976,-297.45211)"
+         id="path208" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath210">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-910.07815,-299.19631)"
+         id="path210" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath212">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-952.8583,-302.87601)"
+         id="path212" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath214">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-865.53805,-198.585)"
+         id="path214" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath216">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-867.4609,-139.7412)"
+         id="path216" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath218">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-907.4296,-191.49711)"
+         id="path218" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath220">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-952.82612,-197.14551)"
+         id="path220" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath222">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-954.41792,-140.3193)"
+         id="path222" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath224">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-868.6015,-247.93851)"
+         id="path224" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath226">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-910.9423,-249.53911)"
+         id="path226" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath228">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-952.98632,-246.0664)"
+         id="path228" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath230">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-998.9101,-354.90041)"
+         id="path230" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath232">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-909.3349,-350.61231)"
+         id="path232" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath234">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-952.64155,-357.95211)"
+         id="path234" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath236">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-997.03022,-292.41991)"
+         id="path236" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath238">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-75.198204,-338.18951)"
+         id="path238" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath240">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-118.74111,-334.74561)"
+         id="path240" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath242">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-173.56341,-337.86231)"
+         id="path242" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath244">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-227.06631,-336.86431)"
+         id="path244" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath246">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-279.73531,-331.66461)"
+         id="path246" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath248">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-336.42081,-336.11041)"
+         id="path248" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath250">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-385.15031,-334.05661)"
+         id="path250" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath252">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-436.92181,-332.93851)"
+         id="path252" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath254">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-491.48821,-340.37451)"
+         id="path254" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath256">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-542.36221,-331.78121)"
+         id="path256" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath258">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-596.07031,-336.39651)"
+         id="path258" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath260">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-651.70211,-334.74561)"
+         id="path260" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath262">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-704.45502,-339.14211)"
+         id="path262" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath264">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-729.88472,-287.80131)"
+         id="path264" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath266">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-742.55562,-231.93261)"
+         id="path266" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath268">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-130.7734,-179.2471)"
+         id="path268" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath270">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-556.98241,-175.2949)"
+         id="path270" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath272">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-610.13182,-175.2949)"
+         id="path272" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath274">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-665.94622,-173.0977)"
+         id="path274" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath276">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-191.1864,-336.39601)"
+         id="path276" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath278">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-245.48821,-339.01811)"
+         id="path278" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath280">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-459.22841,-341.29741)"
+         id="path280" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath282">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-512.22061,-331.65141)"
+         id="path282" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath284">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-562.96771,-331.87261)"
+         id="path284" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath286">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-618.11812,-339.28271)"
+         id="path286" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath288">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-668.29001,-341.29741)"
+         id="path288" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath290">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-164.0527,-282.93951)"
+         id="path290" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath292">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-271.35241,-279.79351)"
+         id="path292" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath294">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-750.35252,-283.29051)"
+         id="path294" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath296">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-153.6405,-181.626)"
+         id="path296" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath298">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-522.60442,-173.4883)"
+         id="path298" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath300">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-87.6286,-246.6973)"
+         id="path300" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath302">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-87.628405,-199.0585)"
+         id="path302" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath304">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-819.82202,-199.0585)"
+         id="path304" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath306">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-816.56905,-354.98431)"
+         id="path306" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath308">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-814.86002,-290.60821)"
+         id="path308" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath310">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-79.857699,-301.53721)"
+         id="path310" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath312">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-96.399302,-298.993)"
+         id="path312" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath314">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-91.346005,-299.3164)"
+         id="path314" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath316">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-83.963702,-303.11081)"
+         id="path316" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath318">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-644.46302,-126.46671)"
+         id="path318" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath320">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-78.660099,-141.6406)"
+         id="path320" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath322">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-85.466702,-140.2363)"
+         id="path322" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath324">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-88.9687,-143.17971)"
+         id="path324" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath326">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-95.1835,-140.2363)"
+         id="path326" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath328">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-138.8779,-140.2363)"
+         id="path328" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath330">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-143.07711,-140.2363)"
+         id="path330" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath332">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-244.55851,-145.1592)"
+         id="path332" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath334">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-250.92081,-140.2363)"
+         id="path334" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath336">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-253.26261,-140.2363)"
+         id="path336" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath338">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-557.59951,-145.1592)"
+         id="path338" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath340">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-563.96191,-140.2363)"
+         id="path340" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath342">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-566.30362,-140.2363)"
+         id="path342" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath344">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-572.85541,-140.2363)"
+         id="path344" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath346">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-576.44041,-143.17971)"
+         id="path346" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath348">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-631.54001,-141.6406)"
+         id="path348" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath350">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-638.34662,-140.2363)"
+         id="path350" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath352">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-641.84861,-143.17971)"
+         id="path352" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath354">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-648.06341,-140.2363)"
+         id="path354" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath356">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-860.86615,-353.03321)"
+         id="path356" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath358">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-868.4218,-358.82031)"
+         id="path358" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath360">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-874.3681,-358.82031)"
+         id="path360" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath362">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-988.2919,-182.082)"
+         id="path362" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath364">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-990.3232,-182.082)"
+         id="path364" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath366">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-996.64742,-182.082)"
+         id="path366" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath368">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-1002.2079,-182.082)"
+         id="path368" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath370">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-1004.4999,-185.0254)"
+         id="path370" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath372">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-862.32715,-120.4023)"
+         id="path372" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath374">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-864.54392,-126.0361)"
+         id="path374" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath376">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-866.57222,-120.4023)"
+         id="path376" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath378">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-871.80662,-120.4023)"
+         id="path378" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath380">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-877.56632,-120.4023)"
+         id="path380" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath382">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-948.08395,-120.4365)"
+         id="path382" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath384">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-950.11525,-120.4365)"
+         id="path384" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath386">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-956.4394,-120.4365)"
+         id="path386" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath388">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-959.68652,-120.4365)"
+         id="path388" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath390">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-756.50874,-116.4229)"
+         id="path390" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath392">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-761.40519,-121.3096)"
+         id="path392" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath394">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-765.78999,-115.6758)"
+         id="path394" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath396">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-767.92569,-116.44041)"
+         id="path396" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath398">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-775.79394,-119.583)"
+         id="path398" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath400">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-756.50874,-63.277299)"
+         id="path400" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath402">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-761.40519,-68.164104)"
+         id="path402" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath404">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-765.78999,-62.530299)"
+         id="path404" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath406">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-767.92569,-63.294902)"
+         id="path406" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath408">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-775.33494,-62.088902)"
+         id="path408" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath410">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-706.25092,-65.446299)"
+         id="path410" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath412">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-711.57122,-63.375999)"
+         id="path412" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath414">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-715.04582,-64.015599)"
+         id="path414" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath416">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-719.84662,-66.985404)"
+         id="path416" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath418">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-814.12592,-62.611299)"
+         id="path418" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath420">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-816.15722,-62.611299)"
+         id="path420" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath422">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-821.64355,-63.375999)"
+         id="path422" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath424">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-828.70705,-62.611299)"
+         id="path424" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath426">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-860.5126,-282.70801)"
+         id="path426" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath428">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-865.83295,-280.63821)"
+         id="path428" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath430">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-869.30762,-281.27691)"
+         id="path430" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath432">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-874.1083,-284.2471)"
+         id="path432" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath434">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-943.1767,-280.5391)"
+         id="path434" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath436">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-948.07322,-285.4258)"
+         id="path436" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath438">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-952.45795,-279.79201)"
+         id="path438" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath440">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-954.59372,-280.5571)"
+         id="path440" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath442">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-962.4619,-283.69921)"
+         id="path442" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath444">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-862.08205,-173.58201)"
+         id="path444" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath446">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-864.1132,-173.58201)"
+         id="path446" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath448">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-869.59952,-174.34671)"
+         id="path448" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath450">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-876.66302,-173.58201)"
+         id="path450" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath452">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-943.1767,-174.24801)"
+         id="path452" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath454">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-948.07322,-179.1348)"
+         id="path454" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath456">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-952.45795,-173.50101)"
+         id="path456" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath458">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-954.59372,-174.2656)"
+         id="path458" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath460">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-962.0029,-173.0596)"
+         id="path460" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath462">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-89.459905,-360.86061)"
+         id="path462" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath464">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-92.771402,-361.25111)"
+         id="path464" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath466">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-94.295005,-361.25111)"
+         id="path466" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath468">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-147.08421,-364.66971)"
+         id="path468" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath470">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-143.77281,-364.27931)"
+         id="path470" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath472">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-196.5435,-360.86061)"
+         id="path472" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath474">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-199.855,-361.25111)"
+         id="path474" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath476">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-770.22452,-138.3112)"
+         id="path476" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath478">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-763.22754,-85.5049)"
+         id="path478" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath480">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-715.04112,-88.834)"
+         id="path480" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath482">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-818.42605,-81.836905)"
+         id="path482" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath484">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-80.966702,-390.06841)"
+         id="path484" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath486">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-81.9472,-391.54441)"
+         id="path486" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath488">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-89.2402,-390.06841)"
+         id="path488" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath490">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-70.719702,-381.04441)"
+         id="path490" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath492">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-74.784102,-381.04441)"
+         id="path492" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath494">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-84.080005,-381.04441)"
+         id="path494" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath496">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-86.543905,-381.80961)"
+         id="path496" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath498">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-92.331002,-381.04441)"
+         id="path498" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath500">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-95.4736,-381.04441)"
+         id="path500" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath502">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-713.35252,-382.44821)"
+         id="path502" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath504">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-719.97062,-383.55571)"
+         id="path504" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath506">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-722.77922,-385.96731)"
+         id="path506" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath508">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-726.90912,-381.79151)"
+         id="path508" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath510">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-731.49212,-381.04441)"
+         id="path510" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath512">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-760.67282,-383.98731)"
+         id="path512" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath514">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-765.91599,-381.80961)"
+         id="path514" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath516">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-772.39839,-381.04441)"
+         id="path516" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath518">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-776.49602,-381.04441)"
+         id="path518" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath520">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-780.55854,-381.04441)"
+         id="path520" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath522">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-782.45402,-381.04441)"
+         id="path522" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath524">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-943.33105,-383.87941)"
+         id="path524" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath526">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-948.65522,-385.96731)"
+         id="path526" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath528">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-954.75092,-386.83151)"
+         id="path528" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath530">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-956.52242,-382.44821)"
+         id="path530" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath532">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-964.4599,-381.04441)"
+         id="path532" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath534">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-987.90235,-386.83151)"
+         id="path534" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath536">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-990.46382,-381.04441)"
+         id="path536" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath538">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-996.65335,-381.04441)"
+         id="path538" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath540">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-1000.0165,-381.79151)"
+         id="path540" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath542">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-1004.8525,-383.98731)"
+         id="path542" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath544">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-816.78415,-390.06841)"
+         id="path544" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath546">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-818.79782,-390.06841)"
+         id="path546" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath548">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-824.9599,-390.06841)"
+         id="path548" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath550">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-828.15332,-390.06841)"
+         id="path550" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath552">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-986.36222,-390.94141)"
+         id="path552" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath554">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-991.13762,-395.58541)"
+         id="path554" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath556">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-995.3359,-389.98731)"
+         id="path556" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath558">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-997.50385,-390.97751)"
+         id="path558" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath560">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-1004.5605,-389.54641)"
+         id="path560" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath562">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-860.9023,-393.05621)"
+         id="path562" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath564">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-865.9882,-391.05861)"
+         id="path564" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath566">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-869.16602,-391.54441)"
+         id="path566" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath568">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-873.80762,-394.24411)"
+         id="path568" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath570">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-905.0956,-390.06841)"
+         id="path570" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath572">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-907.10935,-390.06841)"
+         id="path572" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath574">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-912.5302,-391.05861)"
+         id="path574" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath576">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-919.26955,-390.06841)"
+         id="path576" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath578">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-943.58882,-390.94141)"
+         id="path578" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath580">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-948.36422,-395.58541)"
+         id="path580" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath582">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-952.56242,-389.98731)"
+         id="path582" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath584">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-954.73045,-390.97751)"
+         id="path584" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath586">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-962.24605,-393.89451)"
+         id="path586" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath588">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-766.15719,-390.06841)"
+         id="path588" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath590">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-768.40134,-395.66651)"
+         id="path590" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath592">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-770.38284,-390.06841)"
+         id="path592" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath594">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-775.51562,-390.06841)"
+         id="path594" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath596">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-780.96384,-390.06841)"
+         id="path596" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath598">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-713.16302,-391.05861)"
+         id="path598" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath600">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-718.01262,-393.11911)"
+         id="path600" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath602">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-724.52242,-395.85551)"
+         id="path602" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath604">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-728.86132,-390.06841)"
+         id="path604" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath606">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-732.18742,-390.06841)"
+         id="path606" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath608">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-661.45012,-385.56841)"
+         id="path608" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath610">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-664.33102,-389.74411)"
+         id="path610" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath612">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-667.46381,-385.75731)"
+         id="path612" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath614">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-612.27922,-385.56841)"
+         id="path614" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath616">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-615.16012,-389.74411)"
+         id="path616" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath618">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-618.16202,-389.74411)"
+         id="path618" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath620">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-563.09471,-385.56841)"
+         id="path620" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath622">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-565.97551,-389.74411)"
+         id="path622" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath624">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-570.81241,-386.55861)"
+         id="path624" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath626">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-513.90911,-385.56841)"
+         id="path626" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath628">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-518.53612,-388.61911)"
+         id="path628" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath630">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-464.72351,-385.56841)"
+         id="path630" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath632">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-469.38961,-386.54931)"
+         id="path632" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath634">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-415.55361,-385.56841)"
+         id="path634" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath636">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-419.76551,-385.56841)"
+         id="path636" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath638">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-366.36811,-385.56841)"
+         id="path638" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath640">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-371.02921,-386.55861)"
+         id="path640" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath642">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-317.18351,-385.56841)"
+         id="path642" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath644">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-322.18151,-388.51121)"
+         id="path644" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath646">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-268.01361,-385.56841)"
+         id="path646" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath648">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-273.34851,-387.61131)"
+         id="path648" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath650">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-218.82801,-385.56841)"
+         id="path650" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath652">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-223.3954,-388.93461)"
+         id="path652" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath654">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-169.64151,-385.56841)"
+         id="path654" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath656">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-172.6357,-385.75731)"
+         id="path656" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath658">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-120.4579,-385.56841)"
+         id="path658" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath660">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-123.3388,-389.74411)"
+         id="path660" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath662">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-141.069,-390.98301)"
+         id="path662" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath664">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-141.069,-392.88751)"
+         id="path664" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath666">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-141.069,-385.26941)"
+         id="path666" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath668">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-144.8781,-389.07851)"
+         id="path668" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath670">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-137.2599,-389.07851)"
+         id="path670" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath672">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-138.3693,-391.77581)"
+         id="path672" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath674">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-143.7639,-391.77581)"
+         id="path674" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath676">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-143.7639,-386.39071)"
+         id="path676" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath678">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-138.38121,-386.39071)"
+         id="path678" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath680">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-190.23651,-385.26941)"
+         id="path680" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath682">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-586.31201,-390.74491)"
+         id="path682" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath684">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-582.61241,-391.09491)"
+         id="path684" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath686">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-589.99241,-388.55471)"
+         id="path686" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath688">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-681.69221,-384.44571)"
+         id="path688" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath690">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-407.97771,-143.82621)"
+         id="path690" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath692">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-410.67021,-142.7097)"
+         id="path692" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath694">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-411.70821,-140.61471)"
+         id="path694" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath696">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-405.28521,-142.7097)"
+         id="path696" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath698">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-241.8502,-390.94731)"
+         id="path698" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath700">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-234.9034,-386.03601)"
+         id="path700" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath702">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-243.94521,-386.03601)"
+         id="path702" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath704">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-236.4247,-386.03601)"
+         id="path704" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath706">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-538.86431,-385.16711)"
+         id="path706" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath708">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-538.48351,-386.88111)"
+         id="path708" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath710">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-535.61471,-390.42831)"
+         id="path710" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath712">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-383.57711,-390.45931)"
+         id="path712" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath714">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-387.11241,-392.25671)"
+         id="path714" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath716">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-390.92861,-388.55471)"
+         id="path716" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath718">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-439.19491,-386.65021)"
+         id="path718" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath720">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-487.98561,-385.50751)"
+         id="path720" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath722">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-489.12841,-384.36481)"
+         id="path722" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath724">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-480.55801,-390.45931)"
+         id="path724" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath726">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-485.31931,-391.79721)"
+         id="path726" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath728">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-486.84291,-386.65021)"
+         id="path728" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath730">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-195.3739,-149.1667)"
+         id="path730" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath732">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-636.66592,-385.54801)"
+         id="path732" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath688-8">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-681.6922,-384.4457)"
+         id="path688-7" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath680-7">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-190.2365,-385.2694)"
+         id="path680-6" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath680-9">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-190.2365,-385.2694)"
+         id="path680-1" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath680-9-5">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-190.2365,-385.2694)"
+         id="path680-1-2" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath680-9-5-4">
+      <path
+         d="M 0,453.543 H 1077.165 V 0 H 0 Z"
+         transform="translate(-190.2365,-385.2694)"
+         id="path680-1-2-6" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.6437005"
+     inkscape:cx="712.8343"
+     inkscape:cy="262.4078"
+     inkscape:window-width="1024"
+     inkscape:window-height="768"
+     inkscape:window-x="-1"
+     inkscape:window-y="-1"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer-MC1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:document-units="mm">
+    <inkscape:page
+       x="0"
+       y="0"
+       inkscape:label="1"
+       id="page1"
+       width="1436.2267"
+       height="604.724"
+       margin="71.331337 84.866669 71.330666 84.837868"
+       bleed="0" />
+  </sodipodi:namedview>
+  <g
+     id="layer-MC0"
+     inkscape:groupmode="layer"
+     inkscape:label="GRID"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       id="path1"
+       d="M 104.594,377.215 H 63.779 V 399.895 H 104.594 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path2"
+       d="M 842.281,377.215 H 801.451 V 399.895 H 842.281 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path3"
+       d="M 1013.372,377.215 H 978.962 V 399.895 H 1013.372 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path4"
+       d="M 885.047,377.215 H 850.637 V 399.895 H 885.047 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path5"
+       d="M 927.827,377.215 H 893.417 V 399.895 H 927.827 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path6"
+       d="M 970.607,377.215 H 936.182 V 399.895 H 970.607 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path7"
+       d="M 1013.372,324.07 H 978.977 V 368.86 H 1013.372 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path8"
+       d="M 885.047,324.07 H 850.637 V 368.86 H 885.047 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path9"
+       d="M 98.189,324.07 H 63.779 V 368.86 H 98.189 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path10"
+       d="M 151.334,324.07 H 106.544 V 368.86 H 151.334 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path11"
+       d="M 204.483,324.07 H 159.693 V 368.86 H 204.483 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path12"
+       d="M 257.632,324.07 H 212.842 V 368.86 H 257.632 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path13"
+       d="M 310.782,324.07 H 265.992 V 368.86 H 310.782 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path14"
+       d="M 363.931,324.07 H 319.141 V 368.86 H 363.931 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path15"
+       d="M 417.08,324.07 H 372.29 V 368.86 H 417.08 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path16"
+       d="M 470.229,324.07 H 425.439 V 368.86 H 470.229 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path17"
+       d="M 523.379,324.07 H 478.589 V 368.86 H 523.379 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path18"
+       d="M 576.528,324.07 H 531.738 V 368.86 H 576.528 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path19"
+       d="M 629.677,324.07 H 584.887 V 368.86 H 629.677 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path20"
+       d="M 682.827,324.07 H 638.037 V 368.86 H 682.827 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path21"
+       d="M 735.976,324.07 H 691.186 V 368.86 H 735.976 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path22"
+       d="M 842.281,324.07 H 744.346 V 368.86 H 842.281 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path23"
+       d="M 842.281,164.619 H 704.475 V 209.409 H 842.281 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path24"
+       d="M 927.827,324.07 H 893.417 V 368.86 H 927.827 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path25"
+       d="M 970.607,324.07 H 936.182 V 368.86 H 970.607 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path26"
+       d="M 1013.372,217.764 H 978.977 V 315.699 H 1013.372 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path27"
+       d="M 885.047,270.909 H 850.637 V 315.699 H 885.047 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path28"
+       d="M 927.827,270.909 H 893.417 V 315.699 H 927.827 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path29"
+       d="M 970.607,270.909 H 936.182 V 315.699 H 970.607 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path30"
+       d="M 1013.372,106.794 H 978.977 V 209.409 H 1013.372 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path31"
+       d="M 885.047,164.619 H 850.637 V 209.409 H 885.047 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path32"
+       d="M 1237.161,462.3348 H 1134.179 V 396.4192 H 1237.161 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.400006;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path33"
+       d="M 927.827,164.619 H 893.417 V 209.409 H 927.827 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path34"
+       d="M 970.607,164.619 H 936.182 V 209.409 H 970.607 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path35"
+       d="M 970.607,106.794 H 936.182 V 156.264 H 970.607 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path36"
+       d="M 885.047,217.764 H 850.637 V 262.554 H 885.047 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path37"
+       d="M 927.827,217.764 H 893.417 V 262.554 H 927.827 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path38"
+       d="M 970.607,217.764 H 936.182 V 262.554 H 970.607 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path39"
+       d="M 793.096,377.215 H 752.281 V 399.895 H 793.096 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path40"
+       d="M 743.911,377.215 H 703.096 V 399.895 H 743.911 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path41"
+       d="M 694.741,377.215 H 653.911 V 399.895 H 694.741 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path42"
+       d="M 645.556,377.215 H 604.741 V 399.895 H 645.556 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path43"
+       d="M 596.37,377.215 H 555.555 V 399.895 H 596.37 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path44"
+       d="M 547.185,377.215 H 506.37 V 399.895 H 547.185 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path45"
+       d="M 498.015,377.215 H 457.185 V 399.895 H 498.015 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path46"
+       d="M 448.83,377.215 H 408.015 V 399.895 H 448.83 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path47"
+       d="M 399.645,377.215 H 358.83 V 399.895 H 399.645 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path48"
+       d="M 350.474,377.215 H 309.644 V 399.895 H 350.474 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path49"
+       d="M 301.289,377.215 H 260.474 V 399.895 H 301.289 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path50"
+       d="M 252.104,377.215 H 211.289 V 399.895 H 252.104 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path51"
+       d="M 202.916,377.215 H 162.102 V 399.895 H 202.916 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path52"
+       d="M 153.749,377.215 H 112.919 V 399.895 H 153.749 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path53"
+       d="M 177.914,270.924 H 133.124 V 315.714 H 177.914 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path54"
+       d="M 124.754,270.924 H 63.779 V 315.714 H 124.754 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path55"
+       d="M 138.044,217.764 H 63.779 V 262.554 H 138.044 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path56"
+       d="M 231.063,270.924 H 186.273 V 315.714 H 231.063 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path57"
+       d="M 284.212,270.924 H 239.422 V 315.714 H 284.212 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path58"
+       d="M 337.362,270.924 H 292.572 V 315.714 H 337.362 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path59"
+       d="M 390.511,270.924 H 345.721 V 315.714 H 390.511 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path60"
+       d="M 443.66,270.924 H 398.87 V 315.714 H 443.66 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path61"
+       d="M 496.81,270.924 H 452.02 V 315.714 H 496.81 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path62"
+       d="M 549.959,270.924 H 505.169 V 315.714 H 549.959 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path63"
+       d="M 603.108,270.924 H 558.318 V 315.714 H 603.108 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path64"
+       d="M 656.258,270.924 H 611.468 V 315.714 H 656.258 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path65"
+       d="M 709.407,270.924 H 664.617 V 315.714 H 709.407 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path66"
+       d="M 762.556,270.924 H 717.766 V 315.714 H 762.556 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path67"
+       d="M 191.204,217.764 H 146.414 V 262.554 H 191.204 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path68"
+       d="M 244.353,217.764 H 199.563 V 262.554 H 244.353 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path69"
+       d="M 297.502,217.764 H 252.712 V 262.554 H 297.502 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path70"
+       d="M 350.652,217.764 H 305.862 V 262.554 H 350.652 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path71"
+       d="M 403.801,217.764 H 359.011 V 262.554 H 403.801 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path72"
+       d="M 456.95,217.764 H 412.16 V 262.554 H 456.95 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path73"
+       d="M 510.1,217.764 H 465.31 V 262.554 H 510.1 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path74"
+       d="M 563.249,217.764 H 518.459 V 262.554 H 563.249 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path75"
+       d="M 616.398,217.764 H 571.608 V 262.554 H 616.398 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path76"
+       d="M 669.547,217.764 H 624.757 V 262.554 H 669.547 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path77"
+       d="M 722.697,217.764 H 677.907 V 262.554 H 722.697 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path78"
+       d="M 775.846,217.764 H 731.056 V 262.554 H 775.846 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path79"
+       d="M 0,0 V -44.79 H 13.29 V -97.95 H 71.37 V -44.79 V -40.626 V 0 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,1027.882,183.7713)" />
+    <path
+       id="path80"
+       d="M 164.628,164.619 H 119.838 V 209.409 H 164.628 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path81"
+       d="M 111.479,164.619 H 63.779 V 209.409 H 111.479 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path82"
+       d="M 111.479,106.794 H 63.779 V 156.264 H 111.479 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path83"
+       d="M 164.624,106.794 H 119.834 V 156.264 H 164.624 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path84"
+       d="M 217.769,106.794 H 172.979 V 156.264 H 217.769 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path85"
+       d="M 270.914,106.794 H 226.124 V 156.264 H 270.914 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path86"
+       d="M 715.5648,462.3348 H 372.3786 V 396.3739 H 715.5648 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.400006;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path87"
+       d="M 589.815,106.794 H 545.025 V 156.264 H 589.815 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path88"
+       d="M 682.831,106.794 H 598.186 V 156.264 H 682.831 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path89"
+       d="M 217.777,164.619 H 172.987 V 209.409 H 217.777 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path90"
+       d="M 270.926,164.619 H 226.136 V 209.409 H 270.926 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path91"
+       d="M 324.076,164.619 H 279.286 V 209.409 H 324.076 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path92"
+       d="M 377.225,164.619 H 332.435 V 209.409 H 377.225 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path93"
+       d="M 430.374,164.619 H 385.584 V 209.409 H 430.374 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path94"
+       d="M 483.524,164.619 H 438.734 V 209.409 H 483.524 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path95"
+       d="M 536.673,164.619 H 491.883 V 209.409 H 536.673 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path96"
+       d="M 589.822,164.619 H 545.032 V 209.409 H 589.822 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path97"
+       d="M 642.971,164.619 H 598.181 V 209.409 H 642.971 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path98"
+       d="M 696.121,164.619 H 651.331 V 209.409 H 696.121 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path99"
+       d="M 1052.162,462.3348 H 992.4411 V 402.6139 H 1052.162 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.400006;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path100"
+       d="M 789.121,53.648 H 744.331 V 98.438 H 789.121 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path101"
+       d="M 735.976,53.648 H 691.186 V 98.438 H 735.976 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+    <path
+       id="path102"
+       d="M 842.281,53.648 H 797.491 V 98.438 H 842.281 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.333333,0,0,-1.333333,0,604.724)" />
+  </g>
+  <g
+     id="layer-MC1"
+     inkscape:groupmode="layer"
+     inkscape:label="PRINT_MirKBD"
+     style="display:inline">
+    <path
+       d="M 93.86483,77.83005 Q 93.85572,77.98499 93.82382,78.2402 Q 93.79647,78.49541 93.75546,78.73695 Q 93.71444,78.97848 93.67798,79.09697 H 93.33619 Q 93.29517,78.23109 92.96249,78.23109 H 91.19426 L 91.32642,77.68421 H 93.68254 Z M 93.39543,80.2363 Q 93.32251,80.3639 93.19947,80.55531 Q 93.07642,80.74216 92.97616,80.81051 Q 92.83488,80.67835 92.64348,80.61911 Q 92.45663,80.55986 92.07382,80.55986 H 91.13046 L 91.23072,80.07679 H 93.24504 Z M 94.16105,82.04098 Q 94.13827,82.30075 94.10181,82.59242 Q 94.06991,82.87952 94.03345,83.10739 Q 94.00155,83.33525 93.97421,83.4264 H 89.66757 V 83.09372 Q 90.29192,82.96611 90.29192,82.81572 V 78.29945 Q 90.29192,78.24476 90.14153,78.16273 Q 89.99569,78.0807 89.66757,78.0169 V 77.68421 H 92.09205 V 78.0169 Q 91.78671,78.0488 91.60897,78.09437 Q 91.43124,78.13539 91.43124,78.19919 V 82.58786 Q 91.43124,82.67445 91.49504,82.74281 Q 91.5634,82.80661 91.75936,82.84307 Q 91.95988,82.87952 92.36093,82.87952 H 92.8121 Q 93.23137,82.87952 93.43189,82.66989 Q 93.63241,82.4557 93.82837,81.92249 Z"
+       style="font-weight:bold;font-size:9.33333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4238" />
+    <path
+       d="M 97.93905,82.13669 Q 97.93905,82.61976 97.73397,82.90687 Q 97.53345,83.19398 97.23267,83.33525 Q 96.93189,83.47653 96.63111,83.51755 Q 96.33032,83.56312 96.1298,83.56312 Q 95.83814,83.56312 95.46444,83.48109 Q 95.09074,83.40361 94.7854,83.23044 Q 94.75806,83.21221 94.73983,83.07093 Q 94.72616,82.9251 94.72616,82.71546 Q 94.73072,82.50127 94.74895,82.28252 Q 94.77173,82.06377 94.8173,81.89515 L 95.18645,81.94528 Q 95.28215,82.43291 95.58749,82.72002 Q 95.89738,83.00257 96.28931,83.00257 Q 96.93644,83.00257 96.93644,82.49215 Q 96.93644,82.14124 96.61743,81.91794 Q 96.30298,81.69007 95.83814,81.44854 Q 95.58749,81.31637 95.34139,81.15231 Q 95.09986,80.98825 94.93579,80.77406 Q 94.77629,80.55986 94.77629,80.2682 Q 94.77629,79.88994 95.00871,79.62106 Q 95.24569,79.34762 95.61939,79.20179 Q 95.99309,79.0514 96.40324,79.0514 Q 96.79517,79.0514 97.17798,79.1471 Q 97.56535,79.24281 97.77499,79.40231 Q 97.80233,79.4251 97.7841,79.5527 Q 97.77043,79.68031 97.72486,79.84893 Q 97.68384,80.01299 97.6246,80.16794 Q 97.56535,80.31833 97.51066,80.39124 L 97.19621,80.35479 Q 96.96379,79.52992 96.35311,79.52992 Q 96.07967,79.52992 95.92928,79.65752 Q 95.77889,79.78512 95.77889,79.97197 Q 95.77889,80.24541 96.02954,80.4277 Q 96.28475,80.60544 96.82251,80.87887 Q 97.08684,81.01559 97.34204,81.17966 Q 97.60181,81.33916 97.77043,81.56702 Q 97.93905,81.79489 97.93905,82.13669 Z"
+       style="font-weight:bold;font-size:9.33333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4240" />
+    <path
+       d="M 102.3551,82.56051 Q 101.9586,83.00713 101.6396,83.22132 Q 101.3206,83.43551 101.038,83.49932 Q 100.76,83.56312 100.4729,83.56312 Q 99.97616,83.56312 99.54321,83.30791 Q 99.11483,83.04814 98.84595,82.56507 Q 98.58163,82.07744 98.58163,81.40296 Q 98.58163,80.74671 98.89608,80.21351 Q 99.21053,79.68031 99.76652,79.36585 Q 100.3225,79.0514 101.0426,79.0514 Q 101.2431,79.0514 101.5028,79.09697 Q 101.7626,79.14255 101.9905,79.22458 Q 102.2183,79.30205 102.3186,79.41143 Q 102.3277,79.46611 102.2913,79.63473 Q 102.2548,79.7988 102.191,79.99932 Q 102.1272,80.19984 102.0634,80.37301 Q 101.9996,80.54163 101.9586,80.60088 L 101.6532,80.55531 Q 101.5028,80.10869 101.2841,79.86716 Q 101.0653,79.62106 100.7008,79.62106 Q 100.4319,79.62106 100.1995,79.78512 Q 99.96704,79.94919 99.82121,80.31377 Q 99.67538,80.6738 99.67538,81.26169 Q 99.67538,81.9863 100.0217,82.39189 Q 100.3726,82.79749 100.8694,82.79749 Q 101.0426,82.79749 101.2021,82.76559 Q 101.3616,82.73369 101.5712,82.62432 Q 101.7854,82.51038 102.109,82.26885 Z"
+       style="font-weight:bold;font-size:9.33333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4242" />
+    <path
+       d="M 113.3858,83.9915 H 120.2036 V 84.90296 H 113.3858 Z M 113.3858,82.51494 H 120.2036 V 83.4264 H 113.3858 Z M 113.3858,81.04294 H 120.2036 V 81.95439 H 113.3858 Z M 113.3858,79.57093 H 120.2036 V 80.48239 H 113.3858 Z M 113.3858,78.09437 H 120.2036 V 79.00583 H 113.3858 Z M 113.3858,76.62237 H 120.2036 V 77.53382 H 113.3858 Z"
+       style="font-weight:bold;font-size:9.33333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4244" />
+    <path
+       id="path317"
+       d="M 0,0 C 0,0.222 -0.18,0.404 -0.402,0.404 H -7.51 C -7.731,0.404 -7.912,0.222 -7.912,0 C -7.912,-0.222 -7.731,-0.404 -7.51,-0.404 H -0.402 C -0.18,-0.404 0,-0.222 0,0 M 0.002,-3.171 C 0.002,-2.949 -0.178,-2.768 -0.4,-2.768 H -7.508 C -7.729,-2.768 -7.91,-2.949 -7.91,-3.171 C -7.91,-3.394 -7.729,-3.575 -7.508,-3.575 H -0.4 C -0.178,-3.575 0.002,-3.394 0.002,-3.171 M -0.4,-6.745 H -7.508 C -7.729,-6.745 -7.91,-6.564 -7.91,-6.342 C -7.91,-6.119 -7.729,-5.938 -7.508,-5.938 H -0.4 C -0.178,-5.938 0.002,-6.119 0.002,-6.342 C 0.002,-6.564 -0.178,-6.745 -0.4,-6.745"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,898.7383,436.1017)"
+       clip-path="url(#clipPath318)" />
+    <path
+       id="path661"
+       d="M 0,0 C -1.34,0 -2.428,-1.088 -2.428,-2.428 C -2.428,-3.769 -1.34,-4.857 0,-4.857 C 1.34,-4.854 2.426,-3.769 2.428,-2.428 C 2.428,-1.088 1.34,0 0,0 M 0,-0.762 C 0.919,-0.762 1.666,-1.509 1.666,-2.428 C 1.666,-3.347 0.917,-4.095 0,-4.095 C -0.919,-4.095 -1.666,-3.347 -1.666,-2.428 C -1.666,-1.509 -0.919,-0.762 0,-0.762"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,192.9241,83.41333)"
+       clip-path="url(#clipPath662)" />
+    <path
+       id="path663"
+       d="M 0,0 C 0.289,0 0.524,-0.234 0.524,-0.524 C 0.524,-0.813 0.289,-1.047 0,-1.047 C -0.289,-1.047 -0.524,-0.813 -0.524,-0.524 C -0.524,-0.234 -0.289,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,192.9241,80.874)"
+       clip-path="url(#clipPath664)" />
+    <path
+       id="path665"
+       d="M 0,0 C 0.289,0 0.524,-0.234 0.524,-0.524 C 0.524,-0.813 0.289,-1.047 0,-1.047 C -0.289,-1.047 -0.524,-0.813 -0.524,-0.524 C -0.524,-0.234 -0.289,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,192.9241,91.03147)"
+       clip-path="url(#clipPath666)" />
+    <path
+       id="path667"
+       d="M 0,0 C 0.289,0 0.524,-0.234 0.524,-0.524 C 0.524,-0.813 0.289,-1.048 0,-1.048 C -0.289,-1.048 -0.524,-0.813 -0.524,-0.524 C -0.524,-0.234 -0.289,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,198.0029,85.95267)"
+       clip-path="url(#clipPath668)" />
+    <path
+       id="path669"
+       d="M 0,0 C 0.289,0 0.524,-0.234 0.524,-0.524 C 0.524,-0.813 0.289,-1.048 0,-1.048 C -0.289,-1.048 -0.524,-0.813 -0.524,-0.524 C -0.524,-0.234 -0.289,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,187.8453,85.95267)"
+       clip-path="url(#clipPath670)" />
+    <path
+       id="path671"
+       d="M 0,0 C 0.289,0 0.524,-0.234 0.524,-0.524 C 0.524,-0.813 0.289,-1.047 0,-1.047 C -0.289,-1.047 -0.524,-0.813 -0.524,-0.524 C -0.524,-0.234 -0.289,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,189.3245,82.35627)"
+       clip-path="url(#clipPath672)" />
+    <path
+       id="path673"
+       d="M 0,0 C 0.289,0 0.524,-0.234 0.524,-0.524 C 0.524,-0.813 0.289,-1.047 0,-1.047 C -0.289,-1.047 -0.524,-0.813 -0.524,-0.524 C -0.524,-0.234 -0.289,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,196.5173,82.35627)"
+       clip-path="url(#clipPath674)" />
+    <path
+       id="path675"
+       d="M 0,0 C 0.289,0 0.524,-0.234 0.524,-0.524 C 0.524,-0.813 0.289,-1.047 0,-1.047 C -0.289,-1.047 -0.524,-0.813 -0.524,-0.524 C -0.524,-0.234 -0.289,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,196.5173,89.5364)"
+       clip-path="url(#clipPath676)" />
+    <path
+       id="path677"
+       d="M 0,0 C 0.289,0 0.524,-0.234 0.524,-0.524 C 0.524,-0.813 0.289,-1.047 0,-1.047 C -0.289,-1.047 -0.524,-0.813 -0.524,-0.524 C -0.524,-0.234 -0.289,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,189.3404,89.5364)"
+       clip-path="url(#clipPath678)" />
+    <path
+       id="path679"
+       d="M 0,0 C -0.29,0 -0.524,-0.233 -0.524,-0.524 V -1.428 C -0.524,-1.719 -0.29,-1.952 0,-1.952 C 0.29,-1.952 0.524,-1.719 0.524,-1.428 V -0.524 C 0.524,-0.233 0.29,0 0,0 M 2.697,1.112 C 2.566,1.112 2.433,1.062 2.331,0.964 C 2.124,0.762 2.119,0.431 2.321,0.224 L 2.89,-0.345 C 2.988,-0.443 3.121,-0.5 3.259,-0.5 C 3.397,-0.5 3.531,-0.445 3.631,-0.348 C 3.835,-0.143 3.835,0.188 3.631,0.393 L 3.062,0.962 C 2.962,1.062 2.831,1.112 2.697,1.112 M -2.688,1.121 C -2.823,1.121 -2.959,1.069 -3.064,0.964 L -3.633,0.395 C -3.73,0.298 -3.785,0.164 -3.785,0.024 C -3.785,-0.267 -3.552,-0.5 -3.262,-0.5 C -3.123,-0.5 -2.99,-0.445 -2.893,-0.345 L -2.324,0.224 L -2.314,0.233 C -2.112,0.44 -2.116,0.771 -2.324,0.974 C -2.426,1.071 -2.557,1.121 -2.688,1.121 M -3.809,3.809 H -4.714 C -5.004,3.809 -5.237,3.576 -5.237,3.285 C -5.237,2.995 -5.004,2.762 -4.714,2.762 H -3.809 C -3.519,2.762 -3.285,2.995 -3.285,3.285 C -3.285,3.576 -3.519,3.809 -3.809,3.809 M 4.714,3.809 H 3.809 C 3.519,3.809 3.285,3.576 3.285,3.285 C 3.285,2.995 3.519,2.762 3.809,2.762 H 4.714 C 5.004,2.762 5.237,2.995 5.237,3.285 C 5.237,3.576 5.004,3.809 4.714,3.809 M 0,5.714 C -1.34,5.714 -2.428,4.626 -2.428,3.285 C -2.428,1.945 -1.34,0.857 0,0.857 C 1.34,0.859 2.426,1.945 2.428,3.285 C 2.428,4.626 1.34,5.714 0,5.714 M 3.259,7.068 C 3.128,7.068 2.995,7.018 2.895,6.921 L 2.326,6.352 C 2.228,6.254 2.174,6.121 2.174,5.983 C 2.174,5.692 2.407,5.459 2.697,5.459 C 2.835,5.459 2.969,5.514 3.066,5.611 L 3.635,6.18 C 3.833,6.383 3.833,6.709 3.635,6.911 C 3.531,7.013 3.395,7.068 3.259,7.068 M -3.259,7.068 C -3.39,7.068 -3.523,7.018 -3.626,6.921 C -3.833,6.718 -3.838,6.387 -3.635,6.18 L -3.066,5.611 C -2.969,5.514 -2.835,5.459 -2.697,5.459 C -2.559,5.459 -2.426,5.514 -2.328,5.611 C -2.124,5.816 -2.124,6.147 -2.328,6.352 L -2.897,6.921 C -2.995,7.018 -3.126,7.068 -3.259,7.068 M 0,8.523 C -0.29,8.523 -0.524,8.289 -0.524,7.999 V 7.094 C -0.524,6.804 -0.29,6.571 0,6.571 C 0.29,6.571 0.524,6.804 0.524,7.094 V 7.999 C 0.524,8.289 0.29,8.523 0,8.523 M 0,4.952 C 0.919,4.952 1.666,4.204 1.666,3.285 C 1.666,2.366 0.917,1.619 0,1.619 C -0.919,1.619 -1.666,2.366 -1.666,3.285 C -1.666,4.204 -0.919,4.952 0,4.952"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,258.4801,91.03147)"
+       clip-path="url(#clipPath680)" />
+    <path
+       id="path681"
+       d="M 0,0 C -0.017,-0.007 -0.031,-0.017 -0.048,-0.026 L -1.478,-1.033 C -1.626,-1.138 -1.714,-1.309 -1.714,-1.488 V -2.862 C -1.714,-3.045 -1.626,-3.212 -1.478,-3.316 L -0.05,-4.321 C -0.033,-4.33 -0.019,-4.34 -0.002,-4.347 C 0.071,-4.378 0.145,-4.395 0.224,-4.395 C 0.531,-4.395 0.776,-4.147 0.779,-3.84 V -0.507 C 0.779,-0.429 0.762,-0.35 0.731,-0.281 C 0.607,-0.002 0.281,0.124 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,789.0293,80.91839)"
+       clip-path="url(#clipPath682)" />
+    <path
+       id="path683"
+       d="M 0,0 H -2.597 C -3.273,-0.002 -3.826,-0.536 -3.826,-1.193 V -3.854 C -3.826,-4.514 -3.273,-5.047 -2.597,-5.047 H -0.01 C 0.671,-5.047 1.219,-4.514 1.221,-3.857 V -1.186 C 1.219,-0.531 0.676,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,784.0965,80.45172)"
+       clip-path="url(#clipPath684)" />
+    <path
+       id="path685"
+       d="M 0,0 L 0.574,0.574 C 0.721,0.721 0.721,0.964 0.574,1.112 C 0.426,1.259 0.183,1.259 0.036,1.112 L -0.538,0.538 L -1.112,1.112 C -1.259,1.259 -1.502,1.259 -1.65,1.112 C -1.797,0.964 -1.797,0.721 -1.65,0.574 L -1.076,0 L -1.65,-0.574 C -1.797,-0.721 -1.797,-0.964 -1.65,-1.112 C -1.576,-1.186 -1.478,-1.224 -1.381,-1.224 C -1.283,-1.224 -1.186,-1.186 -1.112,-1.112 L -0.538,-0.538 L 0.036,-1.112 C 0.11,-1.186 0.207,-1.224 0.305,-1.224 C 0.402,-1.224 0.5,-1.186 0.574,-1.112 C 0.721,-0.964 0.721,-0.721 0.574,-0.574 Z"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,785.2489,91.21787)"
+       clip-path="url(#clipPath686)" />
+    <path
+       id="path687"
+       d="M 0,0 H -0.526 C -0.7,0 -0.843,0.143 -0.843,0.317 C -0.843,0.362 -0.833,0.407 -0.814,0.448 L 0.459,3.259 L -1.452,3.3 L -2.15,2.454 C -2.283,2.288 -2.388,2.214 -2.659,2.214 H -3.016 C -3.131,2.209 -3.24,2.262 -3.307,2.354 C -3.352,2.419 -3.402,2.523 -3.354,2.678 L -2.964,4.078 C -2.962,4.09 -2.957,4.099 -2.952,4.111 V 4.114 C -2.957,4.123 -2.959,4.135 -2.964,4.147 L -3.354,5.559 C -3.395,5.709 -3.35,5.814 -3.304,5.875 C -3.24,5.961 -3.14,6.009 -3.035,6.009 H -2.662 C -2.459,6.009 -2.264,5.918 -2.147,5.773 L -1.464,4.94 L 0.459,4.968 L -0.817,7.775 C -0.888,7.935 -0.819,8.123 -0.659,8.194 C -0.619,8.213 -0.574,8.223 -0.529,8.223 H 0.002 C 0.152,8.22 0.295,8.149 0.383,8.03 L 2.854,5.026 L 3.997,5.057 C 4.08,5.061 4.311,5.064 4.364,5.064 C 5.456,5.064 6.109,4.709 6.109,4.114 C 6.109,3.928 6.035,3.581 5.535,3.359 C 5.24,3.228 4.845,3.164 4.366,3.164 C 4.314,3.164 4.08,3.166 4,3.171 L 2.857,3.202 L 0.381,0.198 C 0.288,0.071 0.148,0.002 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,913.0839,92.12973)"
+       clip-path="url(#clipPath688)" />
+    <path
+       id="path689"
+       d="M 0,0 C -0.29,0 -0.524,0.233 -0.524,0.524 V 1.905 C -0.524,2.195 -0.29,2.428 0,2.428 C 0.29,2.428 0.524,2.195 0.524,1.905 V 0.524 C 0.524,0.233 0.29,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,693.9014,412.957)"
+       clip-path="url(#clipPath690)" />
+    <path
+       id="path691"
+       d="M 0,0 C -0.29,0 -0.524,0.236 -0.524,0.524 C -0.524,0.662 -0.469,0.795 -0.371,0.893 L 0.674,1.938 C 0.881,2.14 1.212,2.135 1.414,1.928 C 1.612,1.726 1.612,1.4 1.414,1.197 L 0.369,0.152 C 0.274,0.057 0.14,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,697.4914,414.4457)"
+       clip-path="url(#clipPath692)" />
+    <path
+       id="path693"
+       d="M 0,0 H -7.728 C -8.018,0 -8.251,0.233 -8.251,0.524 C -8.251,0.814 -8.018,1.048 -7.728,1.048 H 0 C 0.29,1.048 0.524,0.814 0.524,0.524 C 0.524,0.233 0.29,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,698.8754,417.239)"
+       clip-path="url(#clipPath694)" />
+    <path
+       id="path695"
+       d="M 0,0 C -0.138,0 -0.271,0.055 -0.371,0.152 L -1.416,1.197 C -1.619,1.405 -1.614,1.736 -1.407,1.938 C -1.205,2.135 -0.878,2.135 -0.676,1.938 L 0.369,0.893 C 0.574,0.688 0.574,0.357 0.369,0.152 C 0.271,0.057 0.138,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,690.3114,414.4457)"
+       clip-path="url(#clipPath696)" />
+    <path
+       id="path697"
+       d="M 0,0 C 0.031,0.083 0.031,0.176 -0.002,0.264 C -0.038,0.355 -0.102,0.424 -0.183,0.464 C -0.276,0.514 -0.39,0.524 -0.495,0.483 C -0.583,0.45 -0.65,0.386 -0.693,0.309 L -3.09,-4.154 C -3.2,-4.345 -3.226,-4.583 -3.14,-4.804 C -2.99,-5.197 -2.55,-5.392 -2.157,-5.242 C -1.935,-5.156 -1.776,-4.98 -1.707,-4.771 Z"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,327.7453,83.46093)"
+       clip-path="url(#clipPath698)" />
+    <path
+       id="path699"
+       d="M 0,0 H -0.005 C -0.214,0 -0.386,0.171 -0.386,0.381 C -0.386,3.085 1.814,5.285 4.518,5.285 C 4.614,5.285 4.711,5.283 4.809,5.276 C 5.018,5.264 5.18,5.083 5.166,4.873 C 5.154,4.664 4.973,4.504 4.764,4.516 C 4.683,4.521 4.599,4.523 4.518,4.523 C 2.362,4.523 0.586,2.869 0.393,0.762 C 0.393,0.762 0.381,0.59 0.381,0.381 C 0.381,0.169 0.21,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,318.4829,90.00933)"
+       clip-path="url(#clipPath700)" />
+    <path
+       id="path701"
+       d="M 0,0 H -0.762 C -0.971,0 -1.143,0.171 -1.143,0.381 C -1.143,0.59 -0.971,0.762 -0.762,0.762 H -0.398 C -0.486,1.738 -0.912,2.64 -1.619,3.335 C -1.769,3.483 -1.771,3.723 -1.624,3.873 C -1.476,4.023 -1.236,4.026 -1.086,3.878 C -0.14,2.95 0.381,1.707 0.381,0.381 C 0.381,0.169 0.21,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,330.5387,90.00933)"
+       clip-path="url(#clipPath702)" />
+    <path
+       id="path703"
+       d="M 0,0 C -0.209,0 -0.381,0.171 -0.381,0.381 C -0.381,2.004 0.774,3.4 2.366,3.7 C 2.574,3.738 2.773,3.602 2.812,3.395 C 2.85,3.188 2.714,2.988 2.507,2.95 C 1.274,2.716 0.379,1.635 0.379,0.379 C 0.381,0.171 0.21,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,320.5113,90.00933)"
+       clip-path="url(#clipPath704)" />
+    <path
+       id="path705"
+       d="M 0,0 H -8.723 C -8.932,0 -9.104,-0.171 -9.104,-0.381 C -9.104,-0.59 -8.932,-0.762 -8.723,-0.762 H 0 C 0.21,-0.762 0.381,-0.59 0.381,-0.381 C 0.381,-0.171 0.21,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,723.9797,91.16787)"
+       clip-path="url(#clipPath706)" />
+    <path
+       id="path707"
+       d="M 0,0 C 0,-0.105 -0.086,-0.19 -0.19,-0.19 H -7.771 C -7.875,-0.19 -7.961,-0.105 -7.961,0 V 4.871 C -7.961,4.976 -7.875,5.061 -7.771,5.061 H -0.19 C -0.086,5.061 0,4.976 0,4.871 Z M -0.19,5.823 H -7.771 C -8.297,5.823 -8.723,5.397 -8.723,4.871 V 0 C -8.723,-0.526 -8.297,-0.952 -7.771,-0.952 H -0.19 C 0.336,-0.952 0.762,-0.526 0.762,0 V 4.871 C 0.762,5.397 0.336,5.823 -0.19,5.823"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,723.472,88.88253)"
+       clip-path="url(#clipPath708)" />
+    <path
+       id="path709"
+       d="M 0,0 C -0.148,0.148 -0.39,0.148 -0.538,0 L -1.112,-0.574 L -1.685,0 C -1.833,0.148 -2.076,0.148 -2.224,0 C -2.371,-0.148 -2.371,-0.39 -2.224,-0.538 L -1.65,-1.112 L -2.224,-1.686 C -2.371,-1.833 -2.371,-2.076 -2.224,-2.224 C -2.15,-2.297 -2.052,-2.335 -1.955,-2.335 C -1.857,-2.335 -1.759,-2.297 -1.685,-2.224 L -1.112,-1.65 L -0.538,-2.224 C -0.464,-2.297 -0.367,-2.335 -0.269,-2.335 C -0.171,-2.335 -0.074,-2.297 0,-2.224 C 0.148,-2.076 0.148,-1.833 0,-1.686 L -0.574,-1.112 L 0,-0.538 C 0.15,-0.39 0.15,-0.148 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,719.6469,84.15293)"
+       clip-path="url(#clipPath710)" />
+    <path
+       id="path711"
+       d="M 0,0 H -0.314 C -0.629,0 -0.886,-0.257 -0.886,-0.571 V -3.238 C -0.886,-3.554 -0.631,-3.809 -0.314,-3.809 H 0 C 0.317,-3.809 0.571,-3.554 0.571,-3.238 V -0.571 C 0.571,-0.255 0.317,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,517.0536,84.1116)"
+       clip-path="url(#clipPath712)" />
+    <path
+       id="path713"
+       d="M 0,0 L -0.017,-0.012 L -1.985,-1.626 C -2.119,-1.736 -2.195,-1.897 -2.195,-2.069 V -5.333 C -2.195,-5.504 -2.119,-5.666 -1.985,-5.775 L -0.017,-7.39 L 0,-7.401 C 0.255,-7.59 0.612,-7.535 0.8,-7.28 C 0.874,-7.182 0.912,-7.063 0.912,-6.942 V -0.459 C 0.914,-0.338 0.874,-0.219 0.8,-0.121 C 0.612,0.133 0.255,0.188 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,521.7674,81.71507)"
+       clip-path="url(#clipPath714)" />
+    <path
+       id="path715"
+       d="M 0,0 L 0.574,0.574 C 0.721,0.721 0.721,0.964 0.574,1.112 C 0.426,1.259 0.183,1.259 0.036,1.112 L -0.538,0.538 L -1.112,1.112 C -1.259,1.259 -1.502,1.259 -1.65,1.112 C -1.797,0.964 -1.797,0.721 -1.65,0.574 L -1.076,0 L -1.65,-0.574 C -1.797,-0.721 -1.797,-0.964 -1.65,-1.112 C -1.576,-1.186 -1.478,-1.224 -1.381,-1.224 C -1.283,-1.224 -1.186,-1.186 -1.112,-1.112 L -0.538,-0.538 L 0.036,-1.112 C 0.109,-1.186 0.207,-1.224 0.305,-1.224 C 0.402,-1.224 0.5,-1.186 0.574,-1.112 C 0.721,-0.964 0.721,-0.721 0.574,-0.574 Z"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,526.8556,86.65107)"
+       clip-path="url(#clipPath716)" />
+    <path
+       id="path717"
+       d="M 0,0 C -0.209,0 -0.381,0.171 -0.381,0.381 C -0.381,0.44 -0.367,0.498 -0.34,0.552 C -0.114,1.002 0,1.457 0,1.905 C 0,2.366 -0.112,2.807 -0.338,3.254 C -0.431,3.442 -0.352,3.671 -0.162,3.764 C 0.021,3.854 0.245,3.78 0.34,3.6 C 0.624,3.042 0.762,2.488 0.762,1.902 C 0.762,1.336 0.619,0.764 0.34,0.207 C 0.276,0.081 0.145,0 0,0 M -1.524,5.147 V -1.336 C -1.524,-1.457 -1.562,-1.576 -1.635,-1.674 C -1.824,-1.928 -2.181,-1.983 -2.435,-1.795 L -2.452,-1.783 L -4.421,-0.169 C -4.554,-0.06 -4.63,0.102 -4.63,0.274 V 3.538 C -4.63,3.709 -4.554,3.871 -4.421,3.98 L -2.452,5.595 L -2.435,5.606 C -2.181,5.795 -1.824,5.74 -1.635,5.485 C -1.562,5.387 -1.524,5.268 -1.524,5.147 M -6.285,3.809 H -5.968 C -5.652,3.809 -5.397,3.554 -5.397,3.238 V 0.571 C -5.397,0.255 -5.652,0 -5.968,0 H -6.285 C -6.602,0 -6.856,0.255 -6.856,0.571 V 3.238 C -6.856,3.552 -6.602,3.809 -6.285,3.809"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,592.332,89.1904)"
+       clip-path="url(#clipPath718)" />
+    <path
+       id="path719"
+       d="M 0,0 C -0.21,0 -0.381,0.171 -0.381,0.381 C -0.381,0.448 -0.364,0.514 -0.331,0.571 C 0.119,1.355 0.381,2.012 0.381,3.047 C 0.381,4.1 0.121,4.752 -0.329,5.521 C -0.433,5.704 -0.367,5.937 -0.186,6.04 C -0.007,6.142 0.221,6.08 0.329,5.904 C 0.831,5.045 1.143,4.266 1.143,3.047 C 1.143,1.847 0.831,1.064 0.331,0.19 C 0.262,0.071 0.136,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,655.3723,90.714)"
+       clip-path="url(#clipPath720)" />
+    <path
+       id="path721"
+       d="M 0,0 C -0.21,0 -0.381,0.171 -0.381,0.381 C -0.381,0.455 -0.359,0.526 -0.319,0.588 C 0.331,1.583 0.762,2.576 0.762,4.19 C 0.762,5.773 0.329,6.775 -0.321,7.794 C -0.436,7.973 -0.383,8.208 -0.205,8.32 C -0.026,8.435 0.21,8.382 0.321,8.204 C 1.043,7.073 1.524,5.959 1.524,4.19 C 1.524,2.647 1.174,1.486 0.319,0.174 C 0.248,0.064 0.129,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,656.896,92.2376)"
+       clip-path="url(#clipPath722)" />
+    <path
+       id="path723"
+       d="M 0,0 H 0.314 C 0.631,0 0.886,-0.255 0.886,-0.571 V -3.238 C 0.886,-3.554 0.631,-3.809 0.314,-3.809 H 0 C -0.317,-3.809 -0.571,-3.554 -0.571,-3.238 V -0.571 C -0.571,-0.257 -0.317,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,645.4688,84.1116)"
+       clip-path="url(#clipPath724)" />
+    <path
+       id="path725"
+       d="M 0,0 V -6.483 C 0,-6.604 -0.038,-6.723 -0.112,-6.821 C -0.3,-7.075 -0.657,-7.13 -0.912,-6.942 L -0.928,-6.93 L -2.897,-5.316 C -3.031,-5.206 -3.107,-5.045 -3.107,-4.873 V -1.609 C -3.107,-1.438 -3.031,-1.276 -2.897,-1.167 L -0.928,0.448 L -0.912,0.459 C -0.657,0.648 -0.3,0.593 -0.112,0.338 C -0.038,0.24 0,0.121 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,651.8172,82.32773)"
+       clip-path="url(#clipPath726)" />
+    <path
+       id="path727"
+       d="M 0,0 C -0.21,0 -0.381,0.171 -0.381,0.381 C -0.381,0.44 -0.367,0.498 -0.34,0.552 C -0.114,1.002 0,1.457 0,1.905 C 0,2.366 -0.112,2.807 -0.338,3.254 C -0.431,3.442 -0.352,3.671 -0.162,3.764 C 0.021,3.854 0.245,3.78 0.34,3.6 C 0.624,3.042 0.762,2.488 0.762,1.902 C 0.762,1.336 0.619,0.764 0.34,0.207 C 0.276,0.081 0.143,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,653.8487,89.1904)"
+       clip-path="url(#clipPath728)" />
+    <path
+       id="path731"
+       d="M 0,0 H -3.221 C -3.326,0 -3.409,0.086 -3.409,0.188 V 0.997 H 0.188 V 0.188 C 0.19,0.086 0.105,0 0,0 M -7.77,0.19 V 1 H -4.173 V 0.19 C -4.173,0.086 -4.259,0.002 -4.361,0.002 H -7.58 C -7.685,0 -7.77,0.086 -7.77,0.19 M -7.58,6.014 H 0 C 0.105,6.014 0.19,5.928 0.19,5.823 V 1.762 H -7.582 H -7.77 V 5.823 C -7.77,5.928 -7.685,6.014 -7.58,6.014 M 0,6.775 H -7.58 C -8.106,6.775 -8.532,6.349 -8.532,5.823 V 0.19 C -8.532,-0.336 -8.106,-0.762 -7.58,-0.762 H -3.79 H 0 C 0.526,-0.762 0.952,-0.336 0.952,0.19 V 5.823 C 0.952,6.349 0.526,6.775 0,6.775"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,854.3799,90.66)"
+       clip-path="url(#clipPath732)" />
+    <path
+       d="M 97.38243,90.31641 Q 97.31212,90.38086 97.1422,90.46875 Q 96.97813,90.55664 96.87852,90.58594 L 94.64024,88.37695 L 94.81016,88.04883 Q 94.86876,88.03711 95.04454,88.00195 Q 95.22618,87.9668 95.44298,87.93164 Q 95.65977,87.89063 95.84727,87.86133 Q 96.03477,87.82617 96.10509,87.82031 Z"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4247" />
+    <path
+       d="M 119.8064,96.00586 Q 119.4666,96.23438 119.1091,96.42773 Q 118.7517,96.62109 118.4646,96.73828 Q 118.1834,96.85547 118.0662,96.85547 Q 117.7615,96.85547 117.6267,96.46289 Q 117.4919,96.06445 117.4919,95.08594 V 91.79883 Q 117.738,91.69922 118.1189,91.50586 Q 118.4998,91.30664 118.8337,91.05469 L 119.0681,91.27148 Q 119.0681,91.27148 119.0212,91.47656 Q 118.9802,91.67578 118.9392,91.98633 Q 118.8982,92.29102 118.8982,92.61914 V 94.83984 Q 118.8982,95.19141 118.9158,95.41406 Q 118.9392,95.63672 118.9978,95.68945 Q 119.0564,95.74805 119.197,95.73633 Q 119.3435,95.71875 119.6423,95.57813 Q 119.6423,95.57227 119.6834,95.68359 Q 119.7244,95.78906 119.7654,95.90039 Q 119.8064,96.00586 119.8064,96.00586 Z M 117.9314,95.41992 Q 117.4744,95.9707 117.1228,96.28125 Q 116.7771,96.5918 116.4607,96.7207 Q 116.1443,96.85547 115.7752,96.85547 Q 115.2771,96.85547 114.8201,96.53906 Q 114.363,96.22266 114.0701,95.60742 Q 113.783,94.99219 113.783,94.10156 Q 113.783,93.58008 113.9705,93.04688 Q 114.158,92.50781 114.5154,92.05664 Q 114.8787,91.60547 115.3943,91.33008 Q 115.9099,91.05469 116.5662,91.05469 Q 116.9177,91.05469 117.2166,91.18945 Q 117.5154,91.31836 117.8728,91.71094 Q 117.8728,92.4375 117.533,92.6543 Q 117.4099,92.28516 117.1111,92.05664 Q 116.8181,91.82813 116.4783,91.82813 Q 116.156,91.82813 115.8572,92.00391 Q 115.5642,92.17383 115.3767,92.5957 Q 115.1892,93.01172 115.1892,93.74414 Q 115.1892,94.40625 115.365,94.85156 Q 115.5466,95.29688 115.8162,95.51953 Q 116.0916,95.74219 116.3728,95.74219 Q 116.6248,95.74219 116.8884,95.58984 Q 117.158,95.4375 117.6677,94.93945 Q 117.7205,94.96289 117.7732,95.06836 Q 117.8259,95.17383 117.8669,95.28516 Q 117.9138,95.39063 117.9314,95.41992 Z M 117.5447,90.31641 Q 117.4685,90.38672 117.3044,90.47461 Q 117.1404,90.55664 117.0408,90.58594 L 114.8025,88.37695 L 114.9724,88.04883 Q 115.031,88.03711 115.2068,88.00195 Q 115.3884,87.9668 115.6052,87.92578 Q 115.822,87.88477 116.0095,87.85547 Q 116.197,87.82617 116.2673,87.82031 Z"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4249" />
+    <path
+       d="M 160.5879,84.58465 Q 160.5117,84.69598 160.3418,84.86004 Q 160.1719,85.02411 160.002,85.16473 Q 159.8379,85.30536 159.7559,85.34637 Q 159.6973,85.18231 159.5098,85.13543 Q 159.3223,85.0827 158.9473,85.0827 H 156.6797 L 156.5449,84.85418 L 157.3125,84.37957 H 160.4297 Z M 162.1875,81.50262 Q 162.0586,81.59637 161.8653,81.74871 Q 161.6719,81.90106 161.4668,82.05926 Q 161.2676,82.21746 161.0977,82.32293 Q 160.9336,82.4284 160.8633,82.4284 Q 160.7344,82.4284 160.6114,82.25848 Q 160.4883,82.0827 160.336,81.90692 Q 160.1895,81.73114 159.9903,81.73114 Q 159.7442,81.73114 159.5742,81.95965 Q 159.4043,82.18231 159.293,82.54559 Q 159.1817,82.90301 159.1114,83.31903 Q 159.0469,83.72918 159.0059,84.10418 L 158.4903,88.55145 Q 158.3907,89.40692 157.9864,90.18036 Q 157.5879,90.95965 157.0254,91.56317 Q 156.4688,92.17254 155.8887,92.52411 L 155.6485,92.0202 Q 156.041,91.8034 156.3282,91.2995 Q 156.6211,90.80145 156.8028,90.15106 Q 156.9903,89.50653 157.0606,88.86786 L 157.5762,84.41473 Q 157.6934,83.45965 158.0215,82.66864 Q 158.3555,81.87762 159.0996,81.32098 Q 159.4102,81.09246 159.75,80.93426 Q 160.0899,80.77606 160.4473,80.77606 Q 160.834,80.77606 161.1856,80.94012 Q 161.5371,81.10418 161.8008,81.28582 Q 162.0645,81.46161 162.1875,81.50262 Z"
+       style="font-style:italic;font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path3893" />
+    <path
+       d="M 160.9922,89.68231 V 89.19598 Q 161.9121,89.08465 162.2403,88.93817 Q 162.5742,88.79168 162.5742,88.66864 V 84.35028 Q 162.5742,84.1159 162.5567,83.987 Q 162.5391,83.85223 162.4688,83.77606 Q 162.3985,83.69989 162.0762,83.69989 Q 161.7539,83.69403 160.9805,83.85809 L 160.8106,83.38348 Q 161.0625,83.33075 161.461,83.2077 Q 161.8653,83.07879 162.3047,82.92645 Q 162.7442,82.77411 163.125,82.62762 Q 163.5059,82.48114 163.7227,82.38739 L 163.9805,82.63348 V 88.66864 Q 163.9805,88.77996 164.2676,88.93231 Q 164.5606,89.08465 165.4453,89.19598 V 89.68231 Z"
+       id="path3895"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 226.1665,84.58465 Q 226.0903,84.69598 225.9204,84.86005 Q 225.7505,85.02411 225.5806,85.16473 Q 225.4165,85.30536 225.3345,85.34637 Q 225.2759,85.18231 225.0884,85.13544 Q 224.9009,85.0827 224.5259,85.0827 H 222.2583 L 222.1235,84.85419 L 222.8911,84.37958 H 226.0083 Z M 227.7661,81.50262 Q 227.6372,81.59637 227.4439,81.74872 Q 227.2505,81.90106 227.0454,82.05926 Q 226.8462,82.21747 226.6763,82.32294 Q 226.5122,82.4284 226.4419,82.4284 Q 226.313,82.4284 226.19,82.25848 Q 226.0669,82.0827 225.9146,81.90692 Q 225.7681,81.73114 225.5689,81.73114 Q 225.3228,81.73114 225.1528,81.95965 Q 224.9829,82.18231 224.8716,82.54559 Q 224.7603,82.90301 224.69,83.31903 Q 224.6255,83.72919 224.5845,84.10419 L 224.0689,88.55145 Q 223.9693,89.40692 223.565,90.18036 Q 223.1665,90.95965 222.604,91.56317 Q 222.0474,92.17255 221.4673,92.52411 L 221.2271,92.0202 Q 221.6196,91.8034 221.9068,91.2995 Q 222.1997,90.80145 222.3814,90.15106 Q 222.5689,89.50653 222.6392,88.86786 L 223.1548,84.41473 Q 223.272,83.45965 223.6001,82.66864 Q 223.9341,81.87762 224.6782,81.32098 Q 224.9888,81.09247 225.3286,80.93426 Q 225.6685,80.77606 226.0259,80.77606 Q 226.4126,80.77606 226.7642,80.94012 Q 227.1157,81.10419 227.3794,81.28583 Q 227.6431,81.46161 227.7661,81.50262 Z"
+       style="font-style:italic;font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path3898" />
+    <path
+       d="M 231.0005,89.68231 H 226.3189 L 226.1489,89.24872 Q 227.1802,88.04169 227.8364,87.22723 Q 228.4985,86.41278 228.8677,85.87372 Q 229.2368,85.3288 229.3833,84.95965 Q 229.5357,84.58465 229.5357,84.26825 Q 229.5357,83.7702 229.3189,83.43622 Q 229.1079,83.10223 228.6216,83.10223 Q 228.2349,83.10223 228.0239,83.35419 Q 227.8189,83.60614 227.7837,83.94598 Q 227.7603,84.12176 227.7896,84.29755 Q 227.6607,84.36786 227.4263,84.44989 Q 227.1919,84.53192 226.94,84.59637 Q 226.688,84.65497 226.5122,84.67255 L 226.3071,84.27411 Q 226.3071,83.97528 226.5239,83.65301 Q 226.7407,83.33075 227.1157,83.06122 Q 227.4907,82.78583 227.9771,82.6159 Q 228.4693,82.44598 229.02,82.44598 Q 229.9224,82.44598 230.4673,82.82098 Q 231.0122,83.19598 231.0122,83.9284 Q 231.0122,84.32098 230.8423,84.73114 Q 230.6724,85.13544 230.2857,85.65692 Q 229.8989,86.17255 229.2603,86.90497 Q 228.6216,87.63153 227.6841,88.66278 H 230.022 Q 230.2153,88.66278 230.3384,88.47528 Q 230.4673,88.28778 230.5376,88.01825 Q 230.6079,87.74286 230.6196,87.4909 L 231.0884,87.60223 Z"
+       id="path3900"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 291.7489,84.58465 Q 291.6727,84.69598 291.5028,84.86004 Q 291.3329,85.02411 291.163,85.16473 Q 290.9989,85.30536 290.9169,85.34637 Q 290.8583,85.18231 290.6708,85.13544 Q 290.4833,85.0827 290.1083,85.0827 H 287.8407 L 287.7059,84.85419 L 288.4735,84.37958 H 291.5907 Z M 293.3485,81.50262 Q 293.2196,81.59637 293.0263,81.74872 Q 292.8329,81.90106 292.6278,82.05926 Q 292.4286,82.21747 292.2587,82.32294 Q 292.0946,82.4284 292.0243,82.4284 Q 291.8954,82.4284 291.7724,82.25848 Q 291.6493,82.0827 291.497,81.90692 Q 291.3505,81.73114 291.1513,81.73114 Q 290.9052,81.73114 290.7352,81.95965 Q 290.5653,82.18231 290.454,82.54559 Q 290.3427,82.90301 290.2724,83.31903 Q 290.2079,83.72919 290.1669,84.10419 L 289.6513,88.55145 Q 289.5517,89.40692 289.1474,90.18036 Q 288.7489,90.95965 288.1864,91.56317 Q 287.6298,92.17254 287.0497,92.52411 L 286.8095,92.0202 Q 287.202,91.8034 287.4892,91.2995 Q 287.7821,90.80145 287.9638,90.15106 Q 288.1513,89.50653 288.2216,88.86786 L 288.7372,84.41473 Q 288.8544,83.45965 289.1825,82.66864 Q 289.5165,81.87762 290.2606,81.32098 Q 290.5712,81.09247 290.911,80.93426 Q 291.2509,80.77606 291.6083,80.77606 Q 291.995,80.77606 292.3466,80.94012 Q 292.6981,81.10419 292.9618,81.28583 Q 293.2255,81.46161 293.3485,81.50262 Z"
+       style="font-style:italic;font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path3903" />
+    <path
+       d="M 296.6063,87.44989 Q 296.6063,88.10614 296.2724,88.65692 Q 295.9384,89.20184 295.3349,89.52997 Q 294.7372,89.85809 293.9345,89.85809 Q 293.4716,89.85809 292.8446,89.62958 Q 292.2177,89.40106 291.6903,88.89715 L 291.9306,88.32879 Q 292.4638,88.72137 292.8974,88.88544 Q 293.3309,89.0495 293.7704,89.0495 Q 294.3212,89.0495 294.7079,88.69794 Q 295.1005,88.34637 295.1005,87.59637 Q 295.1005,87.05731 294.8837,86.74676 Q 294.6727,86.43036 294.3739,86.29559 Q 294.0809,86.16083 293.8231,86.16083 Q 293.6708,86.16083 293.5829,86.17254 Q 293.495,86.1784 293.3368,86.20184 L 293.2313,85.6745 Q 293.9052,85.49872 294.2274,85.2409 Q 294.5556,84.97723 294.661,84.69598 Q 294.7665,84.41473 294.7665,84.1745 Q 294.7665,83.7702 294.5849,83.44208 Q 294.4091,83.10809 293.9638,83.10809 Q 293.7001,83.10809 293.5067,83.31317 Q 293.3192,83.51239 293.3192,83.81708 Q 293.3192,83.94012 293.3544,84.06903 Q 293.1142,84.20379 292.745,84.32684 Q 292.3817,84.44403 292.0595,84.47333 L 291.8602,84.1159 Q 291.8602,83.78778 292.1708,83.40106 Q 292.4813,83.00848 293.0263,82.72723 Q 293.577,82.44598 294.2977,82.44598 Q 295.0126,82.44598 295.4462,82.68622 Q 295.8798,82.92645 296.0731,83.30145 Q 296.2724,83.67059 296.2724,84.06903 Q 296.2724,84.50848 295.9267,84.95965 Q 295.5809,85.40497 295.0243,85.59247 Q 295.7392,85.66864 296.1727,86.20184 Q 296.6063,86.73504 296.6063,87.44989 Z"
+       id="path3905"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 357.3274,84.58465 Q 357.2512,84.69598 357.0813,84.86004 Q 356.9114,85.02411 356.7415,85.16473 Q 356.5774,85.30536 356.4954,85.34637 Q 356.4368,85.18231 356.2493,85.13544 Q 356.0618,85.0827 355.6868,85.0827 H 353.4192 L 353.2844,84.85419 L 354.052,84.37958 H 357.1692 Z M 358.927,81.50262 Q 358.7981,81.59637 358.6048,81.74872 Q 358.4114,81.90106 358.2063,82.05926 Q 358.0071,82.21747 357.8372,82.32294 Q 357.6731,82.4284 357.6028,82.4284 Q 357.4739,82.4284 357.3509,82.25848 Q 357.2278,82.0827 357.0755,81.90692 Q 356.929,81.73114 356.7298,81.73114 Q 356.4837,81.73114 356.3137,81.95965 Q 356.1438,82.18231 356.0325,82.54559 Q 355.9212,82.90301 355.8509,83.31903 Q 355.7864,83.72919 355.7454,84.10419 L 355.2298,88.55145 Q 355.1302,89.40692 354.7259,90.18036 Q 354.3274,90.95965 353.7649,91.56317 Q 353.2083,92.17254 352.6282,92.52411 L 352.388,92.0202 Q 352.7805,91.8034 353.0677,91.2995 Q 353.3606,90.80145 353.5423,90.15106 Q 353.7298,89.50653 353.8001,88.86786 L 354.3157,84.41473 Q 354.4329,83.45965 354.761,82.66864 Q 355.095,81.87762 355.8391,81.32098 Q 356.1497,81.09247 356.4895,80.93426 Q 356.8294,80.77606 357.1868,80.77606 Q 357.5735,80.77606 357.9251,80.94012 Q 358.2766,81.10419 358.5403,81.28583 Q 358.804,81.46161 358.927,81.50262 Z"
+       style="font-style:italic;font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path3908" />
+    <path
+       d="M 362.4309,87.07489 Q 362.3079,87.26239 362.138,87.44403 Q 361.968,87.61981 361.8333,87.71942 H 361.511 V 88.89715 Q 361.511,88.98504 361.6751,89.06708 Q 361.845,89.14325 362.3255,89.25458 V 89.68231 H 358.9329 V 89.25458 Q 359.7005,89.12567 359.929,89.03192 Q 360.1634,88.93231 360.1634,88.8327 V 87.71942 H 357.386 L 357.1458,87.47919 L 359.9641,82.84442 Q 360.2395,82.75067 360.6145,82.62176 Q 360.9954,82.487 361.2532,82.38739 L 361.511,82.63348 V 86.89911 H 362.2786 Z M 360.1634,83.94012 L 358.2942,86.89911 H 360.1634 Z"
+       id="path3910"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 422.5129,84.58465 Q 422.4367,84.69598 422.2668,84.86004 Q 422.0969,85.02411 421.927,85.16473 Q 421.7629,85.30536 421.6809,85.34637 Q 421.6223,85.18231 421.4348,85.13543 Q 421.2473,85.0827 420.8723,85.0827 H 418.6047 L 418.4699,84.85418 L 419.2375,84.37958 H 422.3547 Z M 424.1125,81.50262 Q 423.9836,81.59637 423.7903,81.74872 Q 423.5969,81.90106 423.3918,82.05926 Q 423.1926,82.21747 423.0227,82.32293 Q 422.8586,82.4284 422.7883,82.4284 Q 422.6594,82.4284 422.5364,82.25848 Q 422.4133,82.0827 422.261,81.90692 Q 422.1145,81.73114 421.9153,81.73114 Q 421.6692,81.73114 421.4992,81.95965 Q 421.3293,82.18231 421.218,82.54559 Q 421.1067,82.90301 421.0364,83.31903 Q 420.9719,83.72918 420.9309,84.10418 L 420.4153,88.55145 Q 420.3157,89.40692 419.9114,90.18036 Q 419.5129,90.95965 418.9504,91.56317 Q 418.3938,92.17254 417.8137,92.52411 L 417.5735,92.0202 Q 417.966,91.8034 418.2532,91.2995 Q 418.5461,90.80145 418.7278,90.15106 Q 418.9153,89.50653 418.9856,88.86786 L 419.5012,84.41473 Q 419.6184,83.45965 419.9465,82.66864 Q 420.2805,81.87762 421.0246,81.32098 Q 421.3352,81.09247 421.675,80.93426 Q 422.0149,80.77606 422.3723,80.77606 Q 422.759,80.77606 423.1106,80.94012 Q 423.4621,81.10418 423.7258,81.28583 Q 423.9895,81.46161 424.1125,81.50262 Z"
+       style="font-style:italic;font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path3913" />
+    <path
+       d="M 427.3996,87.27997 Q 427.3996,87.95965 427.1184,88.55145 Q 426.843,89.13739 426.2571,89.50067 Q 425.677,89.85809 424.7746,89.85809 Q 424.2297,89.85809 423.6028,89.62372 Q 422.9817,89.38934 422.4778,88.92059 L 422.7707,88.39325 Q 423.386,88.82684 423.8489,88.96161 Q 424.3117,89.09637 424.6457,89.09637 Q 425.2317,89.09637 425.6067,88.65106 Q 425.9817,88.19989 425.9817,87.53192 Q 425.9817,86.72918 425.5891,86.30731 Q 425.1965,85.88543 424.5578,85.88543 Q 424.0891,85.88543 423.7434,86.02606 Q 423.4035,86.16668 423.0989,86.40106 L 422.8235,86.2077 Q 422.8762,85.89129 422.9465,85.41083 Q 423.0227,84.93036 423.093,84.40887 Q 423.1692,83.88153 423.2278,83.40692 Q 423.2864,82.93231 423.3039,82.62176 H 426.386 Q 426.7199,82.62176 426.9074,82.56903 Q 427.0949,82.51629 427.0949,82.51629 L 427.3059,82.72723 Q 427.2239,82.85614 427.0657,83.06122 Q 426.9133,83.26043 426.7551,83.44208 Q 426.6028,83.62372 426.509,83.68817 H 423.9778 Q 423.966,83.91668 423.925,84.22137 Q 423.8899,84.52606 423.843,84.80731 Q 423.7961,85.08856 423.761,85.26434 Q 424.0188,85.15301 424.341,85.08856 Q 424.6692,85.02411 425.0383,85.02411 Q 425.8235,85.02411 426.3449,85.35223 Q 426.8723,85.6745 427.136,86.19012 Q 427.3996,86.70575 427.3996,87.27997 Z"
+       id="path3915"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 488.4695,84.58465 Q 488.3933,84.69598 488.2234,84.86004 Q 488.0535,85.02411 487.8836,85.16473 Q 487.7195,85.30536 487.6375,85.34637 Q 487.5789,85.18231 487.3914,85.13543 Q 487.2039,85.0827 486.8289,85.0827 H 484.5613 L 484.4265,84.85418 L 485.1941,84.37957 H 488.3113 Z M 490.0691,81.50262 Q 489.9402,81.59637 489.7469,81.74871 Q 489.5535,81.90106 489.3484,82.05926 Q 489.1492,82.21746 488.9793,82.32293 Q 488.8152,82.4284 488.7449,82.4284 Q 488.616,82.4284 488.493,82.25848 Q 488.3699,82.0827 488.2176,81.90692 Q 488.0711,81.73114 487.8719,81.73114 Q 487.6258,81.73114 487.4558,81.95965 Q 487.2859,82.18231 487.1746,82.54559 Q 487.0633,82.90301 486.993,83.31903 Q 486.9285,83.72918 486.8875,84.10418 L 486.3719,88.55145 Q 486.2723,89.40692 485.868,90.18036 Q 485.4695,90.95965 484.907,91.56317 Q 484.3504,92.17254 483.7703,92.52411 L 483.5301,92.0202 Q 483.9226,91.8034 484.2098,91.2995 Q 484.5027,90.80145 484.6844,90.15106 Q 484.8719,89.50653 484.9422,88.86786 L 485.4578,84.41473 Q 485.575,83.45965 485.9031,82.66864 Q 486.2371,81.87762 486.9812,81.32098 Q 487.2918,81.09246 487.6316,80.93426 Q 487.9715,80.77606 488.3289,80.77606 Q 488.7156,80.77606 489.0672,80.94012 Q 489.4187,81.10418 489.6824,81.28582 Q 489.9461,81.46161 490.0691,81.50262 Z"
+       style="font-style:italic;font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path3918" />
+    <path
+       d="M 493.6551,87.26825 Q 493.6551,87.6784 493.4969,88.12957 Q 493.3445,88.58075 493.034,88.97332 Q 492.7234,89.3659 492.2605,89.612 Q 491.8035,89.85809 491.1941,89.85809 Q 490.45,89.85809 489.8406,89.48895 Q 489.2371,89.11981 488.8797,88.4577 Q 488.5223,87.78973 488.5223,86.91082 Q 488.5223,85.8034 489.0144,84.84832 Q 489.5125,83.88739 490.4969,83.23114 Q 491.4812,82.56903 492.9344,82.36395 L 493.0926,82.88543 Q 491.9441,83.13153 491.2703,83.68817 Q 490.6023,84.24481 490.3152,84.98895 Q 490.034,85.73309 490.034,86.53582 Q 490.034,87.9245 490.4031,88.51629 Q 490.7781,89.10809 491.3348,89.10809 Q 491.6746,89.10809 491.8621,88.89129 Q 492.0555,88.6745 492.1316,88.34051 Q 492.2078,88.00067 492.2078,87.64325 Q 492.2078,86.91082 492.0496,86.53582 Q 491.8914,86.16082 491.6512,86.03192 Q 491.4109,85.90301 491.159,85.90301 Q 490.8191,85.90301 490.3914,86.21356 Q 489.9695,86.52411 489.6238,87.06317 L 489.5066,86.32489 Q 489.9637,85.70379 490.532,85.39325 Q 491.1004,85.0827 491.534,85.0827 Q 492.5301,85.0827 493.0926,85.69793 Q 493.6551,86.30731 493.6551,87.26825 Z"
+       id="path3920"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 554.0519,84.58465 Q 553.9757,84.69598 553.8058,84.86004 Q 553.6359,85.02411 553.466,85.16473 Q 553.3019,85.30536 553.2199,85.34637 Q 553.1613,85.18231 552.9738,85.13544 Q 552.7863,85.0827 552.4113,85.0827 H 550.1437 L 550.0089,84.85419 L 550.7765,84.37958 H 553.8937 Z M 555.6515,81.50262 Q 555.5226,81.59637 555.3292,81.74872 Q 555.1359,81.90106 554.9308,82.05926 Q 554.7316,82.21747 554.5617,82.32294 Q 554.3976,82.4284 554.3273,82.4284 Q 554.1984,82.4284 554.0753,82.25848 Q 553.9523,82.0827 553.7999,81.90692 Q 553.6535,81.73114 553.4542,81.73114 Q 553.2082,81.73114 553.0382,81.95965 Q 552.8683,82.18231 552.757,82.54559 Q 552.6457,82.90301 552.5753,83.31903 Q 552.5109,83.72919 552.4699,84.10419 L 551.9542,88.55145 Q 551.8546,89.40692 551.4503,90.18036 Q 551.0519,90.95965 550.4894,91.56317 Q 549.9328,92.17254 549.3527,92.52411 L 549.1124,92.0202 Q 549.505,91.8034 549.7921,91.2995 Q 550.0851,90.80145 550.2667,90.15106 Q 550.4542,89.50653 550.5246,88.86786 L 551.0402,84.41473 Q 551.1574,83.45965 551.4855,82.66864 Q 551.8195,81.87762 552.5636,81.32098 Q 552.8742,81.09247 553.214,80.93426 Q 553.5539,80.77606 553.9113,80.77606 Q 554.298,80.77606 554.6496,80.94012 Q 555.0011,81.10419 555.2648,81.28583 Q 555.5285,81.46161 555.6515,81.50262 Z"
+       style="font-style:italic;font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path3923" />
+    <path
+       d="M 559.173,82.84442 Q 558.7687,83.78778 558.382,84.74872 Q 557.9953,85.70965 557.6554,86.59442 Q 557.3214,87.47333 557.0636,88.19403 Q 556.8058,88.91473 556.6535,89.37762 Q 556.4425,89.52411 556.0382,89.65301 Q 555.6398,89.78192 555.3527,89.85809 L 555.0656,89.61786 Q 555.5519,88.76825 555.9328,88.04754 Q 556.3136,87.32098 556.6417,86.64129 Q 556.9757,85.96161 557.2921,85.24676 Q 557.6144,84.53192 557.9777,83.68817 H 555.3585 Q 555.2355,83.68817 555.1007,83.7409 Q 554.9718,83.78778 554.8253,83.987 Q 554.6789,84.18036 554.5148,84.62567 L 554.1164,84.47919 Q 554.1339,84.34442 554.1632,84.09247 Q 554.1984,83.83465 554.2394,83.54754 Q 554.2863,83.25458 554.3273,83.00262 Q 554.3742,82.75067 554.4093,82.62176 H 558.9796 Z"
+       id="path3925"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 619.6115,84.58465 Q 619.5354,84.69598 619.3654,84.86004 Q 619.1955,85.02411 619.0256,85.16473 Q 618.8615,85.30536 618.7795,85.34637 Q 618.7209,85.18231 618.5334,85.13544 Q 618.3459,85.0827 617.9709,85.0827 H 615.7033 L 615.5686,84.85419 L 616.3361,84.37958 H 619.4533 Z M 621.2111,81.50262 Q 621.0822,81.59637 620.8889,81.74872 Q 620.6955,81.90106 620.4904,82.05926 Q 620.2912,82.21747 620.1213,82.32294 Q 619.9572,82.4284 619.8869,82.4284 Q 619.758,82.4284 619.635,82.25848 Q 619.5119,82.0827 619.3596,81.90692 Q 619.2131,81.73114 619.0139,81.73114 Q 618.7678,81.73114 618.5979,81.95965 Q 618.4279,82.18231 618.3166,82.54559 Q 618.2053,82.90301 618.135,83.31903 Q 618.0705,83.72919 618.0295,84.10419 L 617.5139,88.55145 Q 617.4143,89.40692 617.01,90.18036 Q 616.6115,90.95965 616.049,91.56317 Q 615.4924,92.17254 614.9123,92.52411 L 614.6721,92.0202 Q 615.0646,91.8034 615.3518,91.2995 Q 615.6447,90.80145 615.8264,90.15106 Q 616.0139,89.50653 616.0842,88.86786 L 616.5998,84.41473 Q 616.717,83.45965 617.0451,82.66864 Q 617.3791,81.87762 618.1232,81.32098 Q 618.4338,81.09247 618.7736,80.93426 Q 619.1135,80.77606 619.4709,80.77606 Q 619.8576,80.77606 620.2092,80.94012 Q 620.5607,81.10419 620.8244,81.28583 Q 621.0881,81.46161 621.2111,81.50262 Z"
+       style="font-style:italic;font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path3928" />
+    <path
+       d="M 624.715,87.61981 Q 624.715,88.22333 624.3576,88.73309 Q 624.0002,89.24286 623.385,89.5534 Q 622.7756,89.85809 622.0139,89.85809 Q 621.217,89.85809 620.6721,89.60028 Q 620.1271,89.33661 619.8459,88.91473 Q 619.5705,88.49286 619.5705,88.01239 Q 619.5705,87.35614 620.0861,86.79364 Q 620.6076,86.23114 621.4045,85.86786 L 622.0373,86.08465 Q 621.5627,86.49481 621.3225,86.89911 Q 621.0822,87.29754 621.0822,87.83661 Q 621.0822,88.44598 621.4279,88.79169 Q 621.7736,89.13739 622.2131,89.13739 Q 622.6936,89.13739 622.9514,88.76239 Q 623.2092,88.38153 623.2092,87.87176 Q 623.2092,87.35614 622.9631,87.03973 Q 622.7229,86.71747 622.342,86.51239 Q 621.967,86.30731 621.5393,86.13739 Q 621.1115,85.96161 620.7307,85.75067 Q 620.3498,85.53387 620.1096,85.19989 Q 619.8693,84.8659 619.8693,84.32098 Q 619.8693,83.77606 620.1857,83.35419 Q 620.5021,82.93231 621.0354,82.69208 Q 621.5686,82.44598 622.2248,82.44598 Q 623.3322,82.44598 623.8771,82.88544 Q 624.4221,83.32489 624.4221,84.00458 Q 624.4221,84.53778 623.9475,84.96551 Q 623.4787,85.39325 622.8166,85.77997 L 622.1838,85.52801 Q 622.9807,84.88348 622.9748,84.18622 Q 622.9689,83.57684 622.6818,83.35419 Q 622.3947,83.12567 622.0139,83.12567 Q 621.6213,83.12567 621.4104,83.4245 Q 621.2053,83.71747 621.2053,84.1159 Q 621.2053,84.47919 621.4572,84.71356 Q 621.7092,84.94794 622.1076,85.12372 Q 622.5119,85.2995 622.9572,85.487 Q 623.4084,85.66864 623.8068,85.93231 Q 624.2053,86.19012 624.4572,86.59442 Q 624.715,86.99872 624.715,87.61981 Z"
+       id="path3930"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 685.1901,84.58465 Q 685.1139,84.69598 684.944,84.86004 Q 684.7741,85.02411 684.6042,85.16473 Q 684.4401,85.30536 684.3581,85.34637 Q 684.2995,85.18231 684.112,85.13543 Q 683.9245,85.0827 683.5495,85.0827 H 681.2819 L 681.1471,84.85418 L 681.9147,84.37957 H 685.0319 Z M 686.7897,81.50262 Q 686.6608,81.59637 686.4675,81.74872 Q 686.2741,81.90106 686.069,82.05926 Q 685.8698,82.21747 685.6999,82.32293 Q 685.5358,82.4284 685.4655,82.4284 Q 685.3366,82.4284 685.2136,82.25848 Q 685.0905,82.0827 684.9382,81.90692 Q 684.7917,81.73114 684.5925,81.73114 Q 684.3464,81.73114 684.1764,81.95965 Q 684.0065,82.18231 683.8952,82.54559 Q 683.7839,82.90301 683.7136,83.31903 Q 683.6491,83.72918 683.6081,84.10418 L 683.0925,88.55145 Q 682.9929,89.40692 682.5886,90.18036 Q 682.1901,90.95965 681.6276,91.56317 Q 681.071,92.17254 680.4909,92.52411 L 680.2507,92.0202 Q 680.6432,91.8034 680.9304,91.2995 Q 681.2233,90.80145 681.405,90.15106 Q 681.5925,89.50653 681.6628,88.86786 L 682.1784,84.41473 Q 682.2956,83.45965 682.6237,82.66864 Q 682.9577,81.87762 683.7018,81.32098 Q 684.0124,81.09247 684.3522,80.93426 Q 684.6921,80.77606 685.0495,80.77606 Q 685.4362,80.77606 685.7878,80.94012 Q 686.1393,81.10418 686.403,81.28582 Q 686.6667,81.46161 686.7897,81.50262 Z"
+       style="font-style:italic;font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path3933" />
+    <path
+       d="M 690.3112,85.39911 Q 690.3112,86.5827 689.819,87.5495 Q 689.3268,88.51043 688.3425,89.13739 Q 687.3639,89.75848 685.8874,89.93426 L 685.7409,89.41278 Q 687.0007,89.10223 687.6569,88.59832 Q 688.319,88.09442 688.5593,87.42059 Q 688.8054,86.74676 688.8054,85.93231 Q 688.8054,84.78387 688.6354,84.19793 Q 688.4655,83.60614 688.2077,83.40106 Q 687.9499,83.19012 687.6745,83.19012 Q 687.1823,83.19012 686.9069,83.5827 Q 686.6374,83.96942 686.6374,84.66668 Q 686.6374,85.32293 686.8132,85.68622 Q 686.9948,86.0495 687.235,86.19598 Q 687.4811,86.34247 687.6804,86.34247 Q 688.0378,86.34247 688.3425,86.14911 Q 688.6471,85.94989 688.8757,85.63934 Q 689.11,85.32879 689.2624,85.00067 L 689.3386,85.79168 Q 689.0339,86.3952 688.4889,86.7995 Q 687.944,87.20379 687.2995,87.20379 Q 686.6081,87.20379 686.1335,86.90497 Q 685.6647,86.60028 685.4245,86.10223 Q 685.1843,85.60418 685.1843,85.02411 Q 685.1843,84.57879 685.3776,84.12762 Q 685.571,83.67059 685.9225,83.28973 Q 686.2741,82.90887 686.7546,82.68036 Q 687.2409,82.44598 687.8268,82.44598 Q 688.5475,82.44598 689.1042,82.75067 Q 689.6667,83.05536 689.9889,83.71161 Q 690.3112,84.362 690.3112,85.39911 Z"
+       id="path3935"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 750.7688,84.58465 Q 750.6926,84.69598 750.5227,84.86004 Q 750.3528,85.02411 750.1829,85.16473 Q 750.0188,85.30536 749.9368,85.34637 Q 749.8782,85.18231 749.6907,85.13543 Q 749.5032,85.0827 749.1282,85.0827 H 746.8606 L 746.7258,84.85418 L 747.4934,84.37958 H 750.6106 Z M 752.3684,81.50262 Q 752.2395,81.59637 752.0461,81.74872 Q 751.8528,81.90106 751.6477,82.05926 Q 751.4485,82.21747 751.2786,82.32293 Q 751.1145,82.4284 751.0442,82.4284 Q 750.9153,82.4284 750.7922,82.25848 Q 750.6692,82.0827 750.5168,81.90692 Q 750.3704,81.73114 750.1711,81.73114 Q 749.925,81.73114 749.7551,81.95965 Q 749.5852,82.18231 749.4739,82.54559 Q 749.3625,82.90301 749.2922,83.31903 Q 749.2278,83.72918 749.1868,84.10418 L 748.6711,88.55145 Q 748.5715,89.40692 748.1672,90.18036 Q 747.7688,90.95965 747.2063,91.56317 Q 746.6496,92.17254 746.0696,92.52411 L 745.8293,92.0202 Q 746.2219,91.8034 746.509,91.2995 Q 746.802,90.80145 746.9836,90.15106 Q 747.1711,89.50653 747.2414,88.86786 L 747.7571,84.41473 Q 747.8743,83.45965 748.2024,82.66864 Q 748.5364,81.87762 749.2805,81.32098 Q 749.5911,81.09247 749.9309,80.93426 Q 750.2707,80.77606 750.6282,80.77606 Q 751.0149,80.77606 751.3664,80.94012 Q 751.718,81.10418 751.9817,81.28583 Q 752.2454,81.46161 752.3684,81.50262 Z"
+       style="font-style:italic;font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path3938" />
+    <path
+       d="M 751.1731,89.68231 V 89.19598 Q 752.093,89.08465 752.4211,88.93817 Q 752.7551,88.79168 752.7551,88.66864 V 84.35028 Q 752.7551,84.1159 752.7375,83.987 Q 752.72,83.85223 752.6496,83.77606 Q 752.5793,83.69989 752.2571,83.69989 Q 751.9348,83.69403 751.1614,83.85809 L 750.9914,83.38348 Q 751.2434,83.33075 751.6418,83.2077 Q 752.0461,83.07879 752.4856,82.92645 Q 752.925,82.77411 753.3059,82.62762 Q 753.6868,82.48114 753.9036,82.38739 L 754.1614,82.63348 V 88.66864 Q 754.1614,88.77997 754.4485,88.93231 Q 754.7414,89.08465 755.6262,89.19598 V 89.68231 Z"
+       id="path3940"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 760.6941,86.15497 Q 760.6941,87.16278 760.3425,88.00653 Q 759.9968,88.84442 759.3757,89.35418 Q 758.7546,89.85809 757.946,89.85809 Q 757.1374,89.85809 756.5515,89.35418 Q 755.9656,88.84442 755.6492,88.00653 Q 755.3386,87.16278 755.3386,86.15497 Q 755.3386,85.14715 755.6726,84.3034 Q 756.0066,83.45965 756.6218,82.95575 Q 757.2371,82.44598 758.0867,82.44598 Q 758.9187,82.44598 759.4988,82.94989 Q 760.0847,83.44793 760.3894,84.29168 Q 760.6941,85.13543 760.6941,86.15497 Z M 759.1648,86.37176 Q 759.1648,84.76629 758.8191,83.987 Q 758.4734,83.2077 757.946,83.2077 Q 757.4128,83.2077 757.1433,83.82293 Q 756.8738,84.43231 756.8738,85.90301 Q 756.8738,87.50848 757.1843,88.30536 Q 757.5007,89.09637 758.0867,89.09637 Q 758.6316,89.09637 758.8953,88.47528 Q 759.1648,87.85418 759.1648,86.37176 Z"
+       id="path3942"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 816.3512,84.58465 Q 816.275,84.69598 816.1051,84.86004 Q 815.9352,85.02411 815.7653,85.16473 Q 815.6012,85.30536 815.5192,85.34637 Q 815.4606,85.18231 815.2731,85.13544 Q 815.0856,85.0827 814.7106,85.0827 H 812.443 L 812.3082,84.85419 L 813.0758,84.37958 H 816.193 Z M 817.9508,81.50262 Q 817.8219,81.59637 817.6285,81.74872 Q 817.4352,81.90106 817.2301,82.05926 Q 817.0309,82.21747 816.861,82.32294 Q 816.6969,82.4284 816.6266,82.4284 Q 816.4977,82.4284 816.3746,82.25848 Q 816.2516,82.0827 816.0992,81.90692 Q 815.9528,81.73114 815.7535,81.73114 Q 815.5074,81.73114 815.3375,81.95965 Q 815.1676,82.18231 815.0563,82.54559 Q 814.9449,82.90301 814.8746,83.31903 Q 814.8102,83.72919 814.7692,84.10419 L 814.2535,88.55145 Q 814.1539,89.40692 813.7496,90.18036 Q 813.3512,90.95965 812.7887,91.56317 Q 812.2321,92.17254 811.652,92.52411 L 811.4117,92.0202 Q 811.8043,91.8034 812.0914,91.2995 Q 812.3844,90.80145 812.566,90.15106 Q 812.7535,89.50653 812.8239,88.86786 L 813.3395,84.41473 Q 813.4567,83.45965 813.7848,82.66864 Q 814.1188,81.87762 814.8629,81.32098 Q 815.1735,81.09247 815.5133,80.93426 Q 815.8532,80.77606 816.2106,80.77606 Q 816.5973,80.77606 816.9489,80.94012 Q 817.3004,81.10419 817.5641,81.28583 Q 817.8278,81.46161 817.9508,81.50262 Z"
+       style="font-style:italic;font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path3945" />
+    <path
+       d="M 816.7555,89.68231 V 89.19598 Q 817.6754,89.08465 818.0035,88.93817 Q 818.3375,88.79169 818.3375,88.66864 V 84.35028 Q 818.3375,84.1159 818.3199,83.987 Q 818.3024,83.85223 818.2321,83.77606 Q 818.1617,83.69989 817.8395,83.69989 Q 817.5172,83.69403 816.7438,83.85809 L 816.5739,83.38348 Q 816.8258,83.33075 817.2242,83.2077 Q 817.6285,83.07879 818.068,82.92645 Q 818.5074,82.77411 818.8883,82.62762 Q 819.2692,82.48114 819.486,82.38739 L 819.7438,82.63348 V 88.66864 Q 819.7438,88.77997 820.0309,88.93231 Q 820.3239,89.08465 821.2086,89.19598 V 89.68231 Z"
+       id="path3947"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 821.8509,89.68231 V 89.19598 Q 822.7708,89.08465 823.099,88.93817 Q 823.4329,88.79169 823.4329,88.66864 V 84.35028 Q 823.4329,84.1159 823.4154,83.987 Q 823.3978,83.85223 823.3275,83.77606 Q 823.2572,83.69989 822.9349,83.69989 Q 822.6126,83.69403 821.8392,83.85809 L 821.6693,83.38348 Q 821.9212,83.33075 822.3197,83.2077 Q 822.724,83.07879 823.1634,82.92645 Q 823.6029,82.77411 823.9837,82.62762 Q 824.3646,82.48114 824.5814,82.38739 L 824.8392,82.63348 V 88.66864 Q 824.8392,88.77997 825.1263,88.93231 Q 825.4193,89.08465 826.304,89.19598 V 89.68231 Z"
+       id="path3949"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 881.9107,84.58465 Q 881.8346,84.69598 881.6646,84.86004 Q 881.4947,85.02411 881.3248,85.16473 Q 881.1607,85.30536 881.0787,85.34637 Q 881.0201,85.18231 880.8326,85.13544 Q 880.6451,85.0827 880.2701,85.0827 H 878.0025 L 877.8678,84.85419 L 878.6353,84.37958 H 881.7525 Z M 883.5103,81.50262 Q 883.3814,81.59637 883.1881,81.74872 Q 882.9947,81.90106 882.7896,82.05926 Q 882.5904,82.21747 882.4205,82.32294 Q 882.2564,82.4284 882.1861,82.4284 Q 882.0572,82.4284 881.9342,82.25848 Q 881.8111,82.0827 881.6588,81.90692 Q 881.5123,81.73114 881.3131,81.73114 Q 881.067,81.73114 880.8971,81.95965 Q 880.7271,82.18231 880.6158,82.54559 Q 880.5045,82.90301 880.4342,83.31903 Q 880.3697,83.72919 880.3287,84.10419 L 879.8131,88.55145 Q 879.7135,89.40692 879.3092,90.18036 Q 878.9107,90.95965 878.3482,91.56317 Q 877.7916,92.17254 877.2115,92.52411 L 876.9713,92.0202 Q 877.3639,91.8034 877.651,91.2995 Q 877.9439,90.80145 878.1256,90.15106 Q 878.3131,89.50653 878.3834,88.86786 L 878.899,84.41473 Q 879.0162,83.45965 879.3443,82.66864 Q 879.6783,81.87762 880.4225,81.32098 Q 880.733,81.09247 881.0728,80.93426 Q 881.4127,80.77606 881.7701,80.77606 Q 882.1568,80.77606 882.5084,80.94012 Q 882.86,81.10419 883.1236,81.28583 Q 883.3873,81.46161 883.5103,81.50262 Z"
+       style="font-style:italic;font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path3952" />
+    <path
+       d="M 882.315,89.68231 V 89.19598 Q 883.235,89.08465 883.5631,88.93817 Q 883.8971,88.79169 883.8971,88.66864 V 84.35028 Q 883.8971,84.1159 883.8795,83.987 Q 883.8619,83.85223 883.7916,83.77606 Q 883.7213,83.69989 883.399,83.69989 Q 883.0767,83.69403 882.3033,83.85809 L 882.1334,83.38348 Q 882.3853,83.33075 882.7838,83.2077 Q 883.1881,83.07879 883.6275,82.92645 Q 884.067,82.77411 884.4478,82.62762 Q 884.8287,82.48114 885.0455,82.38739 L 885.3033,82.63348 V 88.66864 Q 885.3033,88.77997 885.5904,88.93231 Q 885.8834,89.08465 886.7682,89.19598 V 89.68231 Z"
+       id="path3954"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 892.0956,89.68231 H 887.414 L 887.2441,89.24872 Q 888.2753,88.04169 888.9316,87.22723 Q 889.5937,86.41278 889.9628,85.87372 Q 890.332,85.32879 890.4784,84.95965 Q 890.6308,84.58465 890.6308,84.26825 Q 890.6308,83.7702 890.414,83.43622 Q 890.2031,83.10223 889.7167,83.10223 Q 889.33,83.10223 889.1191,83.35419 Q 888.914,83.60614 888.8788,83.94598 Q 888.8554,84.12176 888.8847,84.29754 Q 888.7558,84.36786 888.5214,84.44989 Q 888.287,84.53192 888.0351,84.59637 Q 887.7831,84.65497 887.6073,84.67254 L 887.4023,84.27411 Q 887.4023,83.97528 887.6191,83.65301 Q 887.8359,83.33075 888.2109,83.06122 Q 888.5859,82.78583 889.0722,82.6159 Q 889.5644,82.44598 890.1152,82.44598 Q 891.0175,82.44598 891.5624,82.82098 Q 892.1073,83.19598 892.1073,83.9284 Q 892.1073,84.32098 891.9374,84.73114 Q 891.7675,85.13544 891.3808,85.65692 Q 890.9941,86.17254 890.3554,86.90497 Q 889.7167,87.63153 888.7792,88.66278 H 891.1171 Q 891.3105,88.66278 891.4335,88.47528 Q 891.5624,88.28778 891.6327,88.01825 Q 891.7031,87.74286 891.7148,87.4909 L 892.1835,87.60223 Z"
+       id="path3956"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 174.5232,84.25127 V 76.62236 H 178.7244 V 77.63017 H 175.4607 V 84.25127 Z"
+       id="path1286"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 237.5458,77.63017 V 76.62236 H 245.0048 V 77.63017 Z"
+       id="path1291"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 241.9403,96.4403 Q 241.1435,96.4403 240.4638,96.14147 Q 239.7899,95.83678 239.2919,95.30358 Q 238.7997,94.77037 238.5243,94.07311 Q 238.2489,93.36998 238.2489,92.56725 Q 238.2489,91.76451 238.5243,91.06725 Q 238.7997,90.36998 239.2919,89.83678 Q 239.7899,89.30358 240.4638,89.00475 Q 241.1435,88.70592 241.9403,88.70592 Q 242.7431,88.70592 243.4169,89.00475 Q 244.0907,89.30358 244.5888,89.83678 Q 245.0868,90.36998 245.3564,91.06725 Q 245.6317,91.76451 245.6317,92.56725 Q 245.6317,93.36998 245.3564,94.07311 Q 245.0868,94.77037 244.5888,95.30358 Q 244.0907,95.83678 243.4169,96.14147 Q 242.7431,96.4403 241.9403,96.4403 Z M 241.9403,95.93639 Q 242.872,95.93639 243.5868,95.48522 Q 244.3075,95.02819 244.7177,94.26647 Q 245.1278,93.49889 245.1278,92.56725 Q 245.1278,91.64147 244.7177,90.87975 Q 244.3075,90.11803 243.5868,89.66686 Q 242.872,89.20983 241.9403,89.20983 Q 241.0204,89.20983 240.2997,89.66686 Q 239.579,90.11803 239.163,90.87975 Q 238.7528,91.64147 238.7528,92.56725 Q 238.7528,93.49889 239.163,94.26647 Q 239.579,95.02819 240.2997,95.48522 Q 241.0204,95.93639 241.9403,95.93639 Z M 240.7685,92.01647 Q 240.5399,92.01647 240.3759,91.85826 Q 240.2177,91.6942 240.2177,91.46569 Q 240.2177,91.23717 240.3759,91.07897 Q 240.5399,90.9149 240.7685,90.9149 Q 240.997,90.9149 241.1552,91.07897 Q 241.3192,91.23717 241.3192,91.46569 Q 241.3192,91.6942 241.1552,91.85826 Q 240.997,92.01647 240.7685,92.01647 Z M 243.1122,92.01647 Q 242.8837,92.01647 242.7196,91.85826 Q 242.5614,91.6942 242.5614,91.46569 Q 242.5614,91.23717 242.7196,91.07897 Q 242.8837,90.9149 243.1122,90.9149 Q 243.3407,90.9149 243.4989,91.07897 Q 243.663,91.23717 243.663,91.46569 Q 243.663,91.6942 243.4989,91.85826 Q 243.3407,92.01647 243.1122,92.01647 Z M 243.9911,93.14147 Q 243.8857,93.57506 243.6103,93.96178 Q 243.3407,94.3485 242.9189,94.59459 Q 242.5028,94.83483 241.9403,94.83483 Q 241.3837,94.83483 240.9618,94.59459 Q 240.5399,94.3485 240.2704,93.96178 Q 240.0009,93.57506 239.8896,93.14147 L 240.3876,93.02428 Q 240.5048,93.55748 240.9208,93.9442 Q 241.3368,94.33092 241.9403,94.33092 Q 242.5439,94.33092 242.9599,93.9442 Q 243.3759,93.55748 243.4931,93.02428 Z"
+       id="path1293"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 306.3863,84.25127 V 77.63017 H 303.1285 V 76.62236 H 307.3238 V 84.25127 Z"
+       id="path1296"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 307.523,96.4403 Q 306.7262,96.4403 306.0465,96.14147 Q 305.3727,95.83678 304.8746,95.30358 Q 304.3824,94.77037 304.107,94.07311 Q 303.8316,93.36998 303.8316,92.56725 Q 303.8316,91.76451 304.107,91.06725 Q 304.3824,90.36998 304.8746,89.83678 Q 305.3727,89.30358 306.0465,89.00475 Q 306.7262,88.70592 307.523,88.70592 Q 308.3258,88.70592 308.9996,89.00475 Q 309.6734,89.30358 310.1715,89.83678 Q 310.6695,90.36998 310.9391,91.06725 Q 311.2144,91.76451 311.2144,92.56725 Q 311.2144,93.36998 310.9391,94.07311 Q 310.6695,94.77037 310.1715,95.30358 Q 309.6734,95.83678 308.9996,96.14147 Q 308.3258,96.4403 307.523,96.4403 Z M 307.523,95.93639 Q 308.4547,95.93639 309.1695,95.48522 Q 309.8902,95.02819 310.3004,94.26647 Q 310.7105,93.49889 310.7105,92.56725 Q 310.7105,91.64147 310.3004,90.87975 Q 309.8902,90.11803 309.1695,89.66686 Q 308.4547,89.20983 307.523,89.20983 Q 306.6031,89.20983 305.8824,89.66686 Q 305.1617,90.11803 304.7457,90.87975 Q 304.3355,91.64147 304.3355,92.56725 Q 304.3355,93.49889 304.7457,94.26647 Q 305.1617,95.02819 305.8824,95.48522 Q 306.6031,95.93639 307.523,95.93639 Z M 306.3512,92.01647 Q 306.1227,92.01647 305.9586,91.85826 Q 305.8004,91.6942 305.8004,91.46569 Q 305.8004,91.23717 305.9586,91.07897 Q 306.1227,90.9149 306.3512,90.9149 Q 306.5797,90.9149 306.7379,91.07897 Q 306.9019,91.23717 306.9019,91.46569 Q 306.9019,91.6942 306.7379,91.85826 Q 306.5797,92.01647 306.3512,92.01647 Z M 308.6949,92.01647 Q 308.4664,92.01647 308.3023,91.85826 Q 308.1441,91.6942 308.1441,91.46569 Q 308.1441,91.23717 308.3023,91.07897 Q 308.4664,90.9149 308.6949,90.9149 Q 308.9234,90.9149 309.0816,91.07897 Q 309.2457,91.23717 309.2457,91.46569 Q 309.2457,91.6942 309.0816,91.85826 Q 308.9234,92.01647 308.6949,92.01647 Z M 305.4723,94.36608 Q 305.5836,93.93248 305.8531,93.54576 Q 306.1227,93.15905 306.5445,92.91881 Q 306.9664,92.67272 307.523,92.67272 Q 308.0855,92.67272 308.5016,92.91881 Q 308.9234,93.15905 309.193,93.54576 Q 309.4684,93.93248 309.5738,94.36608 L 309.0758,94.48326 Q 308.9586,93.9442 308.5426,93.56334 Q 308.1266,93.17662 307.523,93.17662 Q 306.9195,93.17662 306.5035,93.56334 Q 306.0875,93.9442 305.9703,94.48326 Z"
+       id="path1298"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 389.2913,90.87822 V 76.62236 H 390.2288 V 90.87822 Z"
+       id="path1301"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 375.8019,90.77333 Q 376.5929,91.10735 377.0734,91.38864 Q 377.5597,91.66992 377.8116,91.94535 Q 378.0636,92.21491 378.1515,92.50789 Q 378.2452,92.80093 378.2452,93.16427 Q 378.2452,93.55692 378.046,93.97297 Q 377.8526,94.38903 377.4894,94.74647 Q 377.1319,95.10392 376.6339,95.32664 Q 376.1417,95.54927 375.5499,95.54927 Q 375.3507,95.54927 374.9991,95.49657 Q 374.6476,95.44386 374.2726,95.32074 Q 373.8976,95.19183 373.6222,94.975 Q 373.5812,94.9516 373.5636,94.75237 Q 373.546,94.55315 373.5519,94.27771 Q 373.5577,93.99638 373.5812,93.72684 Q 373.6046,93.45731 373.6515,93.29899 L 374.1085,93.32829 Q 374.3136,93.99058 374.753,94.35382 Q 375.1925,94.71137 375.7023,94.71137 Q 375.9952,94.71137 376.2648,94.57065 Q 376.5343,94.42413 376.7042,94.1722 Q 376.88,93.91437 376.88,93.59203 Q 376.88,93.21698 376.6339,92.93574 Q 376.3878,92.64861 375.7843,92.33798 Q 375.1808,92.02153 374.1026,91.5703 L 373.9855,91.31246 Q 374.1847,91.10149 374.4776,90.83193 Q 374.7765,90.5565 375.087,90.27522 Q 375.4034,89.98807 375.6671,89.74195 Q 375.9366,89.48996 376.0948,89.32588 Q 376.253,89.15594 376.2237,89.12077 Q 376.13,89.00358 375.8839,88.88051 Q 375.6378,88.75745 375.3214,88.67541 Q 375.005,88.58751 374.712,88.58751 Q 374.4073,88.58751 374.0616,88.68713 Q 373.7159,88.78089 373.4054,89.04459 Q 373.0948,89.30244 372.9015,89.79469 Q 372.7081,90.28108 372.7081,91.0722 V 94.58825 Q 372.7081,94.65856 372.8312,94.76407 Q 372.9542,94.86369 373.3819,94.9457 V 95.37355 H 370.3937 V 94.9457 Q 370.7862,94.86369 371.0148,94.76407 Q 371.2433,94.66446 371.2433,94.58825 V 91.47068 Q 371.2433,90.53306 371.6007,89.84743 Q 371.964,89.15594 372.5558,88.70471 Q 373.1534,88.25348 373.8741,88.03666 Q 374.6007,87.81397 375.3214,87.81397 Q 376.1534,87.81397 376.8214,88.0308 Q 377.4952,88.24762 377.8878,88.57578 Q 377.9347,88.61681 377.7941,88.78675 Q 377.6593,88.95669 377.4073,89.20867 Q 377.1554,89.46067 376.8566,89.74781 Q 376.5577,90.0291 376.2765,90.29866 Q 375.9952,90.56823 375.8019,90.77333 Z"
+       id="path1303"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00006" />
+    <path
+       d="M 451.2652,84.25713 V 76.62236 H 452.2027 V 83.24931 H 455.4664 V 84.25713 Z"
+       id="path1306"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 439.978,96.68032 L 434.2615,90.96379 L 439.978,85.24725 L 445.7071,90.96379 Z M 439.5661,92.62383 H 440.1777 L 440.3774,91.71268 Q 441.376,91.30079 441.8627,90.80153 Q 442.362,90.30226 442.362,89.50345 Q 442.362,88.9293 442.0375,88.51741 Q 441.7254,88.10552 441.1763,87.89333 Q 440.6271,87.66866 439.9156,87.66866 Q 438.8173,87.66866 438.3055,88.00567 Q 437.7938,88.34267 437.7938,88.82945 Q 437.7938,89.17893 438.1932,89.35367 Q 438.5926,89.52841 439.2042,89.52841 Q 439.2042,89.01667 439.3789,88.64222 Q 439.5537,88.26778 440.003,88.26778 Q 440.4149,88.26778 440.5896,88.56733 Q 440.7769,88.86689 440.7769,89.35367 Q 440.7769,89.7406 440.652,90.12752 Q 440.5397,90.51445 440.2401,90.83897 Q 439.9406,91.16349 439.3664,91.40064 Z M 439.8532,94.98283 Q 440.1902,94.98283 440.4274,94.80809 Q 440.677,94.63335 440.677,94.18402 Q 440.677,93.7222 440.4274,93.55994 Q 440.1902,93.3852 439.8532,93.3852 Q 439.5162,93.3852 439.2791,93.55994 Q 439.0419,93.7222 439.0419,94.18402 Q 439.0419,94.63335 439.2791,94.80809 Q 439.5162,94.98283 439.8532,94.98283 Z"
+       id="path2256"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:1.25;font-family:'Noto Serif';-inkscape-font-specification:'Noto Serif';word-spacing:0px;stroke-width:1.04013" />
+    <path
+       d="M 499.8497,84.25713 V 83.24931 H 503.1075 V 76.62236 H 504.045 V 84.25713 Z"
+       id="path1311"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 502.6563,95.67982 Q 502.6563,96.15442 502.3399,96.41812 Q 502.0235,96.68172 501.5841,96.68172 Q 501.2384,96.68172 500.9864,96.49422 Q 500.7345,96.30672 500.7345,95.89072 Q 500.7345,95.43372 501.0567,95.16422 Q 501.3849,94.88882 501.8126,94.88882 Q 502.1349,94.88882 502.3927,95.08212 Q 502.6563,95.26962 502.6563,95.67982 Z M 505.8556,95.67982 Q 505.8556,96.15442 505.5392,96.41812 Q 505.2286,96.68172 504.7833,96.68172 Q 504.4376,96.68172 504.1856,96.49422 Q 503.9337,96.30672 503.9337,95.89072 Q 503.9337,95.43372 504.256,95.16422 Q 504.5841,94.88882 505.0118,94.88882 Q 505.3341,94.88882 505.5919,95.08212 Q 505.8556,95.26962 505.8556,95.67982 Z"
+       id="path1313"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 573.5433,90.87822 V 76.62236 H 574.4808 V 83.24931 H 577.7445 V 84.25713 H 574.4808 V 90.87822 Z"
+       id="path1316"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 565.382,93.16857 Q 565.3293,93.23888 565.1066,93.35021 Q 564.8898,93.45568 564.6086,93.56115 Q 564.3273,93.66076 564.0813,93.73107 Q 563.841,93.79552 563.7355,93.7838 Q 563.1496,93.35607 563.1496,92.60021 Q 563.1496,92.16661 563.343,91.73302 Q 563.5422,91.29357 563.8586,90.91857 Q 564.1809,90.54357 564.5617,90.30333 L 564.9426,90.5963 Q 564.7316,90.87169 564.591,91.24083 Q 564.4504,91.60411 564.4504,91.98497 Q 564.4504,92.30724 564.6672,92.51232 Q 564.884,92.7174 565.2883,92.72911 Z"
+       id="path1318"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 638.6909,90.87822 V 84.25713 H 635.4331 V 83.24931 H 638.6909 V 76.62236 H 639.6284 V 90.87822 Z"
+       id="path1321"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 631.5178,90.94786 Q 631.5178,91.38146 631.3245,91.82091 Q 631.1311,92.26036 630.8088,92.63536 Q 630.4866,93.01036 630.1116,93.2506 L 629.7249,92.95763 Q 629.9416,92.68224 630.0764,92.3131 Q 630.217,91.94396 630.217,91.56896 Q 630.217,91.24669 630.0002,91.04161 Q 629.7834,90.83068 629.385,90.81896 L 629.2913,90.37951 Q 629.344,90.30919 629.5608,90.20372 Q 629.7834,90.09826 630.0588,89.99279 Q 630.3401,89.88732 630.5862,89.82286 Q 630.8323,89.75841 630.9377,89.76427 Q 631.5178,90.20372 631.5178,90.94786 Z"
+       id="path1323"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 704.9197,84.25713 V 90.87822 H 703.9822 V 84.25713 H 700.7244 V 83.24931 H 703.9822 V 76.62236 H 704.9197 V 83.24931 H 708.1834 V 84.25713 Z"
+       id="path1326"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 696.309,89.57718 Q 696.3324,89.62406 696.3324,89.68851 Q 696.3324,89.79984 696.2562,89.88773 Q 696.1859,89.96976 696.0687,89.96976 Q 695.9574,89.96976 695.8637,89.89359 Q 695.7758,89.81156 695.7758,89.68851 Q 695.7758,89.58304 695.8578,89.49515 Q 695.9457,89.40726 696.0629,89.40726 Q 696.2387,89.40726 696.309,89.57718 Z M 698.1547,94.02444 Q 698.1781,94.09474 698.1781,94.12994 Q 698.1781,94.23534 698.0961,94.32324 Q 698.014,94.41114 697.8969,94.41114 Q 697.7914,94.41114 697.7035,94.32914 Q 697.6156,94.24714 697.6156,94.12404 Q 697.6156,94.02444 697.6918,93.93654 Q 697.768,93.84864 697.8793,93.84864 Q 698.0668,93.84864 698.1547,94.02444 Z M 695.4652,90.01078 Q 695.5531,90.08695 695.5531,90.20414 Q 695.5531,90.48539 695.2777,90.48539 Q 695.1605,90.48539 695.0785,90.40921 Q 694.9965,90.32718 694.9965,90.21585 Q 694.9965,90.09867 695.0785,90.01664 Q 695.1605,89.92874 695.2719,89.92874 Q 695.3832,89.92874 695.4652,90.01078 Z M 698.8754,93.40924 Q 698.9574,93.49124 698.9574,93.60844 Q 698.9574,93.71974 698.8754,93.80184 Q 698.7992,93.88384 698.6762,93.88384 Q 698.559,93.88384 698.4769,93.80184 Q 698.3949,93.71974 698.3949,93.60844 Q 698.3949,93.49124 698.4711,93.41504 Q 698.5531,93.33304 698.6644,93.33304 Q 698.7816,93.33304 698.8754,93.40924 Z M 694.8558,90.73148 Q 695.0375,90.80765 695.0375,91.00101 Q 695.0375,91.11234 694.9437,91.19437 Q 694.8558,91.27054 694.7504,91.27054 Q 694.6273,91.27054 694.5512,91.18265 Q 694.475,91.09476 694.475,90.98929 Q 694.475,90.8721 694.557,90.79007 Q 694.6449,90.70804 694.7504,90.70804 Q 694.7855,90.70804 694.8558,90.73148 Z M 699.3031,92.57134 Q 699.4789,92.64754 699.4789,92.82914 Q 699.4789,92.94634 699.391,93.02834 Q 699.309,93.10454 699.1976,93.10454 Q 699.0687,93.10454 698.9926,93.02254 Q 698.9164,92.93464 698.9164,92.82914 Q 698.9164,92.69434 699.0043,92.62404 Q 699.098,92.55374 699.2035,92.55374 Q 699.2621,92.55374 699.3031,92.57134 Z M 694.5687,91.63382 Q 694.6801,91.63382 694.768,91.71584 Q 694.8558,91.79204 694.8558,91.90334 Q 694.8558,92.02054 694.768,92.10844 Q 694.6801,92.19044 694.5746,92.19044 H 694.5629 Q 694.4515,92.19044 694.3695,92.10844 Q 694.2933,92.02054 694.2933,91.90924 Q 694.2933,91.79204 694.3695,91.71584 Q 694.4515,91.63382 694.5687,91.63382 Z M 699.3793,91.62796 Q 699.4965,91.62796 699.5785,91.71004 Q 699.6605,91.79204 699.6605,91.90924 Q 699.6605,92.02054 699.5785,92.10254 Q 699.5023,92.18464 699.3851,92.18464 H 699.3617 Q 699.2562,92.18464 699.1742,92.10254 Q 699.098,92.02054 699.098,91.91504 Q 699.098,91.79784 699.1859,91.71584 Q 699.2738,91.63382 699.3793,91.62796 Z M 694.6449,92.57714 Q 694.6918,92.55374 694.7562,92.55374 Q 694.8734,92.55374 694.9555,92.62994 Q 695.0375,92.70604 695.0375,92.82324 Q 695.0375,92.93464 694.9555,93.02254 Q 694.8734,93.11034 694.7562,93.11034 Q 694.6449,93.11034 694.557,93.02834 Q 694.475,92.94044 694.475,92.82324 Q 694.475,92.64164 694.6449,92.57714 Z M 699.0922,90.73148 Q 699.1625,90.70804 699.1976,90.70804 Q 699.3031,90.70804 699.391,90.79007 Q 699.4789,90.8721 699.4789,90.98929 Q 699.4789,91.09476 699.3969,91.18265 Q 699.3148,91.27054 699.1918,91.27054 Q 699.0863,91.27054 699.0043,91.18851 Q 698.9222,91.10648 698.9222,90.99515 Q 698.9222,90.80765 699.0922,90.73148 Z M 695.0785,93.42094 Q 695.1664,93.33304 695.266,93.33304 Q 695.389,93.33304 695.4711,93.41504 Q 695.5531,93.49124 695.5531,93.60844 Q 695.5531,93.71974 695.4711,93.80764 Q 695.3949,93.88964 695.2777,93.88964 Q 695.1664,93.88964 695.0785,93.80764 Q 694.9965,93.71974 694.9965,93.60844 Q 694.9965,93.50294 695.0785,93.42094 Z M 698.4769,90.01078 Q 698.5707,89.92874 698.6762,89.92874 Q 698.7933,89.92874 698.8695,90.01078 Q 698.9515,90.09281 698.9515,90.20999 Q 698.9515,90.32132 698.8695,90.40921 Q 698.7933,90.49124 698.6762,90.49124 Q 698.5648,90.49124 698.4828,90.40335 Q 698.4008,90.31546 698.4008,90.20999 Q 698.4008,90.09867 698.4769,90.01078 Z M 695.7992,94.03034 Q 695.8344,93.94824 695.9105,93.90144 Q 695.9926,93.85454 696.0629,93.85454 Q 696.1801,93.85454 696.2562,93.94244 Q 696.3383,94.03034 696.3383,94.13574 Q 696.3383,94.25294 696.2504,94.33504 Q 696.1625,94.41114 696.057,94.41114 Q 695.9457,94.41114 695.8578,94.32324 Q 695.7758,94.23534 695.7758,94.13574 Q 695.7758,94.10064 695.7992,94.03034 Z M 697.639,89.58304 Q 697.7152,89.40726 697.8969,89.40726 Q 698.014,89.40726 698.0961,89.49515 Q 698.1781,89.58304 698.1781,89.69437 Q 698.1781,89.81156 698.0902,89.89359 Q 698.0023,89.96976 697.8969,89.96976 Q 697.7797,89.96976 697.6976,89.88187 Q 697.6215,89.78812 697.6215,89.68265 Q 697.6215,89.63578 697.639,89.58304 Z M 696.7015,94.31744 Q 696.7015,94.20024 696.7836,94.11824 Q 696.8656,94.03614 696.9769,94.03614 Q 697.0941,94.03614 697.1762,94.11824 Q 697.2582,94.20024 697.2582,94.31744 Q 697.2582,94.42874 697.1762,94.51074 Q 697.0941,94.59284 696.9769,94.59284 Q 696.8656,94.59284 696.7836,94.51074 Q 696.7015,94.42874 696.7015,94.31744 Z M 696.7015,89.50687 Q 696.7015,89.38968 696.7836,89.30765 Q 696.8656,89.22562 696.9769,89.22562 Q 697.0941,89.22562 697.1762,89.30765 Q 697.2582,89.38968 697.2582,89.50687 Q 697.2582,89.6182 697.1762,89.70023 Q 697.0941,89.78226 696.9769,89.78226 Q 696.8656,89.78226 696.7836,89.70023 Q 696.7015,89.6182 696.7015,89.50687 Z"
+       id="path1328"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 700.4457,95.91114 Q 700.4222,95.99324 700.3519,96.15144 Q 700.2875,96.30964 700.2172,96.46194 Q 700.1469,96.61434 700.1176,96.67874 H 693.725 L 693.5433,96.49714 Q 693.5609,96.40924 693.6254,96.25684 Q 693.6898,96.10454 693.7601,95.95214 Q 693.8305,95.79984 693.8715,95.72364 H 700.2582 Z"
+       id="path1330"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 772.3917,84.25127 V 77.63017 H 769.1339 V 76.62236 H 776.5929 V 77.63017 H 773.3292 V 84.25127 Z"
+       id="path1333"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 767.0693,91.66653 Q 767.0927,91.7134 767.0927,91.77786 Q 767.0927,91.88919 767.0165,91.97708 Q 766.9462,92.05911 766.829,92.05911 Q 766.7177,92.05911 766.6239,91.98294 Q 766.5361,91.9009 766.5361,91.77786 Q 766.5361,91.67239 766.6181,91.5845 Q 766.706,91.49661 766.8232,91.49661 Q 766.9989,91.49661 767.0693,91.66653 Z M 768.915,96.11379 Q 768.9384,96.18411 768.9384,96.21926 Q 768.9384,96.32473 768.8564,96.41262 Q 768.7743,96.50051 768.6572,96.50051 Q 768.5517,96.50051 768.4638,96.41848 Q 768.3759,96.33645 768.3759,96.2134 Q 768.3759,96.11379 768.4521,96.0259 Q 768.5282,95.93801 768.6396,95.93801 Q 768.8271,95.93801 768.915,96.11379 Z M 766.2255,92.10012 Q 766.3134,92.17629 766.3134,92.29348 Q 766.3134,92.57473 766.038,92.57473 Q 765.9208,92.57473 765.8388,92.49856 Q 765.7568,92.41653 765.7568,92.3052 Q 765.7568,92.18801 765.8388,92.10598 Q 765.9208,92.01809 766.0322,92.01809 Q 766.1435,92.01809 766.2255,92.10012 Z M 769.6357,95.49856 Q 769.7177,95.58059 769.7177,95.69778 Q 769.7177,95.80911 769.6357,95.89114 Q 769.5595,95.97317 769.4364,95.97317 Q 769.3193,95.97317 769.2372,95.89114 Q 769.1552,95.80911 769.1552,95.69778 Q 769.1552,95.58059 769.2314,95.50442 Q 769.3134,95.42239 769.4247,95.42239 Q 769.5419,95.42239 769.6357,95.49856 Z M 765.6161,92.82083 Q 765.7978,92.897 765.7978,93.09036 Q 765.7978,93.20169 765.704,93.28372 Q 765.6161,93.35989 765.5107,93.35989 Q 765.3876,93.35989 765.3114,93.272 Q 765.2353,93.18411 765.2353,93.07864 Q 765.2353,92.96145 765.3173,92.87942 Q 765.4052,92.79739 765.5107,92.79739 Q 765.5458,92.79739 765.6161,92.82083 Z M 770.0634,94.66067 Q 770.2392,94.73684 770.2392,94.91848 Q 770.2392,95.03567 770.1513,95.1177 Q 770.0693,95.19387 769.9579,95.19387 Q 769.829,95.19387 769.7529,95.11184 Q 769.6767,95.02395 769.6767,94.91848 Q 769.6767,94.78372 769.7646,94.7134 Q 769.8583,94.64309 769.9638,94.64309 Q 770.0224,94.64309 770.0634,94.66067 Z M 765.329,93.72317 Q 765.4404,93.72317 765.5282,93.8052 Q 765.6161,93.88137 765.6161,93.9927 Q 765.6161,94.10989 765.5282,94.19778 Q 765.4404,94.27981 765.3349,94.27981 H 765.3232 Q 765.2118,94.27981 765.1298,94.19778 Q 765.0536,94.10989 765.0536,93.99856 Q 765.0536,93.88137 765.1298,93.8052 Q 765.2118,93.72317 765.329,93.72317 Z M 770.1396,93.71731 Q 770.2568,93.71731 770.3388,93.79934 Q 770.4208,93.88137 770.4208,93.99856 Q 770.4208,94.10989 770.3388,94.19192 Q 770.2626,94.27395 770.1454,94.27395 H 770.122 Q 770.0165,94.27395 769.9345,94.19192 Q 769.8583,94.10989 769.8583,94.00442 Q 769.8583,93.88723 769.9462,93.8052 Q 770.0341,93.72317 770.1396,93.71731 Z M 765.4052,94.66653 Q 765.4521,94.64309 765.5165,94.64309 Q 765.6337,94.64309 765.7157,94.71926 Q 765.7978,94.79544 765.7978,94.91262 Q 765.7978,95.02395 765.7157,95.11184 Q 765.6337,95.19973 765.5165,95.19973 Q 765.4052,95.19973 765.3173,95.1177 Q 765.2353,95.02981 765.2353,94.91262 Q 765.2353,94.73098 765.4052,94.66653 Z M 769.8525,92.82083 Q 769.9228,92.79739 769.9579,92.79739 Q 770.0634,92.79739 770.1513,92.87942 Q 770.2392,92.96145 770.2392,93.07864 Q 770.2392,93.18411 770.1572,93.272 Q 770.0751,93.35989 769.9521,93.35989 Q 769.8466,93.35989 769.7646,93.27786 Q 769.6825,93.19583 769.6825,93.0845 Q 769.6825,92.897 769.8525,92.82083 Z M 765.8388,95.51028 Q 765.9267,95.42239 766.0263,95.42239 Q 766.1493,95.42239 766.2314,95.50442 Q 766.3134,95.58059 766.3134,95.69778 Q 766.3134,95.80911 766.2314,95.897 Q 766.1552,95.97903 766.038,95.97903 Q 765.9267,95.97903 765.8388,95.897 Q 765.7568,95.80911 765.7568,95.69778 Q 765.7568,95.59231 765.8388,95.51028 Z M 769.2372,92.10012 Q 769.331,92.01809 769.4364,92.01809 Q 769.5536,92.01809 769.6298,92.10012 Q 769.7118,92.18215 769.7118,92.29934 Q 769.7118,92.41067 769.6298,92.49856 Q 769.5536,92.58059 769.4364,92.58059 Q 769.3251,92.58059 769.2431,92.4927 Q 769.1611,92.40481 769.1611,92.29934 Q 769.1611,92.18801 769.2372,92.10012 Z M 766.5595,96.11965 Q 766.5947,96.03762 766.6708,95.99075 Q 766.7529,95.94387 766.8232,95.94387 Q 766.9404,95.94387 767.0165,96.03176 Q 767.0986,96.11965 767.0986,96.22512 Q 767.0986,96.34231 767.0107,96.42434 Q 766.9228,96.50051 766.8173,96.50051 Q 766.706,96.50051 766.6181,96.41262 Q 766.5361,96.32473 766.5361,96.22512 Q 766.5361,96.18997 766.5595,96.11965 Z M 768.3993,91.67239 Q 768.4755,91.49661 768.6572,91.49661 Q 768.7743,91.49661 768.8564,91.5845 Q 768.9384,91.67239 768.9384,91.78372 Q 768.9384,91.9009 768.8505,91.98294 Q 768.7626,92.05911 768.6572,92.05911 Q 768.54,92.05911 768.4579,91.97122 Q 768.3818,91.87747 768.3818,91.772 Q 768.3818,91.72512 768.3993,91.67239 Z M 767.4618,96.40676 Q 767.4618,96.28958 767.5439,96.20754 Q 767.6259,96.12551 767.7372,96.12551 Q 767.8544,96.12551 767.9364,96.20754 Q 768.0185,96.28958 768.0185,96.40676 Q 768.0185,96.51809 767.9364,96.60012 Q 767.8544,96.68215 767.7372,96.68215 Q 767.6259,96.68215 767.5439,96.60012 Q 767.4618,96.51809 767.4618,96.40676 Z M 767.4618,91.59622 Q 767.4618,91.47903 767.5439,91.397 Q 767.6259,91.31497 767.7372,91.31497 Q 767.8544,91.31497 767.9364,91.397 Q 768.0185,91.47903 768.0185,91.59622 Q 768.0185,91.70754 767.9364,91.78958 Q 767.8544,91.87161 767.7372,91.87161 Q 767.6259,91.87161 767.5439,91.78958 Q 767.4618,91.70754 767.4618,91.59622 Z"
+       id="path1335"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 771.206,89.12356 Q 771.1825,89.20559 771.1122,89.36379 Q 771.0478,89.522 770.9775,89.67434 Q 770.9072,89.82669 770.8779,89.89114 H 764.4853 L 764.3036,89.7095 Q 764.3212,89.62161 764.3857,89.46926 Q 764.4501,89.31692 764.5204,89.16458 Q 764.5907,89.01223 764.6318,88.93606 H 771.0185 Z"
+       id="path1337"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 831.4961,84.25713 V 83.24931 H 834.7539 V 76.62236 H 835.6914 V 83.24931 H 838.9551 V 84.25713 Z"
+       id="path1340"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 834.4283,93.54964 L 829.6063,96.37794 V 90.70866 Z"
+       id="path1342"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:2.12657" />
+    <path
+       d="M 898.5827,86.07118 V 76.62236 H 904.8547 V 86.07118 Z"
+       id="path1345"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:0.662802" />
+    <path
+       d="M 174.0007,91.39653 Q 174.0007,91.64625 174.1729,91.82708 Q 174.3495,92.00362 174.6035,92.00362 Q 174.8533,92.00362 175.0298,91.82708 Q 175.2062,91.65055 175.2062,91.39653 Q 175.2062,91.14249 175.0298,90.97027 Q 174.8533,90.79373 174.6035,90.79373 Q 174.3495,90.79373 174.1729,90.97027 Q 174.0007,91.14249 174.0007,91.39653 Z M 176.4894,91.39653 Q 176.4894,91.64625 176.6616,91.82708 Q 176.8382,92.00362 177.0922,92.00362 Q 177.3419,92.00362 177.5184,91.82708 Q 177.6992,91.64625 177.6992,91.39653 Q 177.6992,91.14249 177.5184,90.97027 Q 177.3419,90.79373 177.0922,90.79373 Q 176.8425,90.79373 176.6659,90.97027 Q 176.4894,91.14249 176.4894,91.39653 Z M 171.9685,92.58057 Q 171.9685,90.97457 173.1009,89.84219 Q 174.2332,88.70551 175.8349,88.70551 Q 177.4409,88.70551 178.569,89.84219 Q 179.6971,90.97457 179.6971,92.58057 Q 179.6971,94.18226 178.569,95.31035 Q 177.4409,96.43842 175.8349,96.43842 Q 174.2332,96.43842 173.1009,95.31035 Q 171.9685,94.18226 171.9685,92.58057 Z M 173.5659,93.79046 Q 173.7209,94.03155 173.9405,94.25111 Q 174.7241,95.03047 175.8349,95.03047 Q 176.9458,95.03047 177.7294,94.25111 Q 177.9447,94.03155 178.104,93.79046 L 177.6089,93.48043 Q 177.484,93.66987 177.316,93.83778 Q 176.7047,94.44922 175.8349,94.44922 Q 174.9652,94.44922 174.3539,93.83778 Q 174.1816,93.66987 174.061,93.48477 Z"
+       id="path1380"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:0.734826" />
+    <path
+       d="M 1048.194,81.37237 L 1050.871,76.76819 L 1050.631,76.62235 L 1047.787,81.37237 L 1050.631,86.12238 L 1050.871,85.96613 Z M 1049.694,81.37237 L 1052.371,76.76819 L 1052.131,76.62235 L 1049.287,81.37237 L 1052.131,86.12238 L 1052.371,85.96613 Z"
+       id="path1637"
+       style="font-size:10.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg';word-spacing:0px" />
+    <path
+       d="M 1049.142,91.92768 L 1052.371,87.49017 L 1051.944,87.17767 L 1048.382,91.92768 L 1051.944,96.6777 L 1052.371,96.35478 Z"
+       id="path1640"
+       style="font-size:10.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg';word-spacing:0px" />
+    <path
+       d="M 1117.951,81.37237 L 1115.108,76.62235 L 1114.858,76.76819 L 1117.545,81.37237 L 1114.858,85.96613 L 1115.108,86.12238 Z M 1116.451,81.37237 L 1113.608,76.62235 L 1113.358,76.76819 L 1116.045,81.37237 L 1113.358,85.96613 L 1113.608,86.12238 Z"
+       id="path1643"
+       style="font-size:10.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg';word-spacing:0px" />
+    <path
+       d="M 1117.951,91.92768 L 1114.399,87.17767 L 1113.962,87.49017 L 1117.191,91.92768 L 1113.962,96.35478 L 1114.399,96.6777 Z"
+       id="path1646"
+       style="font-size:10.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg';word-spacing:0px" />
+    <path
+       d="M 1160.84,95.12561 L 1163.496,96.6777 L 1163.757,96.20894 L 1161.371,94.82352 V 89.04226 L 1163.767,87.636 L 1163.496,87.17767 L 1160.84,88.74017 V 88.74017 V 88.75059 V 95.11519 Z"
+       id="path1649"
+       style="font-size:10.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg';word-spacing:0px" />
+    <path
+       d="M 1171.962,91.92768 Q 1171.962,90.82351 1172.681,89.45892 Q 1173.379,88.0735 1174.972,87.17767 H 1171.42 V 91.92768 V 96.6777 H 1174.972 Q 1173.399,95.77144 1172.681,94.38602 Q 1171.962,93.03185 1171.962,91.92768 Z"
+       id="path1651"
+       style="font-size:10.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg';word-spacing:0px" />
+    <path
+       d="M 1220.292,94.81311 L 1217.896,96.20894 L 1218.167,96.6777 L 1220.833,95.12561 V 88.74017 V 88.74017 L 1218.167,87.17767 L 1217.885,87.636 L 1220.292,89.05267 Z"
+       id="path1654"
+       style="font-size:10.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg';word-spacing:0px" />
+    <path
+       d="M 1232.014,91.92768 V 87.17767 H 1228.462 Q 1230.035,88.06309 1230.743,89.45892 Q 1231.472,90.81309 1231.472,91.92768 Q 1231.472,93.03185 1230.743,94.38602 Q 1230.045,95.77144 1228.462,96.6777 H 1232.014 Z"
+       id="path1656"
+       style="font-size:10.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg';word-spacing:0px" />
+    <path
+       d="M 1285.5,87.71933 V 96.6777 H 1286.042 V 87.71933 H 1289.052 V 87.17767 H 1286.042 H 1285.5 Z"
+       id="path1659"
+       style="font-size:10.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg';word-spacing:0px" />
+    <path
+       d="M 1346.072,96.13603 V 87.17767 H 1345.53 V 96.13603 H 1342.52 V 96.6777 H 1345.53 H 1346.072 Z"
+       id="path1662"
+       style="font-size:10.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg';word-spacing:0px" />
+    <path
+       d="M 1342.927,86.1224 H 1345.781 H 1346.072 V 85.83073 V 76.91404 V 76.62237 H 1345.781 H 1344.666 H 1344.375 V 76.91404 V 84.53906 H 1342.927 H 1342.635 V 84.83073 V 85.83073 V 86.1224 Z M 1344.666,84.83073 V 84.53906 V 76.91404 H 1345.781 V 85.83073 H 1342.927 V 84.83073 Z"
+       id="path1665"
+       style="font-size:10.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg';word-spacing:0px" />
+    <path
+       d="M 1288.761,76.62237 H 1285.907 H 1285.615 V 76.91404 V 85.83073 V 86.1224 H 1285.907 H 1287.011 H 1287.303 V 85.83073 V 78.19529 H 1288.761 H 1289.053 V 77.90362 V 76.91404 V 76.62237 Z M 1287.011,77.90362 V 78.19529 V 85.83073 H 1285.907 V 76.91404 H 1288.761 V 77.90362 Z"
+       id="path1668"
+       style="font-size:10.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg';word-spacing:0px" />
+    <path
+       d="M 891.4082,158.8054 Q 891.166,158.946 890.9043,159.0828 Q 890.6426,159.2195 890.4121,159.3054 Q 890.1856,159.3953 890.041,159.3953 Q 889.9278,159.3953 889.8379,159.2703 Q 889.7481,159.1492 889.7481,158.9382 Q 889.7442,158.8562 889.7754,158.6414 Q 889.8106,158.4265 889.8574,158.1453 Q 889.9043,157.864 889.9473,157.5828 Q 889.9942,157.2976 890.0254,157.071 Q 890.0606,156.8406 890.0606,156.7351 Q 890.0606,156.4812 890.0137,156.4031 Q 889.9668,156.321 889.8653,156.321 Q 889.7637,156.321 889.5098,156.4578 Q 889.2559,156.5906 889.0332,156.9617 Q 888.9239,157.1453 888.8496,157.4304 Q 888.7754,157.7117 888.7207,158.0593 Q 888.6543,158.489 888.6426,158.6804 Q 888.6309,158.8679 888.6309,158.989 Q 888.5801,159.0124 888.4551,159.0671 Q 888.334,159.1218 888.1856,159.1882 Q 888.041,159.2546 887.9199,159.3093 Q 887.7989,159.3679 887.752,159.3953 L 887.5918,159.2429 Q 887.6387,158.9656 887.709,158.5359 Q 887.7832,158.1023 887.8653,157.5945 Q 887.9473,157.0828 888.0293,156.5593 Q 888.1114,156.0359 888.1778,155.5632 Q 888.2442,155.0867 888.2832,154.7312 Q 888.3262,154.3757 888.3262,154.2117 Q 888.3262,154.032 888.2754,153.9929 Q 888.2285,153.9499 888.166,153.9499 Q 888.1035,153.9499 887.959,153.9929 Q 887.8184,154.032 887.7442,154.0554 L 887.6817,153.7859 Q 887.9004,153.6882 888.1895,153.5749 Q 888.4785,153.4617 888.7285,153.3796 Q 888.9785,153.2976 889.0762,153.2976 Q 889.1817,153.2976 889.2559,153.3679 Q 889.334,153.4382 889.334,153.6179 Q 889.334,153.7273 889.3028,153.9929 Q 889.2715,154.2546 889.2207,154.5984 Q 889.1739,154.9382 889.1192,155.2937 Q 889.0645,155.6453 889.0176,155.9421 Q 888.9707,156.239 888.9434,156.4109 Q 889.4004,155.9578 889.8028,155.7703 Q 890.2051,155.5789 890.5567,155.5789 Q 890.8028,155.5789 890.9317,155.7039 Q 891.0606,155.8289 891.0606,156.2078 Q 891.0606,156.4109 891.0098,156.7234 Q 890.959,157.032 890.8965,157.3679 Q 890.834,157.7039 890.7832,157.9929 Q 890.7364,158.282 890.7364,158.4421 Q 890.7364,158.5749 890.7715,158.6257 Q 890.8067,158.6726 890.877,158.6726 Q 890.9824,158.6726 891.0762,158.6414 Q 891.1739,158.6062 891.3067,158.5437 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path2785" />
+    <path
+       d="M 893.752,159.0203 L 893.1114,159.7742 L 892.9824,159.6609 Q 892.9278,159.3249 892.8223,158.8718 Q 892.7207,158.4187 892.5996,157.9578 Q 892.4824,157.4968 892.3653,157.1218 Q 892.2481,156.7468 892.1621,156.5593 Q 892.0723,156.3601 892.0098,156.3015 Q 891.9473,156.239 891.8809,156.239 Q 891.8262,156.239 891.709,156.2703 Q 891.5918,156.3015 891.4981,156.3328 L 891.4199,156.071 Q 891.6504,155.9578 891.8965,155.8445 Q 892.1426,155.7312 892.3457,155.657 Q 892.5489,155.5789 892.6387,155.5789 Q 892.7481,155.5789 892.8301,155.6921 Q 892.9121,155.8054 893.0059,156.0749 Q 893.1192,156.4031 893.2559,156.8953 Q 893.3965,157.3874 893.5293,157.9421 Q 893.6621,158.4968 893.752,159.0203 Z M 895.2715,155.8757 Q 895.2715,156.0515 895.0918,156.4812 Q 894.9121,156.907 894.5996,157.532 Q 894.2871,158.1531 893.877,158.9148 Q 893.5176,159.5867 893.1621,160.0984 Q 892.8106,160.6101 892.4239,160.8992 Q 892.041,161.1882 891.584,161.1882 Q 891.3809,161.1882 891.1934,161.1257 Q 891.002,161.0632 890.877,160.9812 Q 890.752,160.8992 890.752,160.8406 Q 890.752,160.7859 890.8145,160.6726 Q 890.877,160.5632 890.9707,160.4382 Q 891.0606,160.3132 891.1504,160.2156 Q 891.2403,160.1179 891.2949,160.0867 Q 891.4785,160.2624 891.666,160.3445 Q 891.8574,160.4304 892.002,160.4304 Q 892.291,160.4304 892.6074,160.0398 Q 892.9278,159.6492 893.3028,158.946 Q 893.5059,158.5632 893.7012,158.1609 Q 893.9004,157.7585 894.0567,157.3992 Q 894.2168,157.0359 894.3106,156.7664 Q 894.4043,156.4968 894.4043,156.3796 Q 894.4043,156.1726 894.1973,156.1726 Q 894.0801,156.1726 893.8731,156.2624 L 893.7715,156.0007 Q 894.0528,155.8406 894.3848,155.7117 Q 894.7207,155.5789 894.9199,155.5789 Q 895.0528,155.5789 895.1621,155.6296 Q 895.2715,155.6804 895.2715,155.8757 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path2787" />
+    <path
+       d="M 893.3816,163.0835 Q 893.3816,163.5405 893.2254,164.0366 Q 893.073,164.5327 892.8582,164.8843 Q 892.741,165.0796 892.5769,165.2671 Q 892.4168,165.4507 892.2215,165.5718 Q 892.0301,165.6929 891.8191,165.6929 Q 891.6043,165.6929 891.323,165.4663 Q 891.0418,165.2397 890.7957,164.8725 L 890.9168,164.353 Q 890.9949,164.4936 891.1433,164.6225 Q 891.2957,164.7475 891.4676,164.8296 Q 891.6394,164.9116 891.7761,164.9116 Q 891.9402,164.9116 892.0691,164.8139 Q 892.2019,164.7163 892.2761,164.56 Q 892.3738,164.353 892.4168,164.0639 Q 892.4597,163.7749 892.4597,163.4819 Q 892.4597,163.0679 892.3386,162.8179 Q 892.2176,162.5639 892.073,162.5639 Q 891.9793,162.5639 891.7996,162.685 Q 891.6238,162.8061 891.4207,163.0405 Q 891.2215,163.2749 891.0535,163.6069 L 891.0261,162.9272 Q 891.3699,162.4858 891.6355,162.2593 Q 891.9011,162.0327 892.116,161.9546 Q 892.3347,161.8764 892.5261,161.8764 Q 892.8738,161.8764 893.1277,162.1889 Q 893.3816,162.4975 893.3816,163.0835 Z M 891.284,162.1343 Q 891.284,162.3022 891.2254,162.6811 Q 891.1707,163.06 891.0535,163.7436 Q 890.9402,164.4272 890.7644,165.5093 Q 890.6355,166.3139 890.6043,166.6694 Q 890.573,167.0249 890.6121,167.1304 Q 890.5535,167.146 890.4246,167.1929 Q 890.2996,167.2397 890.1511,167.2983 Q 890.0027,167.3608 889.8777,167.4116 Q 889.7566,167.4624 889.7058,167.4858 L 889.5496,167.3413 Q 889.5691,167.1929 889.6316,166.8491 Q 889.6902,166.5054 889.7722,166.0483 Q 889.8582,165.5913 889.948,165.0952 Q 890.0379,164.5991 890.1121,164.1382 Q 890.1902,163.6733 890.2371,163.3179 Q 890.2879,162.9624 890.2879,162.7983 Q 890.2879,162.6186 890.2293,162.5796 Q 890.1707,162.5366 890.1043,162.5366 Q 890.0535,162.5366 889.9285,162.5718 Q 889.8035,162.6069 889.741,162.6304 L 889.6707,162.3686 Q 889.9011,162.2593 890.1941,162.146 Q 890.4871,162.0327 890.7332,161.9546 Q 890.9793,161.8764 891.073,161.8764 Q 891.1707,161.8764 891.2254,161.9311 Q 891.284,161.9819 891.284,162.1343 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path2790" />
+    <path
+       d="M 897.7293,165.103 Q 897.4871,165.2436 897.2254,165.3804 Q 896.9636,165.5171 896.7332,165.603 Q 896.5066,165.6929 896.3621,165.6929 Q 896.2488,165.6929 896.159,165.5679 Q 896.0691,165.4468 896.0691,165.2358 Q 896.0652,165.1538 896.0965,164.9389 Q 896.1316,164.7241 896.1785,164.4429 Q 896.2254,164.1616 896.2683,163.8804 Q 896.3152,163.5952 896.3465,163.3686 Q 896.3816,163.1382 896.3816,163.0327 Q 896.3816,162.7788 896.3347,162.7007 Q 896.2879,162.6186 896.1863,162.6186 Q 896.0847,162.6186 895.8308,162.7554 Q 895.5769,162.8882 895.3543,163.2593 Q 895.2449,163.4429 895.1707,163.728 Q 895.0965,164.0093 895.0418,164.3569 Q 894.9754,164.7866 894.9636,164.978 Q 894.9519,165.1655 894.9519,165.2866 Q 894.9011,165.31 894.7761,165.3647 Q 894.6551,165.4194 894.5066,165.4858 Q 894.3621,165.5522 894.241,165.6069 Q 894.1199,165.6655 894.073,165.6929 L 893.9129,165.5405 Q 893.9597,165.2632 894.0301,164.8335 Q 894.1043,164.3999 894.1863,163.8921 Q 894.2683,163.3804 894.3504,162.8569 Q 894.4324,162.3335 894.4988,161.8608 Q 894.5652,161.3843 894.6043,161.0288 Q 894.6472,160.6733 894.6472,160.5093 Q 894.6472,160.3296 894.5965,160.2905 Q 894.5496,160.2475 894.4871,160.2475 Q 894.4246,160.2475 894.2801,160.2905 Q 894.1394,160.3296 894.0652,160.353 L 894.0027,160.0835 Q 894.2215,159.9858 894.5105,159.8725 Q 894.7996,159.7593 895.0496,159.6772 Q 895.2996,159.5952 895.3972,159.5952 Q 895.5027,159.5952 895.5769,159.6655 Q 895.6551,159.7358 895.6551,159.9155 Q 895.6551,160.0249 895.6238,160.2905 Q 895.5926,160.5522 895.5418,160.896 Q 895.4949,161.2358 895.4402,161.5913 Q 895.3855,161.9429 895.3386,162.2397 Q 895.2918,162.5366 895.2644,162.7085 Q 895.7215,162.2554 896.1238,162.0679 Q 896.5261,161.8764 896.8777,161.8764 Q 897.1238,161.8764 897.2527,162.0014 Q 897.3816,162.1264 897.3816,162.5054 Q 897.3816,162.7085 897.3308,163.021 Q 897.2801,163.3296 897.2176,163.6655 Q 897.1551,164.0014 897.1043,164.2905 Q 897.0574,164.5796 897.0574,164.7397 Q 897.0574,164.8725 897.0926,164.9233 Q 897.1277,164.9702 897.198,164.9702 Q 897.3035,164.9702 897.3972,164.9389 Q 897.4949,164.9038 897.6277,164.8413 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path2792" />
+    <path
+       d="M 901.0613,162.5639 Q 901.0613,162.7358 900.9793,162.9429 Q 900.9011,163.1499 900.6511,163.3882 Q 900.4011,163.6225 899.8972,163.8843 Q 899.3933,164.146 898.5418,164.4194 L 898.5144,164.0132 Q 899.0496,163.7983 899.3621,163.6304 Q 899.6785,163.4585 899.8347,163.3179 Q 899.991,163.1772 900.0379,163.0483 Q 900.0847,162.9155 900.0847,162.7671 Q 900.0847,162.5874 900.0027,162.4975 Q 899.9246,162.4038 899.8152,162.4038 Q 899.7527,162.4038 899.6238,162.4702 Q 899.4949,162.5366 899.3972,162.6538 Q 899.1863,162.8999 899.0574,163.2202 Q 898.9324,163.5405 898.9324,163.9702 Q 898.9324,164.4819 899.1082,164.7866 Q 899.2879,165.0874 899.5183,165.0874 Q 899.6824,165.0874 899.9988,164.935 Q 900.3191,164.7827 900.7918,164.4038 Q 900.8347,164.4272 900.8972,164.5405 Q 900.9597,164.6538 900.9715,164.6811 Q 900.3308,165.2397 899.9129,165.4663 Q 899.4949,165.6929 899.1472,165.6929 Q 898.9324,165.6929 898.6668,165.56 Q 898.4051,165.4311 898.2136,165.1382 Q 898.0261,164.8413 898.0261,164.3491 Q 898.0261,163.7358 898.3113,163.2319 Q 898.5965,162.7241 899.0886,162.3139 Q 899.2644,162.1694 899.5769,162.0249 Q 899.8933,161.8764 900.2019,161.8764 Q 900.6433,161.8764 900.8504,162.0952 Q 901.0613,162.31 901.0613,162.5639 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path2794" />
+    <path
+       d="M 905.3426,165.103 Q 905.1082,165.2436 904.8465,165.3804 Q 904.5886,165.5171 904.3621,165.603 Q 904.1355,165.6929 904.0066,165.6929 Q 903.8699,165.6929 903.7801,165.5679 Q 903.6902,165.4468 903.6902,165.2358 Q 903.6902,165.1538 903.7215,164.9389 Q 903.7527,164.7241 903.7996,164.4429 Q 903.8504,164.1616 903.8972,163.8804 Q 903.9441,163.5952 903.9754,163.3686 Q 904.0105,163.1382 904.0105,163.0327 Q 904.0105,162.8022 903.9676,162.7124 Q 903.9285,162.6186 903.8035,162.6186 Q 903.698,162.6186 903.4519,162.7593 Q 903.2058,162.8999 902.9793,163.2671 Q 902.8621,163.4507 902.7957,163.7163 Q 902.7332,163.978 902.6668,164.3569 Q 902.6043,164.7046 902.5847,164.9038 Q 902.5691,165.0991 902.5769,165.2866 Q 902.5222,165.31 902.3972,165.3647 Q 902.2761,165.4194 902.1316,165.4858 Q 901.9871,165.5522 901.8621,165.6069 Q 901.741,165.6655 901.6941,165.6929 L 901.5379,165.5405 Q 901.616,165.1538 901.6902,164.7319 Q 901.7644,164.3061 901.823,163.9155 Q 901.8816,163.5249 901.9168,163.228 Q 901.9519,162.9272 901.9519,162.7905 Q 901.9519,162.6108 901.9129,162.5718 Q 901.8738,162.5288 901.8035,162.5288 Q 901.7488,162.5288 901.6121,162.5679 Q 901.4793,162.6069 901.4168,162.6304 L 901.3426,162.3608 Q 901.5066,162.2905 901.7176,162.2085 Q 901.9324,162.1225 902.1394,162.0483 Q 902.3504,161.9702 902.5105,161.9233 Q 902.6707,161.8764 902.7293,161.8764 Q 902.8386,161.8764 902.8738,161.9585 Q 902.9129,162.0405 902.9129,162.3179 Q 902.9129,162.5054 902.8855,162.7085 Q 903.3113,162.2866 903.7254,162.0835 Q 904.1394,161.8764 904.491,161.8764 Q 904.7371,161.8764 904.8699,161.9975 Q 905.0066,162.1186 905.0066,162.4975 Q 905.0066,162.7007 904.9558,163.0132 Q 904.9051,163.3218 904.8386,163.6616 Q 904.7761,163.9975 904.7254,164.2905 Q 904.6746,164.5796 904.6746,164.7397 Q 904.6746,164.8725 904.7097,164.9233 Q 904.7449,164.9702 904.8152,164.9702 Q 904.9051,164.9702 904.9988,164.9429 Q 905.0926,164.9116 905.241,164.8413 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path2796" />
+    <path
+       d="M 902.4033,155.9863 Q 902.3408,156.2155 902.1637,156.6113 Q 901.9971,156.9968 901.9242,157.1739 H 896.1948 L 895.8615,156.8405 Q 895.9135,156.6218 896.0802,156.2468 Q 896.2469,155.8613 896.3406,155.6634 H 902.0596 Z"
+       id="path2445"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;display:inline;stroke-width:1.00004" />
+    <path
+       d="M 1011.239,162.3307 L 1001.575,151.2265 L 1011.239,140.1221 H 1036.615 V 162.3307 Z M 1012.423,160.0587 H 1034.311 V 142.3943 H 1012.423 L 1004.679,151.2265 Z M 1017.063,158.8106 L 1015.367,157.2105 L 1021.062,151.2265 L 1015.367,145.2423 L 1017.031,143.6423 L 1022.663,149.5623 L 1028.295,143.6423 L 1029.959,145.2423 L 1024.263,151.2265 L 1029.959,157.2105 L 1028.263,158.8106 L 1022.663,152.9225 Z"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32.0004px;line-height:1.25;font-family:'Noto Sans Symbols2';-inkscape-font-specification:'Noto Sans Symbols2';word-spacing:0px;stroke-width:1.00001"
+       id="path2817" />
+    <path
+       d="M 1164.987,134.7298 H 1166.459 L 1167.739,130.8471 H 1171.963 L 1173.435,134.7298 H 1174.971 L 1169.851,121.2045 H 1169.68 Z M 1171.622,129.6951 H 1168.038 L 1169.744,124.6178 Z"
+       id="path4617"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:21.3333px;line-height:1.25;font-family:Inconsolatazi4varl_qu;-inkscape-font-specification:Inconsolatazi4varl_qu;word-spacing:0px" />
+    <path
+       d="M 1223.286,121.4392 V 134.7298 H 1227.041 C 1228.769,134.7298 1230.027,134.3885 1230.817,133.7058 C 1231.606,133.0231 1232.011,132.1271 1232.011,130.9965 C 1232.011,130.6338 1231.947,130.2711 1231.841,129.9085 C 1231.734,129.5671 1231.563,129.2471 1231.329,128.9485 C 1231.094,128.6498 1230.838,128.3725 1230.539,128.1591 C 1230.219,127.9031 1229.878,127.7325 1229.515,127.6045 C 1230.134,127.3698 1230.625,126.9858 1230.966,126.4311 C 1231.307,125.8765 1231.478,125.2791 1231.478,124.6605 C 1231.478,124.1911 1231.393,123.7645 1231.201,123.3805 C 1231.009,122.9751 1230.753,122.6338 1230.411,122.3352 C 1230.07,122.0365 1229.622,121.8018 1229.046,121.6738 C 1228.491,121.5032 1227.83,121.4392 1227.062,121.4392 Z M 1224.758,122.6978 H 1227.083 C 1227.617,122.6978 1228.043,122.7618 1228.406,122.8685 C 1228.769,122.9751 1229.046,123.1245 1229.281,123.3378 C 1229.515,123.5085 1229.686,123.7431 1229.771,123.9991 C 1229.899,124.2551 1229.963,124.5325 1229.985,124.8311 C 1229.963,125.1298 1229.878,125.4071 1229.771,125.6845 C 1229.665,125.9405 1229.473,126.1538 1229.259,126.3458 C 1229.003,126.5378 1228.705,126.6658 1228.321,126.7938 C 1227.937,126.8791 1227.446,126.9431 1226.849,126.9431 H 1224.758 Z M 1224.758,128.2018 H 1226.934 C 1227.553,128.2018 1228.107,128.2658 1228.534,128.3938 C 1229.003,128.5218 1229.345,128.7138 1229.601,128.9698 C 1229.878,129.2045 1230.07,129.5031 1230.198,129.8231 C 1230.326,130.1431 1230.411,130.5058 1230.433,130.9111 C 1230.369,131.6365 1230.113,132.2338 1229.686,132.7245 C 1229.217,133.1938 1228.427,133.4285 1227.297,133.4285 H 1224.758 Z"
+       id="path4620"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:21.3333px;line-height:1.25;font-family:Inconsolatazi4varl_qu;-inkscape-font-specification:Inconsolatazi4varl_qu;word-spacing:0px" />
+    <path
+       d="M 1287.538,124.4471 C 1287.538,124.5538 1287.559,124.6178 1287.623,124.6605 L 1289.052,123.9565 C 1288.882,123.5511 1288.647,123.2098 1288.37,122.8685 C 1288.092,122.5698 1287.751,122.2925 1287.41,122.0578 C 1287.026,121.8232 1286.642,121.6525 1286.215,121.5245 C 1285.81,121.3965 1285.383,121.3325 1284.935,121.3325 C 1284.402,121.3325 1283.826,121.4392 1283.271,121.6738 C 1282.674,121.8872 1282.14,122.2498 1281.628,122.7831 C 1281.116,123.3165 1280.711,124.0205 1280.391,124.8738 C 1280.071,125.7698 1279.922,126.8578 1279.922,128.1591 C 1279.922,129.3325 1280.05,130.3565 1280.327,131.2098 C 1280.604,132.0631 1280.967,132.7671 1281.479,133.3218 C 1281.948,133.8765 1282.503,134.2818 1283.1,134.5591 C 1283.676,134.8151 1284.359,134.9431 1285.127,134.9431 C 1285.468,134.9431 1285.81,134.9005 1286.13,134.8151 C 1286.471,134.7085 1286.812,134.5805 1287.154,134.3885 C 1287.474,134.1965 1287.794,133.9831 1288.092,133.7058 C 1288.391,133.4285 1288.647,133.1298 1288.86,132.7671 L 1287.751,132.0418 C 1287.452,132.5325 1287.068,132.9378 1286.556,133.2365 C 1286.087,133.5138 1285.575,133.6631 1285.042,133.6631 C 1284.53,133.6631 1284.039,133.5351 1283.612,133.2578 C 1283.143,132.9805 1282.759,132.5965 1282.418,132.1271 C 1282.098,131.6151 1281.842,131.0391 1281.65,130.3351 C 1281.458,129.6525 1281.372,128.8845 1281.372,128.0525 C 1281.372,127.1778 1281.458,126.4098 1281.65,125.7271 C 1281.842,125.0445 1282.098,124.4685 1282.418,123.9778 C 1282.738,123.5085 1283.122,123.1458 1283.548,122.9111 C 1283.975,122.6551 1284.423,122.5271 1284.914,122.5271 C 1285.426,122.5271 1285.916,122.6551 1286.364,122.9538 C 1286.812,123.2098 1287.196,123.5938 1287.474,124.0631 C 1287.516,124.1485 1287.538,124.2765 1287.538,124.4471 Z"
+       id="path4623"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:21.3333px;line-height:1.25;font-family:Inconsolatazi4varl_qu;-inkscape-font-specification:Inconsolatazi4varl_qu;word-spacing:0px" />
+    <path
+       d="M 1337.409,121.4392 V 134.7298 H 1340.246 C 1341.292,134.7298 1342.188,134.6018 1342.892,134.3031 C 1343.596,134.0045 1344.193,133.5778 1344.62,132.9805 C 1345.089,132.4258 1345.43,131.7218 1345.686,130.9111 C 1345.942,130.1005 1346.07,129.1831 1346.07,128.1591 C 1346.07,127.1138 1345.964,126.1965 1345.75,125.3645 C 1345.537,124.5325 1345.217,123.8285 1344.769,123.2525 C 1344.321,122.6765 1343.788,122.2285 1343.169,121.9085 C 1342.529,121.5885 1341.633,121.4392 1340.502,121.4392 Z M 1338.817,122.6978 H 1340.417 C 1341.91,122.6978 1342.977,123.1885 1343.596,124.1698 C 1344.236,125.1511 1344.556,126.5165 1344.577,128.2445 C 1344.577,129.9725 1344.236,131.2738 1343.51,132.2125 C 1342.828,133.1085 1341.697,133.5778 1340.182,133.5778 H 1338.817 Z"
+       id="path4626"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:21.3333px;line-height:1.25;font-family:Inconsolatazi4varl_qu;-inkscape-font-specification:Inconsolatazi4varl_qu;word-spacing:0px" />
+    <path
+       d="M 1150.233,129.9612 L 1140.328,120.0565 C 1140.212,119.9307 1140.058,119.8727 1139.893,119.8727 C 1139.816,119.8727 1139.729,119.892 1139.661,119.921 C 1139.429,120.0178 1139.274,120.2402 1139.274,120.4917 V 135.0393 C 1139.274,135.2908 1139.429,135.5133 1139.661,135.61 C 1139.729,135.639 1139.816,135.6584 1139.893,135.6584 C 1140.058,135.6584 1140.212,135.5907 1140.328,135.4746 L 1143.346,132.4567 L 1145.194,136.8288 C 1145.329,137.1383 1145.687,137.293 1146.006,137.1576 L 1147.718,136.4322 C 1148.028,136.2968 1148.183,135.9389 1148.047,135.6197 L 1146.103,131.0155 H 1149.798 C 1150.049,131.0155 1150.272,130.8608 1150.369,130.6286 C 1150.465,130.4061 1150.417,130.1353 1150.233,129.9612 Z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.3333px;line-height:1.25;font-family:FontAwesome;-inkscape-font-specification:'FontAwesome Bold';word-spacing:0px"
+       id="path4629" />
+    <path
+       d="M 1144.788,234.2562 V 233.7334 Q 1145.769,233.5329 1145.769,233.2966 V 226.1995 Q 1145.769,226.1136 1145.533,225.9847 Q 1145.304,225.8558 1144.788,225.7555 V 225.2327 H 1148.548 V 225.7555 Q 1147.56,225.9632 1147.56,226.1995 V 233.2966 Q 1147.56,233.3825 1147.796,233.5114 Q 1148.032,233.6331 1148.548,233.7334 V 234.2562 Z M 1141.845,229.9593 V 229.0999 H 1145.913 V 229.9593 Z M 1139.274,234.2562 V 233.7334 Q 1140.255,233.5329 1140.255,233.2966 V 226.1995 Q 1140.255,226.1136 1140.019,225.9847 Q 1139.79,225.8558 1139.274,225.7555 V 225.2327 H 1143.034 V 225.7555 Q 1142.045,225.9632 1142.045,226.1995 V 233.2966 Q 1142.045,233.3825 1142.275,233.5114 Q 1142.511,233.6331 1143.034,233.7334 V 234.2562 Z"
+       style="font-weight:bold;font-size:14.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:0.980755"
+       id="path4632" />
+    <path
+       d="M 1156.218,230.7829 Q 1156.218,231.499 1155.939,232.1579 Q 1155.659,232.8167 1155.172,233.3395 Q 1154.685,233.8623 1154.048,234.1703 Q 1153.411,234.471 1152.702,234.471 Q 1151.713,234.471 1150.983,234.027 Q 1150.252,233.583 1149.851,232.8167 Q 1149.45,232.0505 1149.45,231.0765 Q 1149.45,230.3675 1149.708,229.7087 Q 1149.966,229.0426 1150.439,228.5199 Q 1150.911,227.9899 1151.556,227.6891 Q 1152.208,227.3812 1152.981,227.3812 Q 1153.955,227.3812 1154.685,227.8252 Q 1155.416,228.2692 1155.817,229.0355 Q 1156.218,229.8018 1156.218,230.7829 Z M 1154.413,231.1051 Q 1154.413,230.346 1154.206,229.7087 Q 1153.998,229.0641 1153.625,228.6702 Q 1153.26,228.2764 1152.773,228.2764 Q 1152.179,228.2764 1151.849,228.6201 Q 1151.52,228.9567 1151.391,229.5439 Q 1151.262,230.1312 1151.262,230.8688 Q 1151.262,231.6208 1151.484,232.2367 Q 1151.713,232.8525 1152.086,233.2178 Q 1152.458,233.5759 1152.902,233.5759 Q 1153.754,233.5759 1154.084,232.9313 Q 1154.413,232.2868 1154.413,231.1051 Z"
+       style="font-weight:bold;font-size:14.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:0.980755"
+       id="path4634" />
+    <path
+       d="M 1165.342,234.2562 V 233.7334 Q 1165.857,233.5973 1166.015,233.4971 Q 1166.172,233.3897 1166.172,233.2966 V 229.9378 Q 1166.172,229.3506 1166.086,229.0713 Q 1166.008,228.7848 1165.843,228.6989 Q 1165.678,228.613 1165.42,228.613 Q 1165.105,228.613 1164.676,228.835 Q 1164.253,229.057 1163.795,229.5081 V 233.2966 Q 1163.795,233.3897 1163.959,233.4899 Q 1164.131,233.5902 1164.697,233.7334 V 234.2562 H 1161.238 V 233.7334 Q 1161.754,233.5973 1161.911,233.4971 Q 1162.076,233.3897 1162.076,233.2966 V 229.9378 Q 1162.076,229.3506 1162.012,229.0713 Q 1161.947,228.7848 1161.79,228.6989 Q 1161.639,228.613 1161.374,228.613 Q 1160.715,228.613 1159.691,229.5081 V 233.2966 Q 1159.691,233.5472 1160.586,233.7334 V 234.2562 H 1157.027 V 233.7334 Q 1157.972,233.4828 1157.972,233.2966 V 229.3219 Q 1157.972,228.9424 1157.93,228.7705 Q 1157.887,228.5915 1157.686,228.527 Q 1157.486,228.4554 1157.027,228.3981 V 227.8968 Q 1157.765,227.8109 1158.266,227.6891 Q 1158.775,227.5674 1159.283,227.3812 L 1159.584,227.682 L 1159.663,228.57 Q 1160.465,227.861 1161.045,227.6247 Q 1161.632,227.3812 1162.148,227.3812 Q 1162.828,227.3812 1163.2,227.6963 Q 1163.58,228.0114 1163.666,228.4697 L 1163.687,228.57 Q 1164.489,227.8753 1165.077,227.6318 Q 1165.671,227.3812 1166.194,227.3812 Q 1166.874,227.3812 1167.383,227.7965 Q 1167.891,228.2119 1167.891,229.2145 V 233.2966 Q 1167.891,233.3897 1168.113,233.4899 Q 1168.335,233.5902 1168.901,233.7334 V 234.2562 Z"
+       style="font-weight:bold;font-size:14.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:0.980755"
+       id="path4636" />
+    <path
+       d="M 1175.69,230.3174 Q 1175.561,230.4678 1175.239,230.6468 Q 1174.917,230.8187 1174.687,230.9046 H 1170.362 L 1170.376,230.1025 H 1173.706 Q 1173.871,230.1025 1173.921,230.0524 Q 1173.978,229.9951 1173.978,229.8447 Q 1173.978,229.5583 1173.864,229.1859 Q 1173.756,228.8063 1173.477,228.527 Q 1173.205,228.2406 1172.718,228.2406 Q 1171.937,228.2406 1171.615,228.9281 Q 1171.3,229.6084 1171.3,230.7471 Q 1171.3,231.8356 1171.758,232.5518 Q 1172.224,233.2679 1173.098,233.2679 Q 1173.398,233.2679 1173.685,233.2178 Q 1173.971,233.1605 1174.344,232.9743 Q 1174.716,232.7881 1175.275,232.4014 Q 1175.368,232.4515 1175.489,232.6305 Q 1175.618,232.8024 1175.647,232.8597 Q 1174.981,233.5329 1174.487,233.8838 Q 1173.993,234.2275 1173.527,234.3493 Q 1173.069,234.471 1172.496,234.471 Q 1171.68,234.471 1171.006,234.0485 Q 1170.333,233.626 1169.925,232.8669 Q 1169.524,232.1006 1169.524,231.0908 Q 1169.524,229.1357 1170.999,228.0544 Q 1171.379,227.7751 1171.902,227.5817 Q 1172.432,227.3812 1172.976,227.3812 Q 1173.914,227.3812 1174.508,227.7965 Q 1175.11,228.2119 1175.396,228.8851 Q 1175.69,229.5511 1175.69,230.3174 Z"
+       style="font-weight:bold;font-size:14.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:0.980755"
+       id="path4638" />
+    <path
+       d="M 1260.903,227.5531 Q 1260.903,228.2978 1260.609,228.8564 Q 1260.322,229.415 1259.857,229.7874 Q 1259.399,230.1598 1258.869,230.346 Q 1258.339,230.5322 1257.866,230.5322 Q 1257.537,230.5322 1257.214,230.4821 Q 1256.899,230.4248 1256.663,230.3174 L 1256.441,229.5654 Q 1256.735,229.7015 1256.957,229.7445 Q 1257.186,229.7803 1257.436,229.7803 Q 1257.852,229.7803 1258.231,229.5798 Q 1258.611,229.3721 1258.854,228.9495 Q 1259.098,228.5199 1259.098,227.8467 Q 1259.098,226.8297 1258.453,226.307 Q 1257.816,225.777 1256.792,225.777 Q 1256.291,225.777 1255.682,225.8271 Q 1255.073,225.8773 1254.479,225.9489 Q 1253.884,226.0205 1253.426,226.1064 L 1253.333,225.4476 Q 1253.849,225.3187 1254.507,225.2256 Q 1255.166,225.1253 1255.868,225.0752 Q 1256.57,225.0179 1257.2,225.0179 Q 1258.862,225.0179 1259.878,225.6696 Q 1260.903,226.3213 1260.903,227.5531 Z M 1253.426,234.2562 V 233.7334 Q 1254.407,233.5329 1254.407,233.2966 V 225.7484 H 1256.197 V 233.2966 Q 1256.197,233.3825 1256.419,233.4971 Q 1256.649,233.6117 1257.401,233.7334 V 234.2562 Z"
+       style="font-weight:bold;font-size:14.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:0.985246"
+       id="path4644" />
+    <path
+       d="M 1267.169,232.5016 Q 1266.61,233.2751 1266.173,233.7048 Q 1265.737,234.1344 1265.321,234.2992 Q 1264.913,234.471 1264.412,234.471 Q 1263.796,234.471 1263.216,234.1058 Q 1262.643,233.7334 1262.27,233.0387 Q 1261.898,232.3369 1261.898,231.3486 Q 1261.898,230.7327 1262.127,230.0452 Q 1262.364,229.3577 1262.808,228.7562 Q 1263.259,228.1475 1263.903,227.7679 Q 1264.555,227.3812 1265.378,227.3812 Q 1265.808,227.3812 1266.166,227.5316 Q 1266.531,227.682 1267.097,228.2406 Q 1267.097,229.0784 1266.668,229.3363 Q 1266.446,228.8851 1266.095,228.6058 Q 1265.751,228.3265 1265.321,228.3265 Q 1264.483,228.3265 1264.046,229.0641 Q 1263.617,229.8018 1263.617,230.9691 Q 1263.617,231.6566 1263.846,232.1364 Q 1264.075,232.6091 1264.433,232.8597 Q 1264.798,233.1104 1265.192,233.1104 Q 1265.457,233.1104 1265.851,232.9313 Q 1266.245,232.7451 1266.904,232.0218 Q 1266.983,232.0648 1267.054,232.2581 Q 1267.126,232.4443 1267.169,232.5016 Z M 1268.558,227.6462 Q 1268.487,227.8467 1268.408,228.2477 Q 1268.336,228.6488 1268.343,229.1214 L 1268.451,233.361 Q 1268.479,234.3421 1268.207,235.0726 Q 1267.942,235.8102 1267.498,236.3259 Q 1267.054,236.8486 1266.531,237.1638 Q 1266.009,237.486 1265.507,237.6292 Q 1265.013,237.7796 1264.648,237.7796 Q 1263.946,237.7796 1263.352,237.5863 Q 1262.757,237.4001 1262.399,237.1423 Q 1262.041,236.8916 1262.041,236.6983 Q 1262.041,236.6266 1262.206,236.4476 Q 1262.378,236.2757 1262.614,236.0752 Q 1262.858,235.8747 1263.08,235.7171 Q 1263.309,235.5667 1263.423,235.5309 Q 1263.903,236.1325 1264.333,236.3975 Q 1264.77,236.6696 1265.228,236.6696 Q 1265.615,236.6696 1265.959,236.4834 Q 1266.302,236.2972 1266.503,235.7028 Q 1266.711,235.1156 1266.696,233.9196 L 1266.625,228.2907 Q 1266.782,228.2406 1267.104,228.0758 Q 1267.434,227.9111 1267.763,227.7178 Q 1268.1,227.5172 1268.286,227.374 Z"
+       style="font-weight:bold;font-size:14.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:0.985246"
+       id="path4646" />
+    <path
+       d="M 1278.427,225.7555 Q 1277.438,225.9632 1277.438,226.1995 V 230.5036 Q 1277.438,231.7568 1276.98,232.6449 Q 1276.529,233.5329 1275.727,234.0055 Q 1274.932,234.471 1273.901,234.471 Q 1272.92,234.471 1272.103,234.1058 Q 1271.287,233.7406 1270.8,232.9886 Q 1270.313,232.2367 1270.313,231.0765 V 226.1995 Q 1270.313,226.1136 1270.076,225.9847 Q 1269.847,225.8558 1269.332,225.7555 V 225.2327 H 1273.091 V 225.7555 Q 1272.103,225.9632 1272.103,226.1995 V 230.611 Q 1272.103,231.986 1272.612,232.7093 Q 1273.12,233.4326 1274.345,233.4326 Q 1275.025,233.4326 1275.426,233.0459 Q 1275.827,232.652 1276.006,232.029 Q 1276.185,231.3988 1276.185,230.6898 V 226.1995 Q 1276.185,226.1136 1275.949,225.9847 Q 1275.72,225.8558 1275.204,225.7555 V 225.2327 H 1278.427 Z"
+       style="font-weight:bold;font-size:14.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:0.985246"
+       id="path4648" />
+    <path
+       d="M 1283.776,234.471 Q 1283.354,234.471 1282.903,234.2848 Q 1282.459,234.0986 1281.836,233.6618 V 236.7269 Q 1281.836,236.8415 1282.101,236.9561 Q 1282.373,237.0707 1283.046,237.1709 V 237.6937 H 1279.171 V 237.1709 Q 1280.117,236.9417 1280.117,236.7269 V 229.3219 Q 1280.117,228.9639 1280.067,228.7777 Q 1280.024,228.5843 1279.823,228.5055 Q 1279.623,228.4196 1279.171,228.3981 V 227.8968 Q 1279.716,227.8252 1280.081,227.7607 Q 1280.446,227.6891 1280.754,227.6032 Q 1281.062,227.5101 1281.427,227.3812 L 1281.728,227.682 L 1281.793,228.5628 Q 1282.588,227.8682 1283.16,227.6247 Q 1283.741,227.3812 1284.149,227.3812 Q 1284.8,227.3812 1285.345,227.7393 Q 1285.896,228.0902 1286.226,228.8206 Q 1286.562,229.5511 1286.562,230.6755 Q 1286.562,231.3844 1286.297,232.0576 Q 1286.032,232.7308 1285.61,233.2822 Q 1285.187,233.8265 1284.7,234.1488 Q 1284.213,234.471 1283.776,234.471 Z M 1283.289,228.5986 Q 1283.117,228.5986 1282.938,228.6559 Q 1282.767,228.7132 1282.509,228.8851 Q 1282.258,229.057 1281.836,229.4007 V 232.6234 Q 1282.344,232.917 1282.673,233.0602 Q 1283.003,233.1963 1283.239,233.2321 Q 1283.476,233.2679 1283.705,233.2679 Q 1284.256,233.2679 1284.6,232.738 Q 1284.951,232.2009 1284.951,231.2054 Q 1284.951,230.2887 1284.7,229.7158 Q 1284.457,229.1429 1284.077,228.8708 Q 1283.698,228.5986 1283.289,228.5986 Z"
+       style="font-weight:bold;font-size:14.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:0.985246"
+       id="path4650" />
+    <path
+       d="M 1337.921,259.7443 V 273.0349 H 1346.006 V 271.7122 H 1339.329 V 266.7843 H 1344.897 V 265.4189 H 1339.329 V 261.0456 H 1346.07 V 259.7443 Z"
+       id="path4653"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:21.3333px;line-height:1.25;font-family:Inconsolatazi4varl_qu;-inkscape-font-specification:Inconsolatazi4varl_qu;word-spacing:0px" />
+    <path
+       d="M 1145.87,367.1824 Q 1145.855,367.4259 1145.805,367.827 Q 1145.762,368.228 1145.698,368.6076 Q 1145.633,368.9871 1145.576,369.1733 H 1145.039 Q 1144.974,367.8126 1144.452,367.8126 H 1141.673 L 1141.881,366.9533 H 1145.583 Z M 1145.132,370.9637 Q 1145.017,371.1642 1144.824,371.465 Q 1144.631,371.7586 1144.473,371.866 Q 1144.251,371.6583 1143.95,371.5652 Q 1143.657,371.4721 1143.055,371.4721 H 1141.573 L 1141.73,370.713 H 1144.896 Z M 1146.335,373.7996 Q 1146.299,374.2078 1146.242,374.6662 Q 1146.192,375.1173 1146.135,375.4754 Q 1146.084,375.8335 1146.041,375.9767 H 1139.274 V 375.4539 Q 1140.255,375.2534 1140.255,375.0171 V 367.9201 Q 1140.255,367.8341 1140.019,367.7052 Q 1139.79,367.5763 1139.274,367.476 V 366.9533 H 1143.084 V 367.476 Q 1142.604,367.5262 1142.325,367.5978 Q 1142.045,367.6622 1142.045,367.7625 V 374.659 Q 1142.045,374.7951 1142.146,374.9025 Q 1142.253,375.0028 1142.561,375.06 Q 1142.876,375.1173 1143.506,375.1173 H 1144.215 Q 1144.874,375.1173 1145.189,374.7879 Q 1145.504,374.4513 1145.812,373.6134 Z"
+       style="font-weight:bold;font-size:14.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00007"
+       id="path4665" />
+    <path
+       d="M 1151.42,375.9767 V 375.4539 Q 1151.935,375.3179 1152.15,375.2176 Q 1152.365,375.1102 1152.365,375.0171 V 371.7658 Q 1152.365,370.978 1152.2,370.6915 Q 1152.036,370.4051 1151.613,370.4051 Q 1151.269,370.4051 1150.818,370.6128 Q 1150.374,370.8133 1149.68,371.4005 V 375.0171 Q 1149.68,375.2534 1150.632,375.4539 V 375.9767 H 1147.015 V 375.4539 Q 1147.961,375.2033 1147.961,375.0171 V 371.0425 Q 1147.961,370.6701 1147.918,370.4982 Q 1147.875,370.3192 1147.674,370.2475 Q 1147.481,370.1759 1147.015,370.1186 V 369.6173 Q 1147.696,369.5457 1148.219,369.424 Q 1148.749,369.3022 1149.271,369.1017 L 1149.572,369.4025 L 1149.651,370.4337 Q 1150.482,369.7247 1151.212,369.4168 Q 1151.943,369.1017 1152.501,369.1017 Q 1153.117,369.1017 1153.597,369.5171 Q 1154.084,369.9324 1154.084,370.935 V 375.0171 Q 1154.084,375.1102 1154.277,375.2104 Q 1154.471,375.3107 1155.036,375.4539 V 375.9767 Z"
+       style="font-weight:bold;font-size:14.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00007"
+       id="path4667" />
+    <path
+       d="M 1163.365,375.1603 Q 1162.928,375.4539 1162.484,375.6903 Q 1162.047,375.9194 1161.711,376.0555 Q 1161.374,376.1916 1161.238,376.1916 Q 1160.529,376.1916 1160.529,373.8139 V 367.0678 Q 1160.529,366.5379 1160.479,366.2944 Q 1160.436,366.0437 1160.228,365.9578 Q 1160.021,365.8719 1159.548,365.8361 V 365.3419 Q 1160.329,365.2631 1160.966,365.1342 Q 1161.603,364.9982 1161.976,364.8764 L 1162.248,365.1414 V 373.8354 Q 1162.248,374.3367 1162.284,374.5373 Q 1162.327,374.7306 1162.413,374.7879 Q 1162.491,374.838 1162.635,374.8237 Q 1162.778,374.8022 1163.165,374.6375 Z M 1161.059,374.437 Q 1160.472,375.0672 1160.042,375.4539 Q 1159.612,375.8406 1159.204,376.0125 Q 1158.803,376.1916 1158.28,376.1916 Q 1157.643,376.1916 1157.042,375.7905 Q 1156.44,375.3823 1156.046,374.6232 Q 1155.659,373.8569 1155.659,372.797 Q 1155.659,371.8374 1156.103,370.9995 Q 1156.547,370.1544 1157.328,369.6316 Q 1158.116,369.1017 1159.14,369.1017 Q 1159.57,369.1017 1160.006,369.2449 Q 1160.443,369.3882 1161.002,369.9038 Q 1161.002,370.7488 1160.579,370.9995 Q 1160.321,370.5483 1159.92,370.2977 Q 1159.527,370.047 1159.025,370.047 Q 1158.316,370.047 1157.844,370.6128 Q 1157.378,371.1714 1157.378,372.4103 Q 1157.378,373.1694 1157.622,373.7137 Q 1157.865,374.2508 1158.237,374.5444 Q 1158.61,374.8309 1159.004,374.8309 Q 1159.433,374.8309 1159.827,374.5946 Q 1160.228,374.3511 1160.744,373.8498 Q 1160.801,373.8784 1160.866,374.0073 Q 1160.937,374.1362 1160.987,374.2723 Q 1161.045,374.4012 1161.059,374.437 Z"
+       style="font-weight:bold;font-size:14.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00007"
+       id="path4669" />
+    <path
+       d="M 1260.903,369.2736 Q 1260.903,370.0184 1260.609,370.577 Q 1260.322,371.1356 1259.857,371.508 Q 1259.399,371.8804 1258.869,372.0665 Q 1258.339,372.2527 1257.866,372.2527 Q 1257.537,372.2527 1257.214,372.2026 Q 1256.899,372.1453 1256.663,372.0379 L 1256.441,371.2859 Q 1256.735,371.422 1256.957,371.465 Q 1257.186,371.5008 1257.436,371.5008 Q 1257.852,371.5008 1258.231,371.3003 Q 1258.611,371.0926 1258.854,370.6701 Q 1259.098,370.2404 1259.098,369.5672 Q 1259.098,368.5503 1258.453,368.0275 Q 1257.816,367.4975 1256.792,367.4975 Q 1256.291,367.4975 1255.682,367.5477 Q 1255.073,367.5978 1254.479,367.6694 Q 1253.884,367.741 1253.426,367.827 L 1253.333,367.1681 Q 1253.849,367.0392 1254.507,366.9461 Q 1255.166,366.8458 1255.868,366.7957 Q 1256.57,366.7384 1257.2,366.7384 Q 1258.862,366.7384 1259.878,367.3901 Q 1260.903,368.0418 1260.903,369.2736 Z M 1253.426,375.9767 V 375.4539 Q 1254.407,375.2534 1254.407,375.0171 V 367.4689 H 1256.197 V 375.0171 Q 1256.197,375.103 1256.419,375.2176 Q 1256.649,375.3322 1257.401,375.4539 V 375.9767 Z"
+       style="font-weight:bold;font-size:14.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:0.980491"
+       id="path4675" />
+    <path
+       d="M 1267.169,374.2222 Q 1266.61,374.9956 1266.173,375.4253 Q 1265.737,375.855 1265.321,376.0197 Q 1264.913,376.1916 1264.412,376.1916 Q 1263.796,376.1916 1263.216,375.8263 Q 1262.643,375.4539 1262.27,374.7593 Q 1261.898,374.0574 1261.898,373.0692 Q 1261.898,372.4533 1262.127,371.7658 Q 1262.364,371.0783 1262.808,370.4767 Q 1263.259,369.868 1263.903,369.4884 Q 1264.555,369.1017 1265.378,369.1017 Q 1265.808,369.1017 1266.166,369.2521 Q 1266.531,369.4025 1267.097,369.9611 Q 1267.097,370.799 1266.668,371.0568 Q 1266.446,370.6056 1266.095,370.3263 Q 1265.751,370.047 1265.321,370.047 Q 1264.483,370.047 1264.046,370.7846 Q 1263.617,371.5223 1263.617,372.6896 Q 1263.617,373.3771 1263.846,373.8569 Q 1264.075,374.3296 1264.433,374.5802 Q 1264.798,374.8309 1265.192,374.8309 Q 1265.457,374.8309 1265.851,374.6518 Q 1266.245,374.4656 1266.904,373.7423 Q 1266.983,373.7853 1267.054,373.9787 Q 1267.126,374.1649 1267.169,374.2222 Z M 1268.558,369.3667 Q 1268.487,369.5672 1268.408,369.9682 Q 1268.336,370.3693 1268.343,370.8419 L 1268.451,375.0815 Q 1268.479,376.0627 1268.207,376.7931 Q 1267.942,377.5308 1267.498,378.0464 Q 1267.054,378.5692 1266.531,378.8843 Q 1266.009,379.2065 1265.507,379.3498 Q 1265.013,379.5002 1264.648,379.5002 Q 1263.946,379.5002 1263.352,379.3068 Q 1262.757,379.1206 1262.399,378.8628 Q 1262.041,378.6121 1262.041,378.4188 Q 1262.041,378.3472 1262.206,378.1681 Q 1262.378,377.9963 1262.614,377.7957 Q 1262.858,377.5952 1263.08,377.4377 Q 1263.309,377.2873 1263.423,377.2515 Q 1263.903,377.853 1264.333,378.118 Q 1264.77,378.3901 1265.228,378.3901 Q 1265.615,378.3901 1265.959,378.2039 Q 1266.302,378.0177 1266.503,377.4233 Q 1266.711,376.8361 1266.696,375.6401 L 1266.625,370.0112 Q 1266.782,369.9611 1267.104,369.7964 Q 1267.434,369.6316 1267.763,369.4383 Q 1268.1,369.2378 1268.286,369.0945 Z"
+       style="font-weight:bold;font-size:14.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:0.980491"
+       id="path4677" />
+    <path
+       d="M 1269.332,375.9767 V 375.4539 Q 1270.313,375.2534 1270.313,375.0171 V 367.6837 Q 1270.033,367.7267 1269.783,367.7625 Q 1269.532,367.7983 1269.332,367.827 L 1269.239,367.1681 Q 1269.711,367.0464 1270.392,366.9533 Q 1271.079,366.853 1271.809,366.7957 Q 1272.547,366.7384 1273.163,366.7384 Q 1275.354,366.7384 1276.558,367.8986 Q 1277.768,369.0587 1277.768,371.1356 Q 1277.768,372.4748 1277.374,373.4057 Q 1276.98,374.3296 1276.343,374.9025 Q 1275.705,375.4683 1274.946,375.7261 Q 1274.194,375.9767 1273.457,375.9767 H 1272.877 Q 1272.039,375.9767 1271.315,375.9767 Q 1270.599,375.9767 1269.611,375.9767 Z M 1273.192,375.2104 Q 1273.607,375.2104 1274.065,374.9956 Q 1274.531,374.7807 1274.932,374.3224 Q 1275.34,373.8641 1275.591,373.1479 Q 1275.849,372.4246 1275.849,371.4149 Q 1275.849,369.5099 1275.025,368.5073 Q 1274.209,367.4975 1272.647,367.4975 Q 1272.518,367.4975 1272.382,367.5047 Q 1272.246,367.5119 1272.103,367.519 V 374.7664 Q 1272.103,375.0529 1272.433,375.1317 Q 1272.762,375.2104 1273.192,375.2104 Z"
+       style="font-weight:bold;font-size:14.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:0.980491"
+       id="path4679" />
+    <path
+       d="M 1283.11,375.9767 V 375.4539 Q 1283.626,375.3179 1283.841,375.2176 Q 1284.056,375.1102 1284.056,375.0171 V 371.7658 Q 1284.056,370.978 1283.891,370.6915 Q 1283.726,370.4051 1283.304,370.4051 Q 1282.96,370.4051 1282.509,370.6128 Q 1282.065,370.8133 1281.37,371.4005 V 375.0171 Q 1281.37,375.2534 1282.323,375.4539 V 375.9767 H 1278.706 V 375.4539 Q 1279.651,375.2033 1279.651,375.0171 V 371.0425 Q 1279.651,370.6701 1279.608,370.4982 Q 1279.565,370.3192 1279.365,370.2475 Q 1279.171,370.1759 1278.706,370.1186 V 369.6173 Q 1279.386,369.5457 1279.909,369.424 Q 1280.439,369.3022 1280.962,369.1017 L 1281.263,369.4025 L 1281.341,370.4337 Q 1282.172,369.7247 1282.903,369.4168 Q 1283.633,369.1017 1284.192,369.1017 Q 1284.808,369.1017 1285.287,369.5171 Q 1285.774,369.9324 1285.774,370.935 V 375.0171 Q 1285.774,375.1102 1285.968,375.2104 Q 1286.161,375.3107 1286.727,375.4539 V 375.9767 Z"
+       style="font-weight:bold;font-size:14.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:0.980491"
+       id="path4681" />
+    <path
+       d="M 1338.411,404.4095 V 417.7001 H 1339.904 V 411.1721 H 1344.875 V 409.8708 H 1339.904 V 405.6895 H 1346.07 V 404.4095 Z"
+       id="path4714"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:21.3333px;line-height:1.25;font-family:Inconsolatazi4varl_qu;-inkscape-font-specification:Inconsolatazi4varl_qu;word-spacing:0px" />
+    <path
+       d="M 1146.746,156.4189 Q 1146.324,156.4775 1146.13,156.5888 Q 1145.937,156.7002 1145.937,156.7822 V 163.187 L 1145.058,162.9584 V 156.7822 Q 1145.058,156.7119 1144.888,156.6006 Q 1144.724,156.4834 1144.255,156.4189 V 155.9911 H 1146.746 Z M 1145.937,163.5503 Q 1145.38,163.5034 1145.035,163.3335 Q 1144.695,163.1577 1144.536,162.9409 L 1140.417,157.2334 Q 1140.177,156.8994 1139.878,156.6826 Q 1139.579,156.4658 1139.274,156.4189 V 155.9911 H 1140.909 Q 1141.079,155.9911 1141.167,156.0673 Q 1141.255,156.1435 1141.472,156.4482 L 1145.158,161.5521 Q 1145.222,161.64 1145.345,161.8041 Q 1145.474,161.9623 1145.609,162.1322 Q 1145.744,162.3022 1145.837,162.4193 Q 1145.937,162.5365 1145.937,162.5365 Z M 1139.274,163.3745 V 162.9467 Q 1139.702,162.894 1139.89,162.7827 Q 1140.077,162.6655 1140.077,162.5893 V 156.542 L 1140.956,156.2197 V 162.5893 Q 1140.956,162.6596 1141.132,162.7709 Q 1141.308,162.8823 1141.765,162.9467 V 163.3745 Z"
+       style="font-weight:bold;font-size:12.0009px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00008"
+       id="path4746" />
+    <path
+       d="M 1153.689,162.7182 Q 1153.402,162.9057 1153.045,163.0991 Q 1152.693,163.2925 1152.4,163.4214 Q 1152.107,163.5503 1152.014,163.5503 Q 1151.803,163.5503 1151.627,163.3686 Q 1151.451,163.1811 1151.381,162.5776 Q 1150.894,162.9995 1150.537,163.2104 Q 1150.179,163.4155 1149.904,163.48 Q 1149.629,163.5503 1149.377,163.5503 Q 1149.013,163.5503 1148.673,163.4038 Q 1148.334,163.2573 1148.111,162.8647 Q 1147.894,162.4721 1147.894,161.7396 V 159.3371 Q 1147.894,158.9679 1147.859,158.8038 Q 1147.83,158.6398 1147.677,158.587 Q 1147.531,158.5343 1147.185,158.4991 V 158.0889 Q 1147.771,158.0362 1148.187,157.9717 Q 1148.609,157.9014 1149.095,157.7491 L 1149.3,158.0186 V 161.3704 Q 1149.3,162.0971 1149.476,162.3197 Q 1149.652,162.5365 1149.98,162.5365 Q 1150.226,162.5365 1150.56,162.3959 Q 1150.9,162.2553 1151.381,161.8392 V 159.3371 Q 1151.381,158.9855 1151.334,158.8156 Q 1151.293,158.6456 1151.129,158.5812 Q 1150.965,158.5167 1150.607,158.4991 V 158.0889 Q 1151.193,158.0362 1151.668,157.9483 Q 1152.148,157.8546 1152.57,157.7491 L 1152.787,158.0186 V 161.7103 Q 1152.787,162.0678 1152.816,162.2143 Q 1152.846,162.3549 1152.922,162.4135 Q 1152.986,162.4662 1153.115,162.4369 Q 1153.244,162.4076 1153.543,162.2787 Z"
+       style="font-weight:bold;font-size:12.0009px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00008"
+       id="path4748" />
+    <path
+       d="M 1160.827,163.3745 V 162.9467 Q 1161.249,162.8354 1161.378,162.7534 Q 1161.506,162.6655 1161.506,162.5893 V 159.841 Q 1161.506,159.3605 1161.436,159.132 Q 1161.372,158.8976 1161.237,158.8273 Q 1161.102,158.757 1160.891,158.757 Q 1160.633,158.757 1160.282,158.9386 Q 1159.936,159.1203 1159.561,159.4894 V 162.5893 Q 1159.561,162.6655 1159.696,162.7475 Q 1159.836,162.8295 1160.299,162.9467 V 163.3745 H 1157.469 V 162.9467 Q 1157.891,162.8354 1158.02,162.7534 Q 1158.155,162.6655 1158.155,162.5893 V 159.841 Q 1158.155,159.3605 1158.102,159.132 Q 1158.049,158.8976 1157.92,158.8273 Q 1157.797,158.757 1157.58,158.757 Q 1157.041,158.757 1156.203,159.4894 V 162.5893 Q 1156.203,162.7944 1156.936,162.9467 V 163.3745 H 1154.023 V 162.9467 Q 1154.797,162.7416 1154.797,162.5893 V 159.3371 Q 1154.797,159.0265 1154.762,158.8859 Q 1154.727,158.7394 1154.563,158.6866 Q 1154.398,158.628 1154.023,158.5812 V 158.171 Q 1154.627,158.1007 1155.037,158.001 Q 1155.453,157.9014 1155.869,157.7491 L 1156.115,157.9952 L 1156.18,158.7218 Q 1156.836,158.1417 1157.311,157.9483 Q 1157.791,157.7491 1158.213,157.7491 Q 1158.77,157.7491 1159.075,158.0069 Q 1159.385,158.2647 1159.456,158.6398 L 1159.473,158.7218 Q 1160.129,158.1534 1160.61,157.9542 Q 1161.096,157.7491 1161.524,157.7491 Q 1162.081,157.7491 1162.497,158.0889 Q 1162.913,158.4288 1162.913,159.2492 V 162.5893 Q 1162.913,162.6655 1163.094,162.7475 Q 1163.276,162.8295 1163.739,162.9467 V 163.3745 Z"
+       style="font-weight:bold;font-size:12.0009px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00008"
+       id="path4750" />
+    <path
+       d="M 1169.839,161.5931 Q 1169.81,161.9271 1169.763,162.3022 Q 1169.722,162.6713 1169.675,162.9643 Q 1169.628,163.2573 1169.599,163.3745 H 1164.12 V 162.9467 Q 1164.923,162.7827 1164.923,162.5893 V 156.7822 Q 1164.923,156.7119 1164.729,156.6064 Q 1164.542,156.5009 1164.12,156.4189 V 155.9911 H 1167.196 V 156.4189 Q 1166.388,156.5888 1166.388,156.7822 V 162.2377 Q 1166.388,162.4428 1166.61,162.56 Q 1166.839,162.6713 1167.478,162.6713 H 1168.14 Q 1168.503,162.6713 1168.72,162.5541 Q 1168.937,162.4369 1169.089,162.1674 Q 1169.247,161.8978 1169.411,161.4408 Z"
+       style="font-weight:bold;font-size:12.0009px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00008"
+       id="path4752" />
+    <path
+       d="M 1176.396,158.3526 Q 1176.138,158.3761 1175.881,158.4757 Q 1175.623,158.5694 1175.371,158.757 L 1173.115,160.468 L 1172.353,160.2922 L 1173.947,158.8683 Q 1174.199,158.6398 1174.222,158.5284 Q 1174.246,158.4171 1174.117,158.3878 Q 1173.988,158.3526 1173.783,158.3526 V 157.9249 H 1176.396 Z M 1170.22,163.3745 V 162.9467 Q 1170.607,162.8471 1170.8,162.7709 Q 1170.999,162.6948 1170.999,162.5893 V 155.956 Q 1170.999,155.6102 1170.941,155.4579 Q 1170.888,155.3055 1170.724,155.2587 Q 1170.56,155.2059 1170.22,155.1708 V 154.7606 Q 1170.788,154.6785 1171.269,154.5731 Q 1171.749,154.4676 1172.142,154.2918 L 1172.406,154.532 V 162.5893 Q 1172.406,162.6772 1172.511,162.7475 Q 1172.617,162.812 1173.05,162.9467 V 163.3745 Z M 1176.601,163.1811 Q 1176.373,163.2339 1176.08,163.2925 Q 1175.787,163.3511 1175.541,163.3921 Q 1175.3,163.4331 1175.218,163.4331 Q 1174.732,163.4331 1174.498,163.1225 L 1172.365,160.2922 L 1173.373,159.8469 L 1175.711,162.5014 Q 1175.875,162.6948 1176.051,162.7358 Q 1176.226,162.7768 1176.566,162.7534 Z"
+       style="font-weight:bold;font-size:12.0009px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00008"
+       id="path4754" />
+    <path
+       id="path4308"
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0228797;stroke-opacity:1"
+       d="M 1207.918,118.0006 C 1206.001,118.0006 1204.475,119.2639 1203.336,121.7916 L 1202.949,122.6452 C 1202.325,124.0271 1201.796,124.9382 1201.365,125.3756 C 1200.893,125.8548 1200.286,126.0944 1199.543,126.0944 C 1198.564,126.0944 1197.87,125.5972 1197.461,124.6041 C 1197.232,124.0555 1197.011,123.7819 1196.803,123.7819 C 1196.477,123.7819 1196.315,123.9542 1196.315,124.3014 C 1196.315,125.0306 1196.675,125.6916 1197.397,126.2819 C 1198.076,126.8443 1198.79,127.1256 1199.533,127.1256 C 1201.519,127.1256 1202.999,125.7534 1203.971,123.0104 L 1204.137,122.5416 C 1204.97,120.2014 1206.216,119.0319 1207.875,119.0319 C 1208.736,119.0319 1209.345,119.2639 1209.699,119.7291 C 1209.998,120.1122 1210.15,120.7126 1210.17,121.5143 L 1209.279,121.4245 C 1208.991,121.3885 1208.726,121.3698 1208.486,121.3698 C 1207.622,121.3698 1206.981,121.6214 1206.561,122.1256 C 1206.141,122.63 1205.9,123.4294 1205.84,124.5221 L 1205.606,129.4206 V 130.2487 C 1205.606,131.9897 1206.044,133.3166 1206.92,134.2291 C 1207.809,135.1297 1209.1,135.5807 1210.793,135.5807 C 1212.474,135.5807 1213.752,135.1297 1214.629,134.2291 C 1215.518,133.3166 1215.963,132.0084 1215.963,130.3034 V 129.7799 L 1215.674,124.1256 C 1215.637,123.3932 1215.47,122.8527 1215.17,122.5045 C 1214.882,122.1443 1214.407,121.9337 1213.746,121.8737 L 1211.195,121.6178 C 1211.177,119.208 1210.087,118.0006 1207.918,118.0006 Z M 1209.783,122.0006 L 1212.27,122.2526 V 125.8541 C 1211.861,125.7941 1211.447,125.7531 1211.028,125.7291 C 1210.62,125.6931 1210.203,125.6689 1209.783,125.6569 Z M 1212.774,122.3073 L 1213.674,122.3971 C 1214.203,122.4451 1214.57,122.5997 1214.774,122.8639 C 1214.978,123.116 1215.097,123.5429 1215.133,124.1432 L 1215.26,126.4674 C 1214.468,126.2513 1213.639,126.0705 1212.774,125.9264 Z M 1209.01,126.1784 C 1210.054,126.1784 1211.092,126.251 1212.125,126.3952 C 1213.158,126.5272 1214.21,126.7379 1215.278,127.026 L 1215.422,129.817 V 130.3034 C 1215.422,133.4732 1213.884,135.0573 1210.811,135.0573 C 1207.701,135.0573 1206.147,133.4545 1206.147,130.2487 V 129.403 L 1206.289,126.3229 C 1206.757,126.2749 1207.214,126.2395 1207.658,126.2155 C 1208.114,126.1914 1208.565,126.1784 1209.01,126.1784 Z" />
+    <path
+       id="path4310"
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0228797;stroke-opacity:1"
+       d="M 1264.938,118.0006 C 1263.021,118.0006 1261.495,119.264 1260.356,121.7917 L 1259.969,122.6452 C 1259.345,124.0271 1258.816,124.9382 1258.385,125.3756 C 1257.913,125.8548 1257.306,126.0944 1256.563,126.0944 C 1255.584,126.0944 1254.89,125.5973 1254.481,124.6042 C 1254.252,124.0556 1254.033,123.7819 1253.825,123.7819 C 1253.499,123.7819 1253.335,123.9542 1253.335,124.3014 C 1253.335,125.0306 1253.697,125.6916 1254.419,126.2819 C 1255.098,126.8443 1255.81,127.1256 1256.553,127.1256 C 1258.539,127.1256 1260.021,125.7534 1260.993,123.0104 L 1261.159,122.5417 C 1261.992,120.2015 1263.236,119.0319 1264.895,119.0319 C 1265.756,119.0319 1266.365,119.264 1266.719,119.7292 C 1267.018,120.1123 1267.17,120.7126 1267.19,121.5143 L 1266.299,121.4245 C 1266.011,121.3885 1265.746,121.3698 1265.506,121.3698 C 1264.643,121.3698 1264.003,121.6214 1263.583,122.1256 C 1263.163,122.63 1262.92,123.4294 1262.86,124.5221 L 1262.626,129.4206 V 130.2487 C 1262.626,131.9897 1263.064,133.3167 1263.94,134.2292 C 1264.829,135.1298 1266.12,135.5807 1267.813,135.5807 C 1269.494,135.5807 1270.772,135.1298 1271.649,134.2292 C 1272.538,133.3167 1272.983,132.0084 1272.983,130.3034 V 129.7799 L 1272.696,124.1256 C 1272.659,123.3932 1272.49,122.8527 1272.19,122.5045 C 1271.902,122.1443 1271.427,121.9337 1270.766,121.8737 L 1268.215,121.6178 C 1268.197,119.208 1267.107,118.0006 1264.938,118.0006 Z M 1265.506,121.8913 C 1265.602,121.8913 1265.716,121.8988 1265.848,121.9108 C 1265.993,121.9108 1266.143,121.9219 1266.299,121.9459 V 125.6374 H 1265.94 C 1265.507,125.6374 1265.07,125.6505 1264.626,125.6745 C 1264.194,125.6865 1263.766,125.7163 1263.346,125.7643 L 1263.401,124.5397 C 1263.449,123.5791 1263.636,122.9007 1263.96,122.5045 C 1264.284,122.0963 1264.799,121.8913 1265.506,121.8913 Z M 1269.794,122.3073 L 1270.696,122.3971 C 1271.225,122.4451 1271.59,122.5997 1271.794,122.8639 C 1271.998,123.116 1272.119,123.5429 1272.155,124.1432 L 1272.282,126.4674 C 1271.49,126.2513 1270.659,126.0705 1269.794,125.9264 Z M 1266.032,126.1784 C 1267.076,126.1784 1268.112,126.251 1269.145,126.3952 C 1270.178,126.5272 1271.23,126.7379 1272.298,127.026 L 1272.442,129.817 V 130.3034 C 1272.442,133.4732 1270.906,135.0573 1267.833,135.0573 C 1264.723,135.0573 1263.169,133.4545 1263.169,130.2487 V 129.403 L 1263.309,126.3229 C 1263.777,126.2749 1264.234,126.2395 1264.678,126.2155 C 1265.134,126.1914 1265.587,126.1784 1266.032,126.1784 Z" />
+    <path
+       id="path4306"
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0228797;stroke-opacity:1"
+       d="M 1321.999,118.0006 C 1320.082,118.0006 1318.556,119.2639 1317.417,121.7916 L 1317.03,122.6452 C 1316.406,124.0271 1315.877,124.9382 1315.446,125.3756 C 1314.974,125.8548 1314.367,126.0944 1313.624,126.0944 C 1312.645,126.0944 1311.951,125.5972 1311.542,124.6041 C 1311.313,124.0555 1311.091,123.7819 1310.883,123.7819 C 1310.557,123.7819 1310.395,123.9542 1310.395,124.3014 C 1310.395,125.0306 1310.755,125.6916 1311.477,126.2819 C 1312.156,126.8443 1312.871,127.1256 1313.614,127.1256 C 1315.6,127.1256 1317.079,125.7534 1318.051,123.0104 L 1318.217,122.5416 C 1319.05,120.2014 1320.297,119.0319 1321.956,119.0319 C 1322.817,119.0319 1323.426,119.2639 1323.78,119.7291 C 1324.079,120.1122 1324.231,120.7126 1324.251,121.5143 L 1323.36,121.4245 C 1323.072,121.3885 1322.807,121.3698 1322.567,121.3698 C 1321.703,121.3698 1321.061,121.6214 1320.641,122.1256 C 1320.221,122.63 1319.981,123.4294 1319.921,124.5221 L 1319.686,129.4206 V 130.2487 C 1319.686,131.9897 1320.125,133.3166 1321.001,134.2291 C 1321.89,135.1297 1323.181,135.5807 1324.874,135.5807 C 1326.555,135.5807 1327.833,135.1297 1328.71,134.2291 C 1329.599,133.3166 1330.044,132.0084 1330.044,130.3034 V 129.7799 L 1329.755,124.1256 C 1329.718,123.3932 1329.551,122.8527 1329.251,122.5045 C 1328.963,122.1443 1328.488,121.9337 1327.827,121.8737 L 1325.276,121.6178 C 1325.258,119.208 1324.168,118.0006 1321.999,118.0006 Z M 1322.567,121.8913 C 1322.663,121.8913 1322.777,121.8988 1322.909,121.9108 C 1323.054,121.9108 1323.204,121.9219 1323.36,121.9459 V 125.6374 H 1323.001 C 1322.568,125.6374 1322.13,125.6505 1321.686,125.6745 C 1321.254,125.6865 1320.827,125.7163 1320.407,125.7643 L 1320.462,124.5397 C 1320.51,123.5791 1320.694,122.9007 1321.018,122.5045 C 1321.342,122.0963 1321.859,121.8913 1322.567,121.8913 Z M 1323.864,122.0006 L 1326.35,122.2526 V 125.8541 C 1325.941,125.7941 1325.528,125.7531 1325.108,125.7291 C 1324.7,125.6931 1324.284,125.6689 1323.864,125.6569 Z M 1323.09,126.1784 C 1324.134,126.1784 1325.173,126.251 1326.206,126.3952 C 1327.239,126.5272 1328.29,126.7379 1329.358,127.026 L 1329.503,129.817 V 130.3034 C 1329.503,133.4732 1327.964,135.0573 1324.891,135.0573 C 1321.781,135.0573 1320.227,133.4545 1320.227,130.2487 V 129.403 L 1320.37,126.3229 C 1320.838,126.2749 1321.295,126.2395 1321.739,126.2155 C 1322.195,126.1914 1322.645,126.1784 1323.09,126.1784 Z" />
+    <path
+       id="path4473"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.3324px;line-height:1.25;font-family:FontAwesome;-inkscape-font-specification:'FontAwesome Bold';word-spacing:0px;stroke-width:0.999948"
+       d="M 1231.829,279.0537 L 1221.925,269.1489 C 1221.809,269.0232 1221.655,268.9652 1221.49,268.9652 C 1221.413,268.9652 1221.326,268.9845 1221.258,269.0135 C 1221.026,269.1102 1220.871,269.3327 1220.871,269.5842 V 284.1318 C 1220.871,284.3833 1221.026,284.6057 1221.258,284.7025 C 1221.326,284.7315 1221.413,284.7508 1221.49,284.7508 C 1221.655,284.7508 1221.809,284.6831 1221.925,284.567 L 1224.943,281.5492 L 1226.789,285.9212 C 1226.925,286.2307 1227.283,286.3855 1227.602,286.2501 L 1229.314,285.5246 C 1229.623,285.3892 1229.778,285.0313 1229.643,284.7121 L 1227.699,280.108 H 1231.393 C 1231.645,280.108 1231.867,279.9533 1231.964,279.721 C 1232.061,279.4986 1232.012,279.2277 1231.829,279.0537 Z M 1221.259,274.0487 C 1220.872,274.0487 1220.56,274.3594 1220.56,274.7474 V 275.9527 C 1220.56,276.3407 1220.872,276.6514 1221.259,276.6514 C 1221.646,276.6514 1221.958,276.3407 1221.958,275.9527 V 274.7474 C 1221.958,274.3594 1221.646,274.0487 1221.259,274.0487 M 1224.855,272.566 C 1224.68,272.566 1224.503,272.6327 1224.367,272.7634 C 1224.091,273.0327 1224.084,273.474 1224.354,273.75 L 1225.112,274.5087 C 1225.243,274.6394 1225.42,274.7154 1225.604,274.7154 C 1225.788,274.7154 1225.967,274.642 1226.1,274.5127 C 1226.372,274.2394 1226.372,273.798 1226.1,273.5247 L 1225.342,272.766 C 1225.208,272.6327 1225.034,272.566 1224.855,272.566 M 1217.675,272.554 C 1217.495,272.554 1217.314,272.6234 1217.174,272.7634 L 1216.415,273.522 C 1216.286,273.6514 1216.212,273.83 1216.212,274.0167 C 1216.212,274.4047 1216.523,274.7154 1216.91,274.7154 C 1217.095,274.7154 1217.272,274.642 1217.402,274.5087 L 1218.16,273.75 L 1218.174,273.738 C 1218.443,273.462 1218.438,273.0207 1218.16,272.75 C 1218.024,272.6207 1217.85,272.554 1217.675,272.554 M 1216.18,268.97 H 1214.974 C 1214.587,268.97 1214.276,269.2807 1214.276,269.6687 C 1214.276,270.0554 1214.587,270.366 1214.974,270.366 H 1216.18 C 1216.567,270.366 1216.879,270.0554 1216.879,269.6687 C 1216.879,269.2807 1216.567,268.97 1216.18,268.97 M 1227.544,268.97 H 1226.338 C 1225.951,268.97 1225.639,269.2807 1225.639,269.6687 C 1225.639,270.0554 1225.951,270.366 1226.338,270.366 H 1227.544 C 1227.931,270.366 1228.242,270.0554 1228.242,269.6687 C 1228.242,269.2807 1227.931,268.97 1227.544,268.97 M 1221.259,266.43 C 1219.472,266.43 1218.022,267.8807 1218.022,269.6687 C 1218.022,271.4554 1219.472,272.906 1221.259,272.906 C 1223.046,272.9034 1224.494,271.4554 1224.496,269.6687 C 1224.496,267.8807 1223.046,266.43 1221.259,266.43 M 1225.604,264.6247 C 1225.43,264.6247 1225.252,264.6914 1225.119,264.8207 L 1224.36,265.5794 C 1224.23,265.71 1224.158,265.8874 1224.158,266.0714 C 1224.158,266.4594 1224.468,266.77 1224.855,266.77 C 1225.039,266.77 1225.218,266.6967 1225.347,266.5674 L 1226.106,265.8087 C 1226.37,265.538 1226.37,265.1034 1226.106,264.834 C 1225.967,264.698 1225.786,264.6247 1225.604,264.6247 M 1216.914,264.6247 C 1216.739,264.6247 1216.562,264.6914 1216.424,264.8207 C 1216.148,265.0914 1216.142,265.5327 1216.412,265.8087 L 1217.171,266.5674 C 1217.3,266.6967 1217.479,266.77 1217.663,266.77 C 1217.847,266.77 1218.024,266.6967 1218.155,266.5674 C 1218.427,266.294 1218.427,265.8527 1218.155,265.5794 L 1217.396,264.8207 C 1217.266,264.6914 1217.091,264.6247 1216.914,264.6247 M 1221.259,262.6847 C 1220.872,262.6847 1220.56,262.9967 1220.56,263.3834 V 264.59 C 1220.56,264.9767 1220.872,265.2874 1221.259,265.2874 C 1221.646,265.2874 1221.958,264.9767 1221.958,264.59 V 263.3834 C 1221.958,262.9967 1221.646,262.6847 1221.259,262.6847 M 1221.259,267.446 C 1222.484,267.446 1223.48,268.4434 1223.48,269.6687 C 1223.48,270.894 1222.482,271.89 1221.259,271.89 C 1220.034,271.89 1219.038,270.894 1219.038,269.6687 C 1219.038,268.4434 1220.034,267.446 1221.259,267.446" />
+    <path
+       id="path679-3-6-0"
+       clip-path="url(#clipPath680-9-5-4)"
+       style="display:inline;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,1335.024,200.3135)"
+       d="M 0,0 C -0.29,0 -0.524,-0.233 -0.524,-0.524 V -1.428 C -0.524,-1.719 -0.29,-1.952 0,-1.952 C 0.29,-1.952 0.524,-1.719 0.524,-1.428 V -0.524 C 0.524,-0.233 0.29,0 0,0 M 2.697,1.112 C 2.566,1.112 2.433,1.062 2.331,0.964 C 2.124,0.762 2.119,0.431 2.321,0.224 L 2.89,-0.345 C 2.988,-0.443 3.121,-0.5 3.259,-0.5 C 3.397,-0.5 3.531,-0.445 3.631,-0.348 C 3.835,-0.143 3.835,0.188 3.631,0.393 L 3.062,0.962 C 2.962,1.062 2.831,1.112 2.697,1.112 M -2.688,1.121 C -2.823,1.121 -2.959,1.069 -3.064,0.964 L -3.633,0.395 C -3.73,0.298 -3.785,0.164 -3.785,0.024 C -3.785,-0.267 -3.552,-0.5 -3.262,-0.5 C -3.123,-0.5 -2.99,-0.445 -2.893,-0.345 L -2.324,0.224 L -2.314,0.233 C -2.112,0.44 -2.116,0.771 -2.324,0.974 C -2.426,1.071 -2.557,1.121 -2.688,1.121 M -3.809,3.809 H -4.714 C -5.004,3.809 -5.237,3.576 -5.237,3.285 C -5.237,2.995 -5.004,2.762 -4.714,2.762 H -3.809 C -3.519,2.762 -3.285,2.995 -3.285,3.285 C -3.285,3.576 -3.519,3.809 -3.809,3.809 M 4.714,3.809 H 3.809 C 3.519,3.809 3.285,3.576 3.285,3.285 C 3.285,2.995 3.519,2.762 3.809,2.762 H 4.714 C 5.004,2.762 5.237,2.995 5.237,3.285 C 5.237,3.576 5.004,3.809 4.714,3.809 M 0,5.714 C -1.34,5.714 -2.428,4.626 -2.428,3.285 C -2.428,1.945 -1.34,0.857 0,0.857 C 1.34,0.859 2.426,1.945 2.428,3.285 C 2.428,4.626 1.34,5.714 0,5.714 M 3.259,7.068 C 3.128,7.068 2.995,7.018 2.895,6.921 L 2.326,6.352 C 2.228,6.254 2.174,6.121 2.174,5.983 C 2.174,5.692 2.407,5.459 2.697,5.459 C 2.835,5.459 2.969,5.514 3.066,5.611 L 3.635,6.18 C 3.833,6.383 3.833,6.709 3.635,6.911 C 3.531,7.013 3.395,7.068 3.259,7.068 M -3.259,7.068 C -3.39,7.068 -3.523,7.018 -3.626,6.921 C -3.833,6.718 -3.838,6.387 -3.635,6.18 L -3.066,5.611 C -2.969,5.514 -2.835,5.459 -2.697,5.459 C -2.559,5.459 -2.426,5.514 -2.328,5.611 C -2.124,5.816 -2.124,6.147 -2.328,6.352 L -2.897,6.921 C -2.995,7.018 -3.126,7.068 -3.259,7.068 M 0,8.523 C -0.29,8.523 -0.524,8.289 -0.524,7.999 V 7.094 C -0.524,6.804 -0.29,6.571 0,6.571 C 0.29,6.571 0.524,6.804 0.524,7.094 V 7.999 C 0.524,8.289 0.29,8.523 0,8.523 M 0,4.952 C 0.919,4.952 1.666,4.204 1.666,3.285 C 1.666,2.366 0.917,1.619 0,1.619 C -0.919,1.619 -1.666,2.366 -1.666,3.285 C -1.666,4.204 -0.919,4.952 0,4.952 M 8.148002,-3.754051 L 0.7200002,3.674551 C 0.6330002,3.768826 0.5167501,3.812326 0.3937501,3.812326 C 0.3360001,3.812326 0.2707501,3.797851 0.2197501,3.776101 C 0.04575,3.703576 -0.0705,3.536701 -0.0705,3.348076 V -7.562552 C -0.0705,-7.751252 0.04575,-7.918052 0.2197501,-7.990652 C 0.2707501,-8.012402 0.3360001,-8.026877 0.3937501,-8.026877 C 0.5167501,-8.026877 0.6330002,-7.976102 0.7200002,-7.889102 L 2.983501,-5.625676 L 4.368001,-8.904677 C 4.470001,-9.136802 4.738501,-9.252902 4.977751,-9.151352 L 6.261752,-8.607227 C 6.493502,-8.505677 6.609752,-8.237252 6.508502,-7.997852 L 5.050501,-4.544701 H 7.821002 C 8.010002,-4.544701 8.176502,-4.428676 8.249252,-4.254526 C 8.322002,-4.087726 8.285252,-3.884626 8.148002,-3.754051 Z M 1.4175,-2.250001e-4 C 1.1275,-2.250001e-4 0.8935004,-0.233225 0.8935004,-0.524225 V -1.428225 C 0.8935004,-1.719225 1.1275,-1.952225 1.4175,-1.952225 C 1.7075,-1.952225 1.9415,-1.719225 1.9415,-1.428225 V -0.524225 C 1.9415,-0.233225 1.7075,-2.250001e-4 1.4175,-2.250001e-4 M 4.1145,1.111775 C 3.9835,1.111775 3.8505,1.061775 3.7485,0.963775 C 3.5415,0.761775 3.5365,0.430775 3.7385,0.223775 L 4.3075,-0.345225 C 4.4055,-0.443225 4.5385,-0.500225 4.6765,-0.500225 C 4.8145,-0.500225 4.9485,-0.445225 5.0485,-0.348225 C 5.2525,-0.143225 5.2525,0.187775 5.0485,0.392775 L 4.4795,0.961775 C 4.3795,1.061775 4.2485,1.111775 4.1145,1.111775 M -1.2705,1.120775 C -1.4055,1.120775 -1.5415,1.068775 -1.6465,0.963775 L -2.2155,0.394775 C -2.3125,0.297775 -2.3675,0.163775 -2.3675,0.023775 C -2.3675,-0.267225 -2.1345,-0.500225 -1.8445,-0.500225 C -1.7055,-0.500225 -1.5725,-0.445225 -1.4755,-0.345225 L -0.9064996,0.223775 L -0.8964996,0.232775 C -0.6944996,0.439775 -0.6984996,0.770775 -0.9064996,0.973775 C -1.0085,1.070775 -1.1395,1.120775 -1.2705,1.120775 M -2.3915,3.808775 H -3.2965 C -3.5865,3.808775 -3.8195,3.575775 -3.8195,3.284775 C -3.8195,2.994775 -3.5865,2.761775 -3.2965,2.761775 H -2.3915 C -2.1015,2.761775 -1.8675,2.994775 -1.8675,3.284775 C -1.8675,3.575775 -2.1015,3.808775 -2.3915,3.808775 M 6.1315,3.808775 H 5.2265 C 4.9365,3.808775 4.7025,3.575775 4.7025,3.284775 C 4.7025,2.994775 4.9365,2.761775 5.2265,2.761775 H 6.1315 C 6.4215,2.761775 6.6545,2.994775 6.6545,3.284775 C 6.6545,3.575775 6.4215,3.808775 6.1315,3.808775 M 1.4175,5.713775 C 0.0775004,5.713775 -1.0105,4.625775 -1.0105,3.284775 C -1.0105,1.944775 0.0775004,0.856775 1.4175,0.856775 C 2.7575,0.858775 3.8435,1.944775 3.8455,3.284775 C 3.8455,4.625775 2.7575,5.713775 1.4175,5.713775 M 4.6765,7.067775 C 4.5455,7.067775 4.4125,7.017775 4.3125,6.920775 L 3.7435,6.351775 C 3.6455,6.253775 3.5915,6.120775 3.5915,5.982775 C 3.5915,5.691775 3.8245,5.458775 4.1145,5.458775 C 4.2525,5.458775 4.3865,5.513775 4.4835,5.610775 L 5.0525,6.179775 C 5.2505,6.382775 5.2505,6.708775 5.0525,6.910775 C 4.9485,7.012775 4.8125,7.067775 4.6765,7.067775 M -1.8415,7.067775 C -1.9725,7.067775 -2.1055,7.017775 -2.2085,6.920775 C -2.4155,6.717775 -2.4205,6.386775 -2.2175,6.179775 L -1.6485,5.610775 C -1.5515,5.513775 -1.4175,5.458775 -1.2795,5.458775 C -1.1415,5.458775 -1.0085,5.513775 -0.9104996,5.610775 C -0.7064996,5.815775 -0.7064996,6.146775 -0.9104996,6.351775 L -1.4795,6.920775 C -1.5775,7.017775 -1.7085,7.067775 -1.8415,7.067775 M 1.4175,8.522775 C 1.1275,8.522775 0.8935004,8.288775 0.8935004,7.998775 V 7.093775 C 0.8935004,6.803775 1.1275,6.570775 1.4175,6.570775 C 1.7075,6.570775 1.9415,6.803775 1.9415,7.093775 V 7.998775 C 1.9415,8.288775 1.7075,8.522775 1.4175,8.522775 M 1.4175,4.951775 C 2.3365,4.951775 3.0835,4.203775 3.0835,3.284775 C 3.0835,2.365775 2.3345,1.618775 1.4175,1.618775 C 0.4985004,1.618775 -0.2484996,2.365775 -0.2484996,3.284775 C -0.2484996,4.203775 0.4985004,4.951775 1.4175,4.951775" />
+    <path
+       d="M 935.445,486.4349 L 938.8812,487.8145 L 938.5849,488.5846 L 933.7099,486.4772 V 485.3516 L 938.5849,483.2442 L 938.8812,484.0143 L 935.445,485.3939 H 948.2249 V 486.4349 Z"
+       id="path4534"
+       style="font-weight:bold;font-size:17.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 957.9664,487.8568 L 959.4644,488.8132 L 958.999,489.5749 L 953.8277,486.2572 V 485.5632 L 958.999,482.237 L 959.4644,483.0072 L 957.9664,483.9551 H 969.1721 V 484.7422 H 956.7307 L 955.0042,485.9102 L 956.7307,487.0781 H 969.1721 V 487.8568 Z"
+       id="path4536"
+       style="font-weight:bold;font-size:17.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1017.561,413.1303 L 1016.173,409.6942 V 422.6433 H 1015.149 V 409.6942 L 1013.769,413.1303 L 1012.991,412.8257 L 1015.09,407.9591 H 1016.232 L 1018.331,412.8257 Z"
+       id="path4539"
+       style="font-weight:bold;font-size:17.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1030.832,413.3504 L 1029.892,411.8439 V 422.8973 H 1029.097 V 410.6167 L 1027.937,408.8986 L 1026.769,410.6167 V 422.8973 H 1025.982 V 411.8439 L 1025.034,413.3504 L 1024.264,412.8849 L 1027.582,407.7052 H 1028.284 L 1031.61,412.8849 Z"
+       id="path4541"
+       style="font-weight:bold;font-size:17.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1016.232,493.502 H 1015.09 L 1012.991,488.627 L 1013.769,488.3307 L 1015.149,491.7669 V 478.8177 H 1016.173 V 491.7669 L 1017.561,488.3307 L 1018.331,488.627 Z"
+       id="path4553"
+       style="font-weight:bold;font-size:17.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1028.284,493.7559 H 1027.582 L 1024.264,488.5762 L 1025.034,488.1107 L 1025.982,489.6172 V 478.5638 H 1026.769 V 490.8444 L 1027.937,492.5625 L 1029.097,490.8444 V 478.5638 H 1029.892 V 489.6172 L 1030.832,488.1107 L 1031.61,488.5762 Z"
+       id="path4555"
+       style="font-weight:bold;font-size:17.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1085.09,488.5846 L 1084.794,487.8145 L 1088.23,486.4349 H 1075.45 V 485.3939 H 1088.23 L 1084.794,484.0143 L 1085.09,483.2442 L 1089.965,485.3516 V 486.4772 Z"
+       id="path4558"
+       style="font-weight:bold;font-size:17.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1105.741,489.5749 L 1105.276,488.8132 L 1106.774,487.8568 H 1095.568 V 487.0781 H 1108.009 L 1109.736,485.9102 L 1108.009,484.7422 H 1095.568 V 483.9551 H 1106.774 L 1105.276,483.0072 L 1105.741,482.237 L 1110.912,485.5632 V 486.2572 Z"
+       id="path4560"
+       style="font-weight:bold;font-size:17.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1110.543,124.0982 Q 1110.584,124.1816 1110.584,124.2962 Q 1110.584,124.4941 1110.449,124.6503 Q 1110.324,124.7962 1110.115,124.7962 Q 1109.918,124.7962 1109.751,124.6607 Q 1109.595,124.5149 1109.595,124.2962 Q 1109.595,124.1087 1109.74,123.9524 Q 1109.897,123.7962 1110.105,123.7962 Q 1110.418,123.7962 1110.543,124.0982 Z M 1113.824,132.0045 Q 1113.865,132.1295 1113.865,132.192 Q 1113.865,132.3795 1113.72,132.5357 Q 1113.574,132.692 1113.365,132.692 Q 1113.178,132.692 1113.022,132.5461 Q 1112.865,132.4003 1112.865,132.1816 Q 1112.865,132.0045 1113.001,131.8482 Q 1113.136,131.692 1113.334,131.692 Q 1113.668,131.692 1113.824,132.0045 Z M 1109.043,124.8691 Q 1109.199,125.0045 1109.199,125.2128 Q 1109.199,125.7128 1108.709,125.7128 Q 1108.501,125.7128 1108.355,125.5774 Q 1108.209,125.4316 1108.209,125.2337 Q 1108.209,125.0253 1108.355,124.8795 Q 1108.501,124.7232 1108.699,124.7232 Q 1108.897,124.7232 1109.043,124.8691 Z M 1115.105,130.9107 Q 1115.251,131.0566 1115.251,131.2649 Q 1115.251,131.4628 1115.105,131.6086 Q 1114.97,131.7545 1114.751,131.7545 Q 1114.543,131.7545 1114.397,131.6086 Q 1114.251,131.4628 1114.251,131.2649 Q 1114.251,131.0566 1114.386,130.9211 Q 1114.532,130.7753 1114.73,130.7753 Q 1114.938,130.7753 1115.105,130.9107 Z M 1107.959,126.1503 Q 1108.282,126.2857 1108.282,126.6295 Q 1108.282,126.8274 1108.115,126.9732 Q 1107.959,127.1087 1107.772,127.1087 Q 1107.553,127.1087 1107.418,126.9524 Q 1107.282,126.7962 1107.282,126.6087 Q 1107.282,126.4003 1107.428,126.2545 Q 1107.584,126.1087 1107.772,126.1087 Q 1107.834,126.1087 1107.959,126.1503 Z M 1115.865,129.4211 Q 1116.178,129.5566 1116.178,129.8795 Q 1116.178,130.0878 1116.022,130.2336 Q 1115.876,130.3691 1115.678,130.3691 Q 1115.449,130.3691 1115.313,130.2232 Q 1115.178,130.067 1115.178,129.8795 Q 1115.178,129.6399 1115.334,129.5149 Q 1115.501,129.3899 1115.688,129.3899 Q 1115.793,129.3899 1115.865,129.4211 Z M 1107.449,127.7545 Q 1107.647,127.7545 1107.803,127.9003 Q 1107.959,128.0357 1107.959,128.2337 Q 1107.959,128.442 1107.803,128.5982 Q 1107.647,128.7441 1107.459,128.7441 H 1107.438 Q 1107.24,128.7441 1107.095,128.5982 Q 1106.959,128.442 1106.959,128.2441 Q 1106.959,128.0357 1107.095,127.9003 Q 1107.24,127.7545 1107.449,127.7545 Z M 1116.001,127.7441 Q 1116.209,127.7441 1116.355,127.8899 Q 1116.501,128.0357 1116.501,128.2441 Q 1116.501,128.442 1116.355,128.5878 Q 1116.22,128.7336 1116.011,128.7336 H 1115.97 Q 1115.782,128.7336 1115.636,128.5878 Q 1115.501,128.442 1115.501,128.2545 Q 1115.501,128.0462 1115.657,127.9003 Q 1115.813,127.7545 1116.001,127.7441 Z M 1107.584,129.4316 Q 1107.668,129.3899 1107.782,129.3899 Q 1107.99,129.3899 1108.136,129.5253 Q 1108.282,129.6607 1108.282,129.8691 Q 1108.282,130.067 1108.136,130.2232 Q 1107.99,130.3795 1107.782,130.3795 Q 1107.584,130.3795 1107.428,130.2336 Q 1107.282,130.0774 1107.282,129.8691 Q 1107.282,129.5461 1107.584,129.4316 Z M 1115.49,126.1503 Q 1115.615,126.1087 1115.678,126.1087 Q 1115.865,126.1087 1116.022,126.2545 Q 1116.178,126.4003 1116.178,126.6087 Q 1116.178,126.7962 1116.032,126.9524 Q 1115.886,127.1087 1115.668,127.1087 Q 1115.48,127.1087 1115.334,126.9628 Q 1115.188,126.817 1115.188,126.6191 Q 1115.188,126.2857 1115.49,126.1503 Z M 1108.355,130.9316 Q 1108.511,130.7753 1108.688,130.7753 Q 1108.907,130.7753 1109.053,130.9211 Q 1109.199,131.0566 1109.199,131.2649 Q 1109.199,131.4628 1109.053,131.6191 Q 1108.918,131.7649 1108.709,131.7649 Q 1108.511,131.7649 1108.355,131.6191 Q 1108.209,131.4628 1108.209,131.2649 Q 1108.209,131.0774 1108.355,130.9316 Z M 1114.397,124.8691 Q 1114.563,124.7232 1114.751,124.7232 Q 1114.959,124.7232 1115.095,124.8691 Q 1115.24,125.0149 1115.24,125.2232 Q 1115.24,125.4212 1115.095,125.5774 Q 1114.959,125.7232 1114.751,125.7232 Q 1114.553,125.7232 1114.407,125.567 Q 1114.261,125.4107 1114.261,125.2232 Q 1114.261,125.0253 1114.397,124.8691 Z M 1109.636,132.0149 Q 1109.699,131.8691 1109.834,131.7857 Q 1109.98,131.7024 1110.105,131.7024 Q 1110.313,131.7024 1110.449,131.8586 Q 1110.595,132.0149 1110.595,132.2024 Q 1110.595,132.4107 1110.438,132.5566 Q 1110.282,132.692 1110.095,132.692 Q 1109.897,132.692 1109.74,132.5357 Q 1109.595,132.3795 1109.595,132.2024 Q 1109.595,132.1399 1109.636,132.0149 Z M 1112.907,124.1087 Q 1113.043,123.7962 1113.365,123.7962 Q 1113.574,123.7962 1113.72,123.9524 Q 1113.865,124.1087 1113.865,124.3066 Q 1113.865,124.5149 1113.709,124.6607 Q 1113.553,124.7962 1113.365,124.7962 Q 1113.157,124.7962 1113.011,124.6399 Q 1112.876,124.4732 1112.876,124.2857 Q 1112.876,124.2024 1112.907,124.1087 Z M 1111.24,132.5253 Q 1111.24,132.317 1111.386,132.1711 Q 1111.532,132.0253 1111.73,132.0253 Q 1111.938,132.0253 1112.084,132.1711 Q 1112.23,132.317 1112.23,132.5253 Q 1112.23,132.7232 1112.084,132.8691 Q 1111.938,133.0149 1111.73,133.0149 Q 1111.532,133.0149 1111.386,132.8691 Q 1111.24,132.7232 1111.24,132.5253 Z M 1111.24,123.9732 Q 1111.24,123.7649 1111.386,123.6191 Q 1111.532,123.4732 1111.73,123.4732 Q 1111.938,123.4732 1112.084,123.6191 Q 1112.23,123.7649 1112.23,123.9732 Q 1112.23,124.1712 1112.084,124.317 Q 1111.938,124.4628 1111.73,124.4628 Q 1111.532,124.4628 1111.386,124.317 Q 1111.24,124.1712 1111.24,123.9732 Z"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4846" />
+    <path
+       d="M 1105.834,129.0149 L 1105.501,128.692 Q 1105.553,128.4941 1105.751,128.067 Q 1105.938,127.6295 1106.032,127.4212 H 1117.615 L 1117.949,127.7545 Q 1117.897,127.9524 1117.699,128.3899 Q 1117.501,128.8274 1117.418,129.0149 Z"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4848" />
+    <path
+       d="M 1014.834,519.7337 Q 1014.834,520.3431 1014.594,520.8001 Q 1014.36,521.2571 1013.979,521.5618 Q 1013.604,521.8665 1013.17,522.0189 Q 1012.737,522.1712 1012.35,522.1712 Q 1012.08,522.1712 1011.817,522.1302 Q 1011.559,522.0833 1011.365,521.9954 L 1011.184,521.3802 Q 1011.424,521.4915 1011.606,521.5267 Q 1011.793,521.556 1011.998,521.556 Q 1012.338,521.556 1012.649,521.3919 Q 1012.959,521.222 1013.158,520.8763 Q 1013.358,520.5247 1013.358,519.9739 Q 1013.358,519.1419 1012.83,518.7142 Q 1012.309,518.2806 1011.471,518.2806 Q 1011.061,518.2806 1010.563,518.3216 Q 1010.065,518.3626 1009.578,518.4212 Q 1009.092,518.4798 1008.717,518.5501 L 1008.641,518.011 Q 1009.063,517.9056 1009.602,517.8294 Q 1010.141,517.7474 1010.715,517.7064 Q 1011.289,517.6595 1011.805,517.6595 Q 1013.164,517.6595 1013.996,518.1927 Q 1014.834,518.7259 1014.834,519.7337 Z M 1008.717,525.2181 V 524.7903 Q 1009.52,524.6263 1009.52,524.4329 V 518.2571 H 1010.985 V 524.4329 Q 1010.985,524.5032 1011.166,524.597 Q 1011.354,524.6907 1011.969,524.7903 V 525.2181 Z"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4902" />
+    <path
+       d="M 1019.961,523.7825 Q 1019.504,524.4153 1019.147,524.7669 Q 1018.789,525.1185 1018.449,525.2532 Q 1018.115,525.3939 1017.705,525.3939 Q 1017.201,525.3939 1016.727,525.095 Q 1016.258,524.7903 1015.953,524.222 Q 1015.649,523.6478 1015.649,522.8392 Q 1015.649,522.3353 1015.836,521.7728 Q 1016.029,521.2103 1016.393,520.7181 Q 1016.762,520.22 1017.289,519.9095 Q 1017.822,519.5931 1018.496,519.5931 Q 1018.848,519.5931 1019.141,519.7161 Q 1019.44,519.8392 1019.903,520.2962 Q 1019.903,520.9818 1019.551,521.1927 Q 1019.369,520.8235 1019.082,520.595 Q 1018.801,520.3665 1018.449,520.3665 Q 1017.764,520.3665 1017.406,520.97 Q 1017.055,521.5735 1017.055,522.5286 Q 1017.055,523.0911 1017.242,523.4837 Q 1017.43,523.8704 1017.723,524.0755 Q 1018.022,524.2806 1018.344,524.2806 Q 1018.561,524.2806 1018.883,524.1341 Q 1019.205,523.9818 1019.744,523.39 Q 1019.809,523.4251 1019.867,523.5833 Q 1019.926,523.7357 1019.961,523.7825 Z M 1021.098,519.8099 Q 1021.039,519.9739 1020.975,520.3021 Q 1020.916,520.6302 1020.922,521.0169 L 1021.01,524.4857 Q 1021.033,525.2884 1020.811,525.886 Q 1020.594,526.4896 1020.231,526.9114 Q 1019.867,527.3392 1019.44,527.597 Q 1019.012,527.8607 1018.602,527.9778 Q 1018.197,528.1009 1017.899,528.1009 Q 1017.324,528.1009 1016.838,527.9427 Q 1016.352,527.7903 1016.059,527.5794 Q 1015.766,527.3743 1015.766,527.2161 Q 1015.766,527.1575 1015.901,527.011 Q 1016.041,526.8704 1016.235,526.7064 Q 1016.434,526.5423 1016.615,526.4134 Q 1016.803,526.2903 1016.897,526.261 Q 1017.289,526.7532 1017.641,526.97 Q 1017.998,527.1927 1018.373,527.1927 Q 1018.69,527.1927 1018.971,527.0403 Q 1019.252,526.888 1019.416,526.4017 Q 1019.586,525.9212 1019.574,524.9427 L 1019.516,520.3372 Q 1019.645,520.2962 1019.908,520.1614 Q 1020.178,520.0267 1020.447,519.8685 Q 1020.723,519.7044 1020.875,519.5872 Z"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4904" />
+    <path
+       d="M 1021.731,525.2181 V 524.7903 Q 1022.533,524.6263 1022.533,524.4329 V 518.4329 Q 1022.305,518.4681 1022.1,518.4974 Q 1021.895,518.5267 1021.731,518.5501 L 1021.654,518.011 Q 1022.041,517.9114 1022.598,517.8353 Q 1023.16,517.7532 1023.758,517.7064 Q 1024.362,517.6595 1024.865,517.6595 Q 1026.658,517.6595 1027.643,518.6087 Q 1028.633,519.5579 1028.633,521.2571 Q 1028.633,522.3528 1028.311,523.1146 Q 1027.988,523.8704 1027.467,524.3392 Q 1026.945,524.8021 1026.324,525.013 Q 1025.709,525.2181 1025.106,525.2181 H 1024.631 Q 1023.945,525.2181 1023.354,525.2181 Q 1022.768,525.2181 1021.959,525.2181 Z M 1024.889,524.5911 Q 1025.229,524.5911 1025.604,524.4153 Q 1025.985,524.2396 1026.313,523.8646 Q 1026.647,523.4896 1026.852,522.9036 Q 1027.063,522.3118 1027.063,521.4857 Q 1027.063,519.9271 1026.389,519.1068 Q 1025.721,518.2806 1024.444,518.2806 Q 1024.338,518.2806 1024.227,518.2864 Q 1024.115,518.2923 1023.998,518.2982 V 524.2278 Q 1023.998,524.4622 1024.268,524.5267 Q 1024.537,524.5911 1024.889,524.5911 Z"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4906" />
+    <path
+       d="M 1033.004,525.2181 V 524.7903 Q 1033.426,524.679 1033.602,524.597 Q 1033.778,524.5091 1033.778,524.4329 V 521.7728 Q 1033.778,521.1282 1033.643,520.8939 Q 1033.508,520.6595 1033.162,520.6595 Q 1032.881,520.6595 1032.512,520.8294 Q 1032.149,520.9935 1031.58,521.4739 V 524.4329 Q 1031.58,524.6263 1032.36,524.7903 V 525.2181 H 1029.401 V 524.7903 Q 1030.174,524.5853 1030.174,524.4329 V 521.181 Q 1030.174,520.8763 1030.139,520.7357 Q 1030.104,520.5892 1029.94,520.5306 Q 1029.781,520.472 1029.401,520.4251 V 520.015 Q 1029.957,519.9564 1030.385,519.8568 Q 1030.819,519.7571 1031.246,519.5931 L 1031.492,519.8392 L 1031.557,520.6829 Q 1032.237,520.1028 1032.834,519.8509 Q 1033.432,519.5931 1033.889,519.5931 Q 1034.393,519.5931 1034.785,519.9329 Q 1035.184,520.2728 1035.184,521.0931 V 524.4329 Q 1035.184,524.5091 1035.342,524.5911 Q 1035.5,524.6732 1035.963,524.7903 V 525.2181 Z"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4908" />
+    <path
+       d="M 1014.901,448.8748 Q 1014.901,449.4842 1014.661,449.9412 Q 1014.427,450.3983 1014.046,450.7029 Q 1013.671,451.0076 1013.237,451.16 Q 1012.803,451.3123 1012.417,451.3123 Q 1012.147,451.3123 1011.884,451.2713 Q 1011.626,451.2244 1011.432,451.1365 L 1011.251,450.5213 Q 1011.491,450.6326 1011.673,450.6678 Q 1011.86,450.6971 1012.065,450.6971 Q 1012.405,450.6971 1012.716,450.533 Q 1013.026,450.3631 1013.225,450.0174 Q 1013.425,449.6658 1013.425,449.1151 Q 1013.425,448.283 1012.897,447.8553 Q 1012.376,447.4217 1011.538,447.4217 Q 1011.128,447.4217 1010.63,447.4627 Q 1010.132,447.5037 1009.645,447.5623 Q 1009.159,447.6209 1008.784,447.6912 L 1008.708,447.1522 Q 1009.13,447.0467 1009.669,446.9705 Q 1010.208,446.8885 1010.782,446.8475 Q 1011.356,446.8006 1011.872,446.8006 Q 1013.231,446.8006 1014.063,447.3338 Q 1014.901,447.867 1014.901,448.8748 Z M 1008.784,454.3592 V 453.9315 Q 1009.587,453.7674 1009.587,453.574 V 447.3983 H 1011.052 V 453.574 Q 1011.052,453.6443 1011.233,453.7381 Q 1011.421,453.8318 1012.036,453.9315 V 454.3592 Z"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4918" />
+    <path
+       d="M 1020.028,452.9236 Q 1019.571,453.5565 1019.214,453.908 Q 1018.856,454.2596 1018.516,454.3943 Q 1018.182,454.535 1017.772,454.535 Q 1017.268,454.535 1016.794,454.2361 Q 1016.325,453.9315 1016.02,453.3631 Q 1015.716,452.7889 1015.716,451.9803 Q 1015.716,451.4764 1015.903,450.9139 Q 1016.096,450.3514 1016.46,449.8592 Q 1016.829,449.3611 1017.356,449.0506 Q 1017.889,448.7342 1018.563,448.7342 Q 1018.915,448.7342 1019.208,448.8572 Q 1019.507,448.9803 1019.969,449.4373 Q 1019.969,450.1229 1019.618,450.3338 Q 1019.436,449.9647 1019.149,449.7361 Q 1018.868,449.5076 1018.516,449.5076 Q 1017.831,449.5076 1017.473,450.1111 Q 1017.122,450.7147 1017.122,451.6697 Q 1017.122,452.2322 1017.309,452.6248 Q 1017.497,453.0115 1017.79,453.2166 Q 1018.089,453.4217 1018.411,453.4217 Q 1018.628,453.4217 1018.95,453.2752 Q 1019.272,453.1229 1019.811,452.5311 Q 1019.876,452.5662 1019.934,452.7244 Q 1019.993,452.8768 1020.028,452.9236 Z M 1021.165,448.951 Q 1021.106,449.1151 1021.042,449.4432 Q 1020.983,449.7713 1020.989,450.158 L 1021.077,453.6268 Q 1021.1,454.4295 1020.878,455.0272 Q 1020.661,455.6307 1020.298,456.0526 Q 1019.934,456.4803 1019.507,456.7381 Q 1019.079,457.0018 1018.669,457.119 Q 1018.264,457.242 1017.966,457.242 Q 1017.391,457.242 1016.905,457.0838 Q 1016.419,456.9315 1016.126,456.7205 Q 1015.833,456.5154 1015.833,456.3572 Q 1015.833,456.2986 1015.968,456.1522 Q 1016.108,456.0115 1016.302,455.8475 Q 1016.501,455.6834 1016.682,455.5545 Q 1016.87,455.4315 1016.964,455.4022 Q 1017.356,455.8943 1017.708,456.1111 Q 1018.065,456.3338 1018.44,456.3338 Q 1018.757,456.3338 1019.038,456.1815 Q 1019.319,456.0291 1019.483,455.5428 Q 1019.653,455.0623 1019.641,454.0838 L 1019.583,449.4783 Q 1019.712,449.4373 1019.975,449.3026 Q 1020.245,449.1678 1020.514,449.0096 Q 1020.79,448.8455 1020.942,448.7283 Z"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4920" />
+    <path
+       d="M 1029.239,447.4041 Q 1028.43,447.574 1028.43,447.7674 V 451.2889 Q 1028.43,452.3143 1028.055,453.0408 Q 1027.686,453.7674 1027.03,454.1541 Q 1026.38,454.535 1025.536,454.535 Q 1024.733,454.535 1024.065,454.2361 Q 1023.397,453.9373 1022.999,453.3221 Q 1022.6,452.7068 1022.6,451.7576 V 447.7674 Q 1022.6,447.6971 1022.407,447.5916 Q 1022.219,447.4861 1021.798,447.4041 V 446.9764 H 1024.874 V 447.4041 Q 1024.065,447.574 1024.065,447.7674 V 451.3768 Q 1024.065,452.5018 1024.481,453.0936 Q 1024.897,453.6854 1025.899,453.6854 Q 1026.456,453.6854 1026.784,453.369 Q 1027.112,453.0467 1027.259,452.5369 Q 1027.405,452.0213 1027.405,451.4412 V 447.7674 Q 1027.405,447.6971 1027.212,447.5916 Q 1027.024,447.4861 1026.602,447.4041 V 446.9764 H 1029.239 Z"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4922" />
+    <path
+       d="M 1033.616,454.535 Q 1033.27,454.535 1032.901,454.3826 Q 1032.538,454.2303 1032.028,453.8729 V 456.3807 Q 1032.028,456.4744 1032.245,456.5682 Q 1032.468,456.6619 1033.018,456.744 V 457.1717 H 1029.848 V 456.744 Q 1030.622,456.5565 1030.622,456.3807 V 450.3221 Q 1030.622,450.0291 1030.581,449.8768 Q 1030.546,449.7186 1030.382,449.6541 Q 1030.218,449.5838 1029.848,449.5662 V 449.1561 Q 1030.294,449.0975 1030.593,449.0447 Q 1030.891,448.9861 1031.143,448.9158 Q 1031.395,448.8397 1031.694,448.7342 L 1031.94,448.9803 L 1031.993,449.701 Q 1032.643,449.1326 1033.112,448.9334 Q 1033.587,448.7342 1033.921,448.7342 Q 1034.454,448.7342 1034.899,449.0272 Q 1035.35,449.3143 1035.62,449.9119 Q 1035.895,450.5096 1035.895,451.4295 Q 1035.895,452.0096 1035.678,452.5604 Q 1035.462,453.1111 1035.116,453.5623 Q 1034.77,454.0076 1034.372,454.2713 Q 1033.973,454.535 1033.616,454.535 Z M 1033.218,449.7303 Q 1033.077,449.7303 1032.93,449.7772 Q 1032.79,449.824 1032.579,449.9647 Q 1032.374,450.1053 1032.028,450.3865 V 453.0233 Q 1032.444,453.2635 1032.714,453.3807 Q 1032.983,453.492 1033.177,453.5213 Q 1033.37,453.5506 1033.557,453.5506 Q 1034.009,453.5506 1034.29,453.117 Q 1034.577,452.6776 1034.577,451.8631 Q 1034.577,451.1131 1034.372,450.6443 Q 1034.173,450.1756 1033.862,449.9529 Q 1033.552,449.7303 1033.218,449.7303 Z"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4924" />
+    <path
+       d="M 1088.722,518.0228 Q 1088.711,518.222 1088.67,518.5501 Q 1088.635,518.8782 1088.582,519.1888 Q 1088.529,519.4993 1088.482,519.6517 H 1088.043 Q 1087.99,518.5384 1087.562,518.5384 H 1085.289 L 1085.459,517.8353 H 1088.488 Z M 1088.119,521.1165 Q 1088.025,521.2806 1087.867,521.5267 Q 1087.709,521.7669 1087.58,521.8548 Q 1087.398,521.6849 1087.152,521.6087 Q 1086.912,521.5325 1086.42,521.5325 H 1085.207 L 1085.336,520.9114 H 1087.926 Z M 1089.103,523.4368 Q 1089.074,523.7708 1089.027,524.1458 Q 1088.986,524.515 1088.939,524.8079 Q 1088.898,525.1009 1088.863,525.2181 H 1083.326 V 524.7903 Q 1084.129,524.6263 1084.129,524.4329 V 518.6263 Q 1084.129,518.556 1083.935,518.4505 Q 1083.748,518.345 1083.326,518.263 V 517.8353 H 1086.443 V 518.263 Q 1086.051,518.304 1085.822,518.3626 Q 1085.594,518.4153 1085.594,518.4974 V 524.14 Q 1085.594,524.2513 1085.676,524.3392 Q 1085.763,524.4212 1086.015,524.4681 Q 1086.273,524.515 1086.789,524.515 H 1087.369 Q 1087.908,524.515 1088.166,524.2454 Q 1088.424,523.97 1088.676,523.2845 Z"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4911" />
+    <path
+       d="M 1093.263,525.2181 V 524.7903 Q 1093.685,524.679 1093.861,524.597 Q 1094.037,524.5091 1094.037,524.4329 V 521.7728 Q 1094.037,521.1282 1093.902,520.8939 Q 1093.767,520.6595 1093.422,520.6595 Q 1093.14,520.6595 1092.771,520.8294 Q 1092.408,520.9935 1091.84,521.4739 V 524.4329 Q 1091.84,524.6263 1092.619,524.7903 V 525.2181 H 1089.66 V 524.7903 Q 1090.433,524.5853 1090.433,524.4329 V 521.181 Q 1090.433,520.8763 1090.398,520.7357 Q 1090.363,520.5892 1090.199,520.5306 Q 1090.041,520.472 1089.66,520.4251 V 520.015 Q 1090.217,519.9564 1090.644,519.8568 Q 1091.078,519.7571 1091.506,519.5931 L 1091.752,519.8392 L 1091.816,520.6829 Q 1092.496,520.1028 1093.094,519.8509 Q 1093.691,519.5931 1094.148,519.5931 Q 1094.652,519.5931 1095.045,519.9329 Q 1095.443,520.2728 1095.443,521.0931 V 524.4329 Q 1095.443,524.5091 1095.601,524.5911 Q 1095.76,524.6732 1096.222,524.7903 V 525.2181 Z"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4913" />
+    <path
+       d="M 1103.037,524.5501 Q 1102.679,524.7903 1102.316,524.9837 Q 1101.959,525.1712 1101.683,525.2825 Q 1101.408,525.3939 1101.297,525.3939 Q 1100.717,525.3939 1100.717,523.4485 V 517.929 Q 1100.717,517.4954 1100.676,517.2962 Q 1100.64,517.0911 1100.47,517.0208 Q 1100.301,516.9505 1099.914,516.9212 V 516.5169 Q 1100.552,516.4525 1101.074,516.347 Q 1101.595,516.2357 1101.9,516.136 L 1102.123,516.3528 V 523.4661 Q 1102.123,523.8763 1102.152,524.0403 Q 1102.187,524.1985 1102.258,524.2454 Q 1102.322,524.2864 1102.439,524.2747 Q 1102.556,524.2571 1102.873,524.1224 Z M 1101.15,523.9583 Q 1100.67,524.4739 1100.318,524.7903 Q 1099.967,525.1068 1099.633,525.2474 Q 1099.304,525.3939 1098.877,525.3939 Q 1098.355,525.3939 1097.863,525.0657 Q 1097.371,524.7318 1097.049,524.1107 Q 1096.732,523.4837 1096.732,522.6165 Q 1096.732,521.8314 1097.095,521.1458 Q 1097.459,520.4544 1098.097,520.0267 Q 1098.742,519.5931 1099.58,519.5931 Q 1099.931,519.5931 1100.289,519.7103 Q 1100.646,519.8275 1101.103,520.2493 Q 1101.103,520.9407 1100.758,521.1458 Q 1100.547,520.7767 1100.219,520.5716 Q 1099.896,520.3665 1099.486,520.3665 Q 1098.906,520.3665 1098.519,520.8294 Q 1098.138,521.2864 1098.138,522.3001 Q 1098.138,522.9212 1098.338,523.3665 Q 1098.537,523.806 1098.842,524.0462 Q 1099.146,524.2806 1099.469,524.2806 Q 1099.82,524.2806 1100.142,524.0872 Q 1100.47,523.888 1100.892,523.4778 Q 1100.939,523.5013 1100.992,523.6068 Q 1101.051,523.7122 1101.092,523.8235 Q 1101.138,523.929 1101.15,523.9583 Z"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4915" />
+    <path
+       d="M 941.0554,525.2181 V 524.7903 Q 941.8581,524.6263 941.8581,524.4329 V 518.6263 Q 941.8581,518.556 941.6647,518.4505 Q 941.4772,518.345 941.0554,518.263 V 517.8353 H 944.1315 V 518.263 Q 943.3229,518.4329 943.3229,518.6263 V 524.4329 Q 943.3229,524.5032 943.5163,524.6087 Q 943.7097,524.7083 944.1315,524.7903 V 525.2181 Z M 938.6472,521.7025 V 520.9993 H 941.9753 V 521.7025 Z M 936.5436,525.2181 V 524.7903 Q 937.3464,524.6263 937.3464,524.4329 V 518.6263 Q 937.3464,518.556 937.153,518.4505 Q 936.9655,518.345 936.5436,518.263 V 517.8353 H 939.6198 V 518.263 Q 938.8112,518.4329 938.8112,518.6263 V 524.4329 Q 938.8112,524.5032 938.9987,524.6087 Q 939.1921,524.7083 939.6198,524.7903 V 525.2181 Z"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4893" />
+    <path
+       d="M 950.4069,522.3763 Q 950.4069,522.9622 950.1784,523.5013 Q 949.9499,524.0403 949.5515,524.4681 Q 949.153,524.8958 948.6315,525.1478 Q 948.11,525.3939 947.53,525.3939 Q 946.7214,525.3939 946.1237,525.0306 Q 945.5261,524.6673 945.1979,524.0403 Q 944.8698,523.4134 944.8698,522.6165 Q 944.8698,522.0364 945.0807,521.4974 Q 945.2917,520.9525 945.6784,520.5247 Q 946.0651,520.0911 946.5925,519.845 Q 947.1257,519.5931 947.7585,519.5931 Q 948.5554,519.5931 949.153,519.9564 Q 949.7507,520.3196 950.0788,520.9466 Q 950.4069,521.5735 950.4069,522.3763 Z M 948.9304,522.64 Q 948.9304,522.0189 948.7604,521.4974 Q 948.5905,520.97 948.2858,520.6478 Q 947.987,520.3255 947.5886,520.3255 Q 947.1022,520.3255 946.8327,520.6068 Q 946.5632,520.8821 946.4577,521.3626 Q 946.3522,521.8431 946.3522,522.4466 Q 946.3522,523.0618 946.5339,523.5657 Q 946.7214,524.0696 947.0261,524.3685 Q 947.3307,524.6614 947.694,524.6614 Q 948.3913,524.6614 948.6608,524.1341 Q 948.9304,523.6068 948.9304,522.64 Z"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4895" />
+    <path
+       d="M 957.8718,525.2181 V 524.7903 Q 958.2936,524.679 958.4225,524.597 Q 958.5515,524.5091 958.5515,524.4329 V 521.6849 Q 958.5515,521.2044 958.4811,520.9759 Q 958.4167,520.7415 958.2819,520.6712 Q 958.1472,520.6009 957.9362,520.6009 Q 957.6784,520.6009 957.3268,520.7825 Q 956.9811,520.9642 956.6061,521.3333 V 524.4329 Q 956.6061,524.5091 956.7409,524.5911 Q 956.8815,524.6732 957.3444,524.7903 V 525.2181 H 954.5143 V 524.7903 Q 954.9362,524.679 955.0651,524.597 Q 955.1999,524.5091 955.1999,524.4329 V 521.6849 Q 955.1999,521.2044 955.1472,520.9759 Q 955.0944,520.7415 954.9655,520.6712 Q 954.8425,520.6009 954.6257,520.6009 Q 954.0866,520.6009 953.2487,521.3333 V 524.4329 Q 953.2487,524.638 953.9811,524.7903 V 525.2181 H 951.069 V 524.7903 Q 951.8425,524.5853 951.8425,524.4329 V 521.181 Q 951.8425,520.8704 951.8073,520.7298 Q 951.7722,520.5833 951.6081,520.5306 Q 951.444,520.472 951.069,520.4251 V 520.015 Q 951.6725,519.9446 952.0827,519.845 Q 952.4987,519.7454 952.9147,519.5931 L 953.1608,519.8392 L 953.2253,520.5657 Q 953.8815,519.9857 954.3561,519.7923 Q 954.8366,519.5931 955.2585,519.5931 Q 955.8151,519.5931 956.1198,519.8509 Q 956.4304,520.1087 956.5007,520.4837 L 956.5182,520.5657 Q 957.1745,519.9974 957.655,519.7982 Q 958.1413,519.5931 958.569,519.5931 Q 959.1257,519.5931 959.5417,519.9329 Q 959.9577,520.2728 959.9577,521.0931 V 524.4329 Q 959.9577,524.5091 960.1393,524.5911 Q 960.321,524.6732 960.7839,524.7903 V 525.2181 Z"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4897" />
+    <path
+       d="M 966.3386,521.9954 Q 966.2331,522.1185 965.9694,522.265 Q 965.7057,522.4056 965.5182,522.4759 H 961.9792 L 961.9909,521.8196 H 964.7155 Q 964.8503,521.8196 964.8913,521.7786 Q 964.9382,521.7318 964.9382,521.6087 Q 964.9382,521.3743 964.8444,521.0696 Q 964.7565,520.7591 964.528,520.5306 Q 964.3054,520.2962 963.9069,520.2962 Q 963.2682,520.2962 963.0046,520.8587 Q 962.7468,521.4153 962.7468,522.347 Q 962.7468,523.2376 963.1218,523.8235 Q 963.5026,524.4095 964.2175,524.4095 Q 964.4636,524.4095 964.6979,524.3685 Q 964.9323,524.3216 965.237,524.1693 Q 965.5417,524.0169 965.9987,523.7005 Q 966.0749,523.7415 966.1745,523.888 Q 966.28,524.0286 966.3034,524.0755 Q 965.7585,524.6263 965.3542,524.9134 Q 964.9499,525.1946 964.569,525.2943 Q 964.194,525.3939 963.7253,525.3939 Q 963.0573,525.3939 962.5065,525.0482 Q 961.9557,524.7025 961.6218,524.0814 Q 961.2936,523.4544 961.2936,522.6282 Q 961.2936,521.0286 962.5007,520.1439 Q 962.8112,519.9153 963.239,519.7571 Q 963.6725,519.5931 964.1179,519.5931 Q 964.8854,519.5931 965.3718,519.9329 Q 965.864,520.2728 966.0983,520.8235 Q 966.3386,521.3685 966.3386,521.9954 Z"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path4899" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:#dfdfdf;stroke-width:0.103084;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 1053.483,167.4741 C 1053.323,167.4409 1053.276,167.2827 1053.341,166.9942 C 1053.407,166.7001 1053.383,166.6727 1053.068,166.6717 C 1052.548,166.67 1052.221,166.2958 1052.312,165.8076 C 1052.354,165.5869 1052.615,165.3298 1052.84,165.2874 C 1053.069,165.2446 1053.492,165.3888 1053.968,165.6722 L 1054.328,165.8862 L 1055.991,165.2223 C 1057.762,164.5148 1060.243,163.4739 1060.694,163.249 C 1060.843,163.1742 1061.033,163.0393 1061.114,162.9491 C 1061.257,162.7913 1061.263,162.769 1061.287,162.3437 C 1061.313,161.8602 1061.366,161.7078 1061.553,161.5692 C 1061.65,161.4975 1061.736,161.4788 1061.947,161.4832 C 1062.532,161.4953 1062.968,161.8675 1062.878,162.2782 C 1062.863,162.3449 1062.743,162.5206 1062.611,162.6687 C 1062.371,162.9381 1062.325,163.0575 1062.424,163.1561 C 1062.518,163.2498 1062.59,163.2124 1062.662,163.033 C 1062.788,162.718 1063.101,162.7562 1063.255,163.1054 C 1063.423,163.4835 1063.274,163.8487 1062.873,164.0426 C 1062.487,164.2293 1062.041,164.0801 1061.759,163.6703 C 1061.684,163.5611 1061.602,163.4717 1061.576,163.4717 C 1061.551,163.4717 1061.291,163.5871 1060.998,163.7282 C 1060.322,164.0534 1059.475,164.3931 1058.361,164.7856 C 1057.111,165.2262 1056.726,165.3781 1056.082,165.6863 C 1055.769,165.8362 1055.463,165.9737 1055.403,165.9919 C 1055.165,166.0638 1054.795,166.279 1054.686,166.4091 C 1054.589,166.5237 1054.571,166.5892 1054.571,166.8079 C 1054.571,167.029 1054.553,167.0865 1054.46,167.1799 C 1054.254,167.3858 1053.767,167.5327 1053.483,167.4741 Z M 1060.246,167.3519 C 1060.149,167.3156 1060.066,167.2856 1060.061,167.2852 C 1060,167.2812 1059.916,166.9471 1059.874,166.5395 C 1059.844,166.2507 1059.798,166.0101 1059.765,165.9759 C 1059.733,165.9432 1059.585,165.8882 1059.436,165.8537 C 1059.287,165.8193 1059.085,165.7405 1058.987,165.6787 C 1058.889,165.6169 1058.632,165.48 1058.415,165.3745 C 1058.119,165.2303 1058.041,165.1759 1058.103,165.1552 C 1058.149,165.1401 1058.318,165.0781 1058.478,165.0173 L 1058.771,164.9069 L 1059.147,165.1121 C 1059.58,165.3483 1059.956,165.4877 1060.161,165.4877 C 1060.239,165.4877 1060.482,165.4187 1060.7,165.3343 C 1060.918,165.2499 1061.148,165.1809 1061.21,165.1809 C 1061.369,165.1809 1061.71,165.3651 1061.882,165.5442 C 1062.057,165.7262 1062.117,166.0033 1062.003,166.0981 C 1061.942,166.1484 1061.878,166.1361 1061.562,166.0143 C 1061.314,165.9182 1061.156,165.8806 1061.081,165.8995 C 1060.92,165.94 1060.943,165.9983 1061.133,166.029 C 1061.51,166.0899 1061.79,166.4301 1061.744,166.7719 C 1061.691,167.1646 1061.376,167.3749 1060.8,167.4009 C 1060.533,167.4129 1060.369,167.3984 1060.246,167.3519 Z M 1056.214,164.5673 C 1055.838,164.4692 1055.319,164.2777 1054.862,164.0685 C 1054.492,163.8989 1053.872,163.6908 1053.738,163.6908 C 1053.693,163.6908 1053.558,163.7516 1053.439,163.8258 C 1052.871,164.1788 1052.327,163.9463 1052.204,163.298 C 1052.148,162.9998 1052.183,162.8058 1052.321,162.6569 C 1052.428,162.5414 1052.432,162.5407 1052.86,162.571 C 1053.129,162.5901 1053.3,162.5854 1053.317,162.5585 C 1053.332,162.5348 1053.304,162.4231 1053.256,162.3103 C 1053.207,162.1975 1053.178,162.0885 1053.191,162.0681 C 1053.232,162.0005 1053.695,161.8501 1053.86,161.8504 C 1054.257,161.851 1054.527,162.0317 1054.527,162.2967 C 1054.527,162.3671 1054.468,162.5637 1054.395,162.7336 C 1054.323,162.9036 1054.264,163.0711 1054.264,163.1058 C 1054.264,163.1959 1054.469,163.3752 1054.716,163.5007 C 1054.888,163.5879 1055.665,163.8635 1057.014,164.3152 C 1057.092,164.3414 1057.156,164.3767 1057.156,164.3934 C 1057.156,164.4102 1057.081,164.4759 1056.989,164.5395 C 1056.793,164.6756 1056.648,164.6808 1056.214,164.5673 Z M 1058.495,163.3859 C 1058.333,163.2664 1058.162,163.1561 1058.114,163.1409 C 1058.006,163.1067 1057.885,163.2088 1057.81,163.3982 C 1057.78,163.4748 1057.748,163.5458 1057.74,163.556 C 1057.732,163.5662 1057.621,163.4627 1057.494,163.3259 C 1057.366,163.1892 1057.24,163.0773 1057.213,163.0773 C 1057.186,163.0773 1057.112,163.1671 1057.047,163.2769 C 1056.918,163.4979 1056.779,163.5842 1056.618,163.5438 C 1056.516,163.5182 1056.423,163.404 1056.174,163.0006 C 1056.059,162.8132 1055.926,162.7582 1055.856,162.8691 C 1055.837,162.8992 1055.811,163.0126 1055.799,163.1211 L 1055.776,163.3183 L 1055.545,163.3316 C 1055.332,163.3438 1055.312,163.3364 1055.271,163.2301 C 1055.247,163.167 1055.228,163.0113 1055.228,162.884 C 1055.228,162.7568 1055.188,162.5362 1055.138,162.3938 C 1054.954,161.8603 1054.984,161.398 1055.205,161.3425 C 1055.258,161.329 1055.414,161.3471 1055.55,161.3827 C 1055.795,161.4467 1055.798,161.4464 1055.798,161.3517 C 1055.798,161.1623 1055.484,160.7983 1055.321,160.7983 C 1055.261,160.7983 1055.088,160.8401 1054.937,160.8912 C 1054.573,161.0142 1054.419,160.9824 1054.133,160.7249 C 1053.872,160.4898 1053.711,160.1996 1053.669,159.8888 C 1053.625,159.5518 1053.703,159.3864 1054.105,158.9669 L 1054.461,158.5958 L 1054.449,158.1572 L 1054.438,157.7186 L 1054.657,157.4339 C 1054.918,157.0964 1054.936,156.9647 1054.749,156.756 C 1054.599,156.5876 1054.535,156.6139 1054.633,156.8038 C 1054.73,156.9911 1054.723,157.0203 1054.531,157.2477 C 1054.274,157.5529 1054.176,157.7636 1054.175,158.0147 C 1054.174,158.27 1054.115,158.5541 1054.05,158.6192 C 1053.963,158.7063 1053.88,158.5642 1053.757,158.1156 C 1053.647,157.7155 1053.64,157.6437 1053.681,157.4046 C 1053.788,156.7886 1054.153,156.0685 1054.61,155.5739 C 1055.423,154.6946 1056.619,154.2993 1058.252,154.3701 C 1059.586,154.428 1060.316,154.6817 1060.941,155.304 C 1061.251,155.6128 1061.607,156.1843 1061.81,156.6971 C 1061.93,157.0025 1061.952,157.1189 1061.968,157.5446 L 1061.987,158.038 L 1061.828,158.213 C 1061.63,158.4328 1061.627,158.5432 1061.804,159.1165 C 1061.994,159.7306 1061.986,159.89 1061.743,160.3776 C 1061.634,160.5969 1061.475,160.8438 1061.39,160.9262 C 1061.239,161.0713 1061.22,161.077 1060.772,161.109 C 1060.254,161.1459 1060.091,161.2128 1059.928,161.4536 C 1059.766,161.6937 1059.788,161.7186 1060.157,161.7186 C 1060.471,161.7186 1060.486,161.7235 1060.513,161.8285 C 1060.588,162.1288 1060.36,162.6233 1059.949,163.0523 C 1059.652,163.3619 1059.651,163.3621 1059.429,163.3527 C 1059.307,163.3475 1059.172,163.3321 1059.129,163.3185 C 1059.067,163.2989 1059.045,163.3259 1059.022,163.4484 C 1058.981,163.6672 1058.856,163.6524 1058.495,163.3859 Z M 1057.547,160.7511 C 1057.67,160.6286 1057.682,160.5905 1057.682,160.3356 C 1057.682,160.1801 1057.713,159.9765 1057.753,159.8789 C 1057.867,159.5918 1057.751,159.4675 1057.559,159.6721 C 1057.439,159.7997 1057.25,160.261 1057.216,160.5086 C 1057.188,160.7119 1057.25,160.8859 1057.352,160.8859 C 1057.385,160.8859 1057.473,160.8252 1057.547,160.7511 Z M 1058.825,160.7924 C 1058.894,160.6634 1058.844,160.3971 1058.69,160.0747 C 1058.537,159.7553 1058.377,159.5711 1058.253,159.5711 C 1058.115,159.5711 1058.097,159.6902 1058.201,159.9057 C 1058.265,160.0355 1058.296,160.1829 1058.296,160.3528 C 1058.296,160.6164 1058.332,160.6927 1058.514,160.8138 C 1058.66,160.9116 1058.765,160.9045 1058.825,160.7924 Z M 1057.485,159.3256 C 1057.639,159.2452 1057.662,159.2138 1057.673,159.0602 C 1057.68,158.9644 1057.646,158.7009 1057.597,158.4746 C 1057.523,158.1357 1057.482,158.0374 1057.364,157.916 C 1057.042,157.5827 1056.437,157.3547 1055.966,157.3888 C 1055.649,157.4117 1055.32,157.624 1055.102,157.9456 C 1054.84,158.3322 1054.878,158.6617 1055.228,159.0611 C 1055.493,159.3627 1055.792,159.4381 1056.674,159.4257 C 1057.222,159.4181 1057.334,159.4042 1057.485,159.3256 Z M 1060.578,159.2779 C 1060.933,159.1194 1061.276,158.6828 1061.276,158.3882 C 1061.276,157.8989 1060.655,157.3375 1060.113,157.3364 C 1059.637,157.3355 1058.996,157.5976 1058.716,157.9072 C 1058.604,158.0307 1058.55,158.1504 1058.494,158.3938 C 1058.366,158.957 1058.361,159.0993 1058.466,159.1944 C 1058.64,159.3519 1058.929,159.3964 1059.676,159.3813 C 1060.267,159.3694 1060.409,159.353 1060.578,159.2779 Z"
+       id="path4-4" />
+    <path
+       d="M 1055.116,210.1712 Q 1055.116,211.1868 1054.553,211.7493 L 1044.678,221.5771 Q 1044.084,222.1709 1041.819,222.1709 V 225.3895 Q 1041.819,226.1083 1041.272,226.1083 Q 1040.991,226.1083 1040.725,225.8426 L 1033.163,218.2647 Q 1032.975,218.0772 1032.975,217.8116 Q 1032.975,217.546 1033.163,217.3585 L 1040.725,209.7806 Q 1040.991,209.515 1041.272,209.515 Q 1041.819,209.515 1041.819,210.2337 V 213.4524 H 1046.381 V 201.8746 Q 1046.381,201.1558 1046.928,201.1558 Q 1047.209,201.1558 1047.475,201.4214 L 1050.741,204.7026 L 1054.022,201.4214 Q 1054.288,201.1558 1054.569,201.1558 Q 1055.116,201.1558 1055.116,201.8746 Z M 1053.834,210.1712 V 203.4214 L 1051.194,206.0619 Q 1051.022,206.2338 1050.709,206.2338 Q 1050.475,206.2338 1050.303,206.0619 L 1047.663,203.4214 V 213.4524 H 1051.022 L 1053.647,210.8431 Q 1053.834,210.6556 1053.834,210.1712 Z M 1049.725,214.7336 H 1041.178 Q 1040.538,214.7336 1040.538,214.093 V 211.7805 L 1034.522,217.8116 L 1040.538,223.8427 V 221.5303 Q 1040.538,220.8897 1041.178,220.8897 Q 1043.553,220.8897 1043.772,220.6709 Z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:32px;line-height:1.25;font-family:Symbola;-inkscape-font-specification:'Symbola Bold';word-spacing:0px;stroke-width:0.999986"
+       id="path4999" />
+    <path
+       d="M 320.644,367.2558 Q 319.8002,367.3183 319.4252,367.5475 Q 319.0502,367.7766 318.7585,368.1516 L 316.0398,371.6829 L 315.1023,370.8808 L 317.2169,368.1308 Q 317.5919,367.6412 317.4565,367.485 Q 317.321,367.3183 316.6752,367.2558 V 366.4954 H 320.644 Z M 315.821,376.1829 V 375.4225 Q 316.1648,375.3912 316.4148,375.3287 Q 316.6752,375.2662 316.7273,375.0995 Q 316.7794,374.9225 316.5085,374.5475 L 311.9044,368.1516 Q 311.6336,367.7766 311.3106,367.5475 Q 310.9981,367.3183 310.2169,367.2558 V 366.4954 H 315.3731 V 367.2558 Q 314.7273,367.3183 314.5815,367.4745 Q 314.4356,367.6308 314.7898,368.1308 L 319.3523,374.485 Q 319.5815,374.7975 319.9148,375.0683 Q 320.2585,375.3287 320.946,375.4225 V 376.1829 Z M 313.3419,374.5475 Q 313.0606,374.912 313.144,375.0891 Q 313.2273,375.2558 313.5085,375.3287 Q 313.8002,375.3912 314.1231,375.4225 V 376.1829 H 310.1023 V 375.4225 Q 310.8731,375.2975 311.2273,375.0475 Q 311.5815,374.7975 311.8211,374.485 L 314.644,370.8391 L 315.571,371.6725 Z"
+       id="path7063"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 352.1464,371.1308 Q 352.1464,372.1725 351.7402,373.1308 Q 351.3339,374.0891 350.6256,374.8495 Q 349.9173,375.61 348.9902,376.0579 Q 348.0631,376.4954 347.0318,376.4954 Q 346.3339,376.4954 345.6777,376.3079 Q 345.0318,376.1308 344.5214,375.8391 L 344.3756,376.037 Q 344.2402,376.1412 343.9277,376.287 Q 343.6256,376.4329 343.2923,376.5579 Q 342.9589,376.6829 342.7402,376.7349 L 342.4694,376.412 L 343.5423,375.0266 Q 342.9798,374.3704 342.636,373.4745 Q 342.3027,372.5683 342.3027,371.5579 Q 342.3027,370.5266 342.6777,369.5683 Q 343.0527,368.5995 343.7402,367.8391 Q 344.4277,367.0683 345.3652,366.6308 Q 346.3131,366.1829 347.4381,366.1829 Q 348.1256,366.1829 348.761,366.36 Q 349.3964,366.537 349.9068,366.8391 L 350.0631,366.6516 Q 350.3443,366.4745 350.8443,366.2454 Q 351.3443,366.0162 351.6985,365.9433 L 352.011,366.2662 L 350.9277,367.662 Q 351.4902,368.3183 351.8131,369.2245 Q 352.1464,370.1204 352.1464,371.1308 Z M 345.1777,372.9433 L 348.6881,368.412 Q 348.386,368.0058 347.9798,367.7454 Q 347.5735,367.485 347.136,367.485 Q 346.2714,367.485 345.7818,367.985 Q 345.3027,368.4745 345.1048,369.3287 Q 344.9173,370.1829 344.9173,371.2558 Q 344.9173,371.6725 344.9902,372.1308 Q 345.0631,372.5891 345.1777,372.9433 Z M 347.3235,375.1933 Q 348.5631,375.1933 349.0527,374.2558 Q 349.5423,373.3183 349.5423,371.5995 Q 349.5423,371.1412 349.4589,370.6516 Q 349.3756,370.162 349.2506,369.7662 L 345.7714,374.235 Q 346.0839,374.6516 346.4902,374.9225 Q 346.8964,375.1933 347.3235,375.1933 Z"
+       id="path7066"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 390.7027,374.2037 Q 389.7964,375.2245 389.0673,375.7141 Q 388.3381,376.2037 387.6923,376.3495 Q 387.0568,376.4954 386.4006,376.4954 Q 385.2652,376.4954 384.2756,375.912 Q 383.2964,375.3183 382.6818,374.2141 Q 382.0777,373.0995 382.0777,371.5579 Q 382.0777,370.0579 382.7964,368.8391 Q 383.5152,367.6204 384.786,366.9016 Q 386.0568,366.1829 387.7027,366.1829 Q 388.161,366.1829 388.7548,366.287 Q 389.3485,366.3912 389.8693,366.5787 Q 390.3902,366.7558 390.6193,367.0058 Q 390.6402,367.1308 390.5568,367.5162 Q 390.4735,367.8912 390.3277,368.3495 Q 390.1818,368.8079 390.036,369.2037 Q 389.8902,369.5891 389.7964,369.7245 L 389.0985,369.6204 Q 388.7548,368.5995 388.2548,368.0475 Q 387.7548,367.485 386.9214,367.485 Q 386.3068,367.485 385.7756,367.86 Q 385.2443,368.235 384.911,369.0683 Q 384.5777,369.8912 384.5777,371.235 Q 384.5777,372.8912 385.3693,373.8183 Q 386.1714,374.7454 387.3068,374.7454 Q 387.7027,374.7454 388.0673,374.6725 Q 388.4318,374.5995 388.911,374.3495 Q 389.4006,374.0891 390.1402,373.537 Z"
+       id="path7069"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 423.4444,374.985 Q 422.8402,375.3912 422.2048,375.735 Q 421.5694,376.0787 421.059,376.287 Q 420.559,376.4954 420.3507,376.4954 Q 419.809,376.4954 419.5694,375.7975 Q 419.3298,375.0891 419.3298,373.3495 V 367.5058 Q 419.7673,367.3287 420.4444,366.985 Q 421.1215,366.6308 421.7152,366.1829 L 422.1319,366.5683 Q 422.1319,366.5683 422.0486,366.9329 Q 421.9757,367.287 421.9027,367.8391 Q 421.8298,368.3808 421.8298,368.9641 V 372.912 Q 421.8298,373.537 421.8611,373.9329 Q 421.9027,374.3287 422.0069,374.4225 Q 422.1111,374.5266 422.3611,374.5058 Q 422.6215,374.4745 423.1527,374.2245 Q 423.1527,374.2141 423.2257,374.412 Q 423.2986,374.5995 423.3715,374.7975 Q 423.4444,374.985 423.4444,374.985 Z M 420.1111,373.9433 Q 419.2986,374.9225 418.6736,375.4745 Q 418.059,376.0266 417.4965,376.2558 Q 416.934,376.4954 416.2778,376.4954 Q 415.3923,376.4954 414.5798,375.9329 Q 413.7673,375.3704 413.2465,374.2766 Q 412.7361,373.1829 412.7361,371.5995 Q 412.7361,370.6725 413.0694,369.7245 Q 413.4028,368.7662 414.0382,367.9641 Q 414.684,367.162 415.6007,366.6725 Q 416.5173,366.1829 417.684,366.1829 Q 418.309,366.1829 418.8403,366.4225 Q 419.3715,366.6516 420.0069,367.3495 Q 420.0069,368.6412 419.4028,369.0266 Q 419.184,368.3704 418.6528,367.9641 Q 418.1319,367.5579 417.5278,367.5579 Q 416.9548,367.5579 416.4236,367.8704 Q 415.9028,368.1725 415.5694,368.9225 Q 415.2361,369.662 415.2361,370.9641 Q 415.2361,372.1412 415.5486,372.9329 Q 415.8715,373.7245 416.3507,374.1204 Q 416.8403,374.5162 417.3403,374.5162 Q 417.7882,374.5162 418.2569,374.2454 Q 418.7361,373.9745 419.6423,373.0891 Q 419.7361,373.1308 419.8298,373.3183 Q 419.9236,373.5058 419.9965,373.7037 Q 420.0798,373.8912 420.1111,373.9433 Z M 422.1007,362.0787 Q 421.8611,362.6412 421.4652,363.2975 Q 421.0798,363.9537 420.5277,364.4225 Q 419.9861,364.8912 419.2882,364.8912 Q 418.7778,364.8912 418.3298,364.6204 Q 417.8819,364.3496 417.4653,364.0787 Q 417.059,363.7975 416.6528,363.7975 Q 416.2986,363.7975 415.9444,364.1516 Q 415.6007,364.5058 415.2361,365.0787 L 414.3715,364.7662 Q 414.6111,364.1933 414.9965,363.5371 Q 415.3923,362.8808 415.934,362.4121 Q 416.4757,361.9433 417.1736,361.9433 Q 417.7465,361.9433 418.1944,362.2246 Q 418.6423,362.4954 419.0278,362.7766 Q 419.4236,363.0475 419.7986,363.0475 Q 420.1319,363.0475 420.5069,362.6933 Q 420.8819,362.3287 421.2361,361.7141 Z"
+       id="path7072"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 462.5369,367.2558 Q 461.9223,367.4016 461.7556,367.537 Q 461.589,367.662 461.464,367.9641 L 458.5161,375.3287 Q 458.3286,375.7975 457.7765,376.0891 Q 457.2244,376.3704 456.7244,376.4954 L 453.0473,367.9641 Q 452.9223,367.6829 452.7036,367.5266 Q 452.4848,367.3704 451.9744,367.2558 V 366.4954 H 456.6931 V 367.2558 Q 455.8911,367.36 455.7036,367.4954 Q 455.5265,367.6308 455.6723,367.9641 L 457.9119,373.2037 L 460.0161,367.9641 Q 460.1411,367.6516 460.0056,367.5162 Q 459.8702,367.3704 459.1723,367.2558 V 366.4954 H 462.5369 Z"
+       id="path7075"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 493.8787,371.1308 Q 493.8787,372.1725 493.4725,373.1308 Q 493.0662,374.0891 492.3579,374.8495 Q 491.6496,375.61 490.7225,376.0579 Q 489.7954,376.4954 488.7642,376.4954 Q 487.3267,376.4954 486.2642,375.8495 Q 485.2017,375.2037 484.6183,374.0891 Q 484.035,372.9745 484.035,371.5579 Q 484.035,370.5266 484.41,369.5683 Q 484.785,368.5995 485.4725,367.8391 Q 486.16,367.0683 487.0975,366.6308 Q 488.0454,366.1829 489.1704,366.1829 Q 490.5871,366.1829 491.6496,366.8287 Q 492.7121,367.4745 493.2954,368.5891 Q 493.8787,369.7037 493.8787,371.1308 Z M 491.2537,371.5995 Q 491.2537,370.4954 490.9516,369.5683 Q 490.6496,368.6308 490.1079,368.0579 Q 489.5767,367.485 488.8683,367.485 Q 488.0037,367.485 487.5246,367.985 Q 487.0454,368.4745 486.8579,369.3287 Q 486.6704,370.1829 486.6704,371.2558 Q 486.6704,372.3495 486.9933,373.2454 Q 487.3267,374.1412 487.8683,374.6725 Q 488.41,375.1933 489.0558,375.1933 Q 490.2954,375.1933 490.7746,374.2558 Q 491.2537,373.3183 491.2537,371.5995 Z M 488.4204,362.9746 Q 488.4204,363.735 487.9308,364.2766 Q 487.4517,364.8183 486.785,364.8183 Q 485.5558,364.8183 485.5558,363.5475 Q 485.5558,362.7871 486.0454,362.2558 Q 486.535,361.7141 487.1808,361.7141 Q 487.7537,361.7141 488.0871,362.0371 Q 488.4204,362.3496 488.4204,362.9746 Z M 492.8162,362.9746 Q 492.8162,363.735 492.3371,364.2766 Q 491.8579,364.8183 491.1912,364.8183 Q 489.9516,364.8183 489.9516,363.5475 Q 489.9516,362.7871 490.4412,362.2558 Q 490.9412,361.7141 491.5766,361.7141 Q 492.16,361.7141 492.4829,362.0371 Q 492.8162,362.3496 492.8162,362.9746 Z"
+       id="path7078"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 533.4449,370.9016 Q 533.4449,371.8079 532.9761,372.787 Q 532.5074,373.7662 531.7157,374.61 Q 530.9241,375.4433 529.9449,375.9745 Q 528.9761,376.4954 527.9657,376.4954 Q 527.3928,376.4954 526.2887,376.1204 Q 525.1949,375.7454 524.0699,375.1829 V 362.9954 Q 524.0699,362.3808 523.9866,362.11 Q 523.9032,361.8391 523.6324,361.7558 Q 523.3616,361.6621 522.7991,361.5996 V 360.8704 Q 523.7678,360.7037 524.5491,360.5371 Q 525.3407,360.36 526.1116,360.0371 Q 526.3616,360.2558 526.5699,360.4641 V 367.8287 Q 527.6116,366.9329 528.5595,366.5579 Q 529.5178,366.1829 530.1116,366.1829 Q 531.6428,366.1829 532.5386,367.4641 Q 533.4449,368.735 533.4449,370.9016 Z M 531.1428,371.8495 Q 531.1428,369.7766 530.4553,368.8808 Q 529.7782,367.9745 528.8303,367.9745 Q 528.4657,367.9745 527.8928,368.2245 Q 527.3303,368.4745 526.5699,369.1204 V 373.912 Q 527.4032,374.36 528.0386,374.5579 Q 528.6741,374.7454 528.9866,374.7454 Q 530.0803,374.7454 530.6116,373.9016 Q 531.1428,373.0579 531.1428,371.8495 Z"
+       id="path7081"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 565.1767,374.985 Q 564.5726,375.3912 563.9371,375.735 Q 563.3017,376.0787 562.7913,376.287 Q 562.2913,376.4954 562.083,376.4954 Q 561.5413,376.4954 561.3017,375.7975 Q 561.0621,375.0891 561.0621,373.3495 V 367.5058 Q 561.4996,367.3287 562.1767,366.985 Q 562.8538,366.6308 563.4476,366.1829 L 563.8642,366.5683 Q 563.8642,366.5683 563.7809,366.9329 Q 563.708,367.287 563.6351,367.8391 Q 563.5621,368.3808 563.5621,368.9641 V 372.912 Q 563.5621,373.537 563.5934,373.9329 Q 563.6351,374.3287 563.7392,374.4225 Q 563.8434,374.5266 564.0934,374.5058 Q 564.3538,374.4745 564.8851,374.2245 Q 564.8851,374.2141 564.958,374.412 Q 565.0309,374.5995 565.1038,374.7975 Q 565.1767,374.985 565.1767,374.985 Z M 561.8434,373.9433 Q 561.0309,374.9225 560.4059,375.4745 Q 559.7913,376.0266 559.2288,376.2558 Q 558.6663,376.4954 558.0101,376.4954 Q 557.1246,376.4954 556.3122,375.9329 Q 555.4997,375.3704 554.9788,374.2766 Q 554.4684,373.1829 554.4684,371.5995 Q 554.4684,370.6725 554.8017,369.7245 Q 555.1351,368.7662 555.7705,367.9641 Q 556.4163,367.162 557.333,366.6725 Q 558.2496,366.1829 559.4163,366.1829 Q 560.0413,366.1829 560.5726,366.4225 Q 561.1038,366.6516 561.7392,367.3495 Q 561.7392,368.6412 561.1351,369.0266 Q 560.9163,368.3704 560.3851,367.9641 Q 559.8642,367.5579 559.2601,367.5579 Q 558.6871,367.5579 558.1559,367.8704 Q 557.6351,368.1725 557.3017,368.9225 Q 556.9684,369.662 556.9684,370.9641 Q 556.9684,372.1412 557.2809,372.9329 Q 557.6038,373.7245 558.083,374.1204 Q 558.5726,374.5162 559.0726,374.5162 Q 559.5205,374.5162 559.9892,374.2454 Q 560.4684,373.9745 561.3746,373.0891 Q 561.4684,373.1308 561.5621,373.3183 Q 561.6559,373.5058 561.7288,373.7037 Q 561.8121,373.8912 561.8434,373.9433 Z M 563.3434,364.6516 Q 563.2184,364.8496 563.0621,365.0683 Q 562.9163,365.2766 562.7392,365.3496 L 559.8017,363.0266 L 556.9059,365.3496 Q 556.7288,365.2766 556.5413,365.0683 Q 556.3538,364.8496 556.1976,364.6516 L 559.1038,360.6204 H 560.5309 Z"
+       id="path7084"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 599.5611,376.1829 V 375.4225 Q 600.3111,375.2245 600.6236,375.0787 Q 600.9361,374.9225 600.9361,374.787 V 370.0579 Q 600.9361,368.912 600.6966,368.4954 Q 600.457,368.0787 599.8424,368.0787 Q 599.3424,368.0787 598.6861,368.3808 Q 598.0403,368.6725 597.0299,369.5266 V 374.787 Q 597.0299,375.1308 598.4153,375.4225 V 376.1829 H 593.1549 V 375.4225 Q 594.5299,375.0579 594.5299,374.787 V 369.0058 Q 594.5299,368.4641 594.4674,368.2141 Q 594.4049,367.9537 594.1132,367.8495 Q 593.832,367.7454 593.1549,367.662 V 366.9329 Q 594.1445,366.8287 594.9049,366.6516 Q 595.6757,366.4745 596.4362,366.1829 L 596.8737,366.6204 L 596.9882,368.1204 Q 598.1966,367.0891 599.2591,366.6412 Q 600.3216,366.1829 601.1341,366.1829 Q 602.0299,366.1829 602.7278,366.787 Q 603.4361,367.3912 603.4361,368.8495 V 374.787 Q 603.4361,374.9225 603.7174,375.0683 Q 603.9986,375.2141 604.8216,375.4225 V 376.1829 Z"
+       id="path7087"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 628.108,376.1829 V 375.4225 Q 628.8059,375.2766 629.1393,375.0995 Q 629.483,374.9225 629.483,374.787 V 369.4329 Q 629.483,368.7245 629.4414,368.3704 Q 629.3997,368.0162 629.1184,367.8808 Q 628.8372,367.735 628.108,367.662 V 366.9329 Q 628.9934,366.8079 629.7955,366.6308 Q 630.608,366.4433 631.3164,366.1829 H 631.983 V 374.787 Q 631.983,374.912 632.2955,375.0995 Q 632.608,375.2766 633.3684,375.4225 V 376.1829 Z M 634.2643,364.6516 Q 634.1393,364.8496 633.983,365.0683 Q 633.8372,365.2766 633.6601,365.3496 L 630.7226,363.0266 L 627.8268,365.3496 Q 627.6497,365.2766 627.4622,365.0683 Q 627.2747,364.8496 627.1184,364.6516 L 630.0247,360.6204 H 631.4518 Z"
+       id="path7090"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 673.3085,376.1829 V 375.4225 Q 674.0585,375.2245 674.2876,375.0787 Q 674.5168,374.9225 674.5168,374.787 V 369.9016 Q 674.5168,369.0475 674.3918,368.6412 Q 674.2772,368.2245 674.0376,368.0995 Q 673.798,367.9745 673.423,367.9745 Q 672.9647,367.9745 672.3397,368.2975 Q 671.7251,368.6204 671.0585,369.2766 V 374.787 Q 671.0585,374.9225 671.298,375.0683 Q 671.548,375.2141 672.371,375.4225 V 376.1829 H 667.3397 V 375.4225 Q 668.0897,375.2245 668.3189,375.0787 Q 668.5585,374.9225 668.5585,374.787 V 369.9016 Q 668.5585,369.0475 668.4647,368.6412 Q 668.371,368.2245 668.1418,368.0995 Q 667.923,367.9745 667.5376,367.9745 Q 666.5793,367.9745 665.0897,369.2766 V 374.787 Q 665.0897,375.1516 666.3918,375.4225 V 376.1829 H 661.2147 V 375.4225 Q 662.5897,375.0579 662.5897,374.787 V 369.0058 Q 662.5897,368.4537 662.5272,368.2037 Q 662.4647,367.9433 662.1731,367.8495 Q 661.8814,367.7454 661.2147,367.662 V 366.9329 Q 662.2876,366.8079 663.0168,366.6308 Q 663.7564,366.4537 664.496,366.1829 L 664.9335,366.6204 L 665.048,367.912 Q 666.2147,366.8808 667.0585,366.537 Q 667.9126,366.1829 668.6626,366.1829 Q 669.6522,366.1829 670.1939,366.6412 Q 670.746,367.0995 670.871,367.7662 L 670.9022,367.912 Q 672.0689,366.9016 672.923,366.5475 Q 673.7876,366.1829 674.548,366.1829 Q 675.5376,366.1829 676.2772,366.787 Q 677.0168,367.3912 677.0168,368.8495 V 374.787 Q 677.0168,374.9225 677.3397,375.0683 Q 677.6626,375.2141 678.4855,375.4225 V 376.1829 Z"
+       id="path7093"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 698.5591,376.1829 V 375.4225 Q 699.2571,375.2766 699.5904,375.0995 Q 699.9341,374.9225 699.9341,374.787 V 369.4329 Q 699.9341,368.7245 699.8925,368.3704 Q 699.8508,368.0162 699.5696,367.8808 Q 699.2883,367.735 698.5591,367.662 V 366.9329 Q 699.4446,366.8079 700.2466,366.6308 Q 701.0591,366.4433 701.7675,366.1829 H 702.4341 V 374.787 Q 702.4341,374.912 702.7466,375.0995 Q 703.0591,375.2766 703.8196,375.4225 V 376.1829 Z M 700.5591,365.3496 Q 700.3716,365.3183 700.0696,365.1621 Q 699.7675,364.9954 699.6529,364.9016 L 701.8612,360.4329 Q 701.9758,360.4433 702.3091,360.4954 Q 702.6425,360.5475 703.0383,360.61 Q 703.4446,360.6725 703.7779,360.735 Q 704.1112,360.7975 704.2258,360.8287 L 704.5487,361.3912 Z"
+       id="path7096"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 742.7595,375.4537 Q 742.7595,376.1933 742.3533,377.0787 Q 741.947,377.9641 741.2491,378.7766 Q 740.5616,379.5995 739.7283,380.1412 L 739.0199,379.6204 Q 739.6033,378.9433 739.9366,378.2037 Q 740.2699,377.4745 740.2699,376.5683 Q 740.2699,376.11 739.8949,375.7245 Q 739.5199,375.3287 738.8429,375.3808 L 738.6762,374.5787 Q 738.7699,374.4537 739.1449,374.2766 Q 739.5304,374.0891 740.0304,373.912 Q 740.5408,373.7245 741.0095,373.5995 Q 741.4887,373.4745 741.7595,373.485 Q 742.2595,373.7141 742.5095,374.1725 Q 742.7595,374.6308 742.7595,375.4537 Z"
+       id="path7099"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 776.9836,373.7558 Q 776.7753,373.912 776.4003,374.1412 Q 776.0357,374.36 775.7753,374.4433 L 775.442,374.0995 V 371.0683 H 768.2024 L 767.8586,370.735 Q 767.9211,370.5266 768.0774,370.162 Q 768.2441,369.787 768.3378,369.5891 Q 770.7961,369.5891 772.3586,369.5891 Q 773.9211,369.5891 774.7961,369.5891 Q 775.6711,369.5891 776.0461,369.5891 Q 776.4315,369.5891 776.5149,369.5891 Q 776.6086,369.5891 776.6086,369.5891 L 776.9836,369.8912 Z"
+       id="path7102"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 813.2916,374.8183 Q 813.2916,375.662 812.7291,376.1308 Q 812.1666,376.5995 811.3853,376.5995 Q 810.7707,376.5995 810.3228,376.2662 Q 809.8749,375.9329 809.8749,375.1933 Q 809.8749,374.3808 810.4478,373.9016 Q 811.0311,373.412 811.7916,373.412 Q 812.3645,373.412 812.8228,373.7558 Q 813.2916,374.0891 813.2916,374.8183 Z"
+       id="path7105"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 845.6011,372.9189 H 847.3291 V 372.6842 C 846.8811,372.2575 846.4545,371.7242 845.8358,370.8709 L 844.5985,369.1215 C 845.7291,368.6735 846.3051,367.9055 846.3051,366.8815 C 846.3051,365.6229 845.3665,364.8336 843.8518,364.8336 H 839.7345 V 365.2176 C 840.7158,365.2816 840.7158,365.2816 840.7158,366.1562 V 371.5962 C 840.7158,372.4495 840.6945,372.4709 839.7345,372.5349 V 372.9189 H 843.4038 V 372.5349 C 842.4438,372.4709 842.4225,372.4495 842.4225,371.5962 V 369.3562 H 843.2118 C 844.5558,371.5535 844.9825,372.9189 845.6011,372.9189 Z M 842.4225,365.3029 H 843.1905 C 844.0651,365.3029 844.4918,365.8575 844.4918,367.0095 C 844.4918,368.2042 844.0011,368.8869 843.1691,368.8869 H 842.4225 Z M 843.2971,361.4416 C 839.1158,361.4416 835.8731,364.7696 835.8731,369.0362 C 835.8731,373.2389 839.1158,376.5882 843.1905,376.5882 C 847.4998,376.5882 850.6998,373.3455 850.6998,368.9935 C 850.6998,364.7482 847.4571,361.4416 843.2971,361.4416 Z M 843.2971,362.5509 C 846.5611,362.5509 849.1851,365.4309 849.1851,369.0149 C 849.1851,372.6415 846.5825,375.4789 843.2118,375.4789 C 840.0118,375.4789 837.3878,372.5775 837.3878,369.0362 C 837.3878,365.4309 840.0118,362.5509 843.2971,362.5509 Z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.3333px;line-height:1.25;font-family:FreeSerif;-inkscape-font-specification:'FreeSerif Bold';word-spacing:0px"
+       id="path7108" />
+    <path
+       d="M 879.8927,379.0579 Q 879.7468,379.1516 879.4031,379.2766 Q 879.0697,379.4016 878.7156,379.5058 Q 878.3718,379.6204 878.1947,379.6724 L 877.7364,379.3287 L 885.0385,360.0996 Q 885.3197,359.9225 885.8614,359.7558 Q 886.4031,359.5891 886.6947,359.5162 L 887.1635,359.8183 Z"
+       id="path7111"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 918.5907,362.5683 Q 918.5491,362.7246 918.4241,363.0058 Q 918.3095,363.2871 918.1845,363.5579 Q 918.0595,363.8287 918.0074,363.9433 H 910.0491 L 909.7157,363.61 Q 909.7574,363.4641 909.872,363.1933 Q 909.9866,362.9121 910.1116,362.6516 Q 910.2366,362.3808 910.2991,362.2454 H 918.2574 Z"
+       id="path7114"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 248.8654,372.735 Q 248.8654,373.0683 248.855,373.5787 Q 248.8446,374.0787 248.8237,374.61 Q 248.8133,375.1412 248.7925,375.5683 Q 248.7716,375.9954 248.7404,376.1829 H 240.5842 L 240.3133,375.7141 L 245.8237,367.7454 H 243.1154 Q 242.6675,367.7454 242.2612,368.2766 Q 241.855,368.7975 241.5842,369.9329 L 240.8446,369.7245 L 241.105,366.3287 Q 241.5633,366.4537 241.9175,366.4745 Q 242.2717,366.4954 242.9383,366.4954 H 248.7716 L 249.0008,366.9433 L 243.4696,374.9329 H 247.0425 Q 247.4175,374.9329 247.6258,374.3079 Q 247.8446,373.6829 248.1362,372.5579 Z"
+       id="path7117"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 249.8246,345.3424 Q 249.8038,345.7903 249.7725,346.5091 Q 249.7517,347.2174 249.7308,347.9153 Q 249.71,348.6132 249.6996,349.0195 H 239.8663 L 239.4913,348.4674 L 246.5017,337.2487 H 242.4288 Q 242.085,337.2487 241.6371,337.9257 Q 241.1892,338.6028 240.96,339.6862 L 240.0538,339.4882 L 240.4392,335.7278 Q 241.0017,335.8528 241.3975,335.8737 Q 241.8038,335.8945 242.4183,335.8945 H 249.3767 L 249.7204,336.4153 L 242.7621,347.6653 H 247.5121 Q 247.9496,347.6653 248.2413,347.0299 Q 248.5329,346.3945 248.9392,345.1132 Z"
+       id="path7120"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 282.9764,336.6549 Q 281.5389,336.957 281.5389,337.3007 V 343.5611 Q 281.5389,345.3841 280.8722,346.6757 Q 280.216,347.9674 279.0493,348.6549 Q 277.893,349.332 276.3931,349.332 Q 274.966,349.332 273.7785,348.8007 Q 272.591,348.2695 271.8826,347.1757 Q 271.1743,346.082 271.1743,344.3945 V 337.3007 Q 271.1743,337.1757 270.8306,336.9882 Q 270.4972,336.8007 269.7472,336.6549 V 335.8945 H 275.216 V 336.6549 Q 273.7785,336.957 273.7785,337.3007 V 343.7174 Q 273.7785,345.7174 274.5181,346.7695 Q 275.2576,347.8216 277.0389,347.8216 Q 278.0285,347.8216 278.6118,347.2591 Q 279.1951,346.6861 279.4555,345.7799 Q 279.716,344.8632 279.716,343.832 V 337.3007 Q 279.716,337.1757 279.3722,336.9882 Q 279.0389,336.8007 278.2889,336.6549 V 335.8945 H 282.9764 Z M 274.9764,334.8737 Q 274.7993,334.7903 274.5806,334.5403 Q 274.3722,334.2903 274.2785,334.1445 L 278.1222,330.6028 Q 278.2264,330.6549 278.518,330.8112 Q 278.8201,330.957 279.1639,331.1445 Q 279.5076,331.3216 279.7889,331.4882 Q 280.0805,331.6445 280.1743,331.7278 L 280.2785,332.3632 Z"
+       id="path7123"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 321.4872,336.6549 Q 320.7268,336.7382 320.2893,336.9153 Q 319.8518,337.0924 319.5809,337.5299 L 315.5705,343.8007 L 314.8518,342.2382 L 317.8205,337.5299 Q 318.1122,337.0612 317.9039,336.8945 Q 317.6955,336.7278 316.7685,336.6549 V 335.8945 H 321.4872 Z M 316.4351,349.0195 V 348.2591 Q 317.3518,348.1653 317.5809,347.9882 Q 317.8205,347.8007 317.5289,347.3841 L 310.7789,337.5299 Q 310.456,337.0716 310.1435,336.9153 Q 309.8414,336.7591 309.1539,336.6549 V 335.8945 H 314.7893 V 336.6549 Q 313.9039,336.7382 313.633,336.9049 Q 313.3622,337.0716 313.6747,337.5299 L 320.4247,347.3841 Q 320.7268,347.832 321.0497,348.0091 Q 321.383,348.1757 321.9976,348.2591 V 349.0195 Z M 312.706,347.3841 Q 312.4039,347.8424 312.581,348.0195 Q 312.7685,348.1966 313.7372,348.2591 V 349.0195 H 309.0497 V 348.2591 Q 309.7164,348.207 310.1851,348.0091 Q 310.6643,347.8007 310.9455,347.3841 L 315.008,341.1862 L 315.6122,342.9986 Z"
+       id="path7126"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 353.1771,342.2799 Q 353.1771,343.6966 352.6771,344.9674 Q 352.1876,346.2382 351.3126,347.2278 Q 350.448,348.207 349.3126,348.7695 Q 348.1876,349.332 346.9272,349.332 Q 345.6042,349.332 344.5626,348.7903 Q 343.5209,348.2382 342.7813,347.3007 Q 342.0417,346.3632 341.6563,345.1653 Q 341.2709,343.957 341.2709,342.6445 Q 341.2709,341.2278 341.7292,339.957 Q 342.1876,338.6757 343.0209,337.6966 Q 343.8647,336.707 345.0105,336.1445 Q 346.1563,335.582 347.5313,335.582 Q 348.9063,335.582 349.9584,336.1445 Q 351.0105,336.707 351.7292,337.6653 Q 352.448,338.6132 352.8126,339.8112 Q 353.1771,341.0091 353.1771,342.2799 Z M 350.5521,342.4674 Q 350.5521,341.0299 350.1042,339.7695 Q 349.6563,338.5091 348.8542,337.7278 Q 348.0522,336.9362 346.9897,336.9362 Q 345.4897,336.9362 344.698,338.3632 Q 343.9063,339.7903 343.9063,342.3424 Q 343.9063,343.8945 344.3751,345.1653 Q 344.8438,346.4361 345.6355,347.1861 Q 346.4272,347.9257 347.3855,347.9257 Q 348.7605,347.9257 349.6563,346.582 Q 350.5521,345.2278 350.5521,342.4674 Z M 343.3959,349.0403 Q 343.2709,349.1445 342.9272,349.2591 Q 342.5834,349.3736 342.2188,349.457 Q 341.8647,349.5403 341.698,349.5716 L 341.3647,349.1861 L 351.073,335.8528 Q 351.3646,335.6757 351.8959,335.5299 Q 352.4271,335.3841 352.7501,335.3424 L 353.0834,335.7278 Z"
+       id="path7129"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 391.6821,346.8216 Q 390.3488,348.1861 389.0884,348.7591 Q 387.828,349.332 386.6301,349.332 Q 385.578,349.332 384.5884,348.9049 Q 383.5988,348.4674 382.8072,347.6445 Q 382.0259,346.8111 381.5572,345.6236 Q 381.0988,344.4257 381.0988,342.9153 Q 381.0988,340.6966 381.9738,339.0507 Q 382.8592,337.4049 384.3592,336.4987 Q 385.8592,335.582 387.7238,335.582 Q 388.8384,335.582 389.8905,335.8945 Q 390.9426,336.1966 391.4842,336.6237 Q 391.5363,336.6653 391.4217,336.9674 Q 391.3071,337.2695 391.1092,337.6653 Q 390.9113,338.0507 390.703,338.3841 Q 390.5051,338.7174 390.3905,338.8424 L 389.7134,338.6966 Q 389.1926,337.7903 388.4946,337.3737 Q 387.8071,336.957 387.0051,336.957 Q 386.4738,336.957 385.9009,337.2278 Q 385.328,337.4987 384.828,338.1341 Q 384.3384,338.7591 384.0363,339.832 Q 383.7342,340.9049 383.7342,342.5299 Q 383.7342,344.3007 384.3176,345.4257 Q 384.9113,346.5507 385.8072,347.082 Q 386.703,347.6132 387.6196,347.6132 Q 388.1821,347.6132 389.1092,347.3216 Q 390.0467,347.0195 391.1405,346.1132 Q 391.2446,346.1966 391.4321,346.4674 Q 391.6301,346.7382 391.6821,346.8216 Z"
+       id="path7132"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 415.5797,344.5403 L 414.5797,347.5507 Q 414.486,347.8736 414.8402,348.0195 Q 415.1943,348.1653 416.0485,348.2591 V 349.0195 H 411.4964 V 348.2591 Q 412.2047,348.1341 412.5797,347.9986 Q 412.9652,347.8632 413.0693,347.5507 L 416.7047,336.4466 Q 417.1943,336.0195 417.8297,335.7382 Q 418.4756,335.457 419.0172,335.3007 L 423.3922,347.5507 Q 423.4964,347.8424 423.7464,348.0091 Q 424.0068,348.1757 424.6839,348.2591 V 349.0195 H 419.5068 V 348.2591 Q 420.3089,348.207 420.6006,348.0507 Q 420.8922,347.8945 420.7776,347.5507 L 419.7152,344.5403 Z M 419.2777,343.2903 L 417.5589,338.4466 L 415.9964,343.2903 Z M 422.1839,331.8424 Q 421.9443,332.4049 421.5381,333.082 Q 421.1422,333.7591 420.611,334.2591 Q 420.0902,334.7487 419.4547,334.7487 Q 418.8506,334.7487 418.3193,334.4778 Q 417.7985,334.1966 417.2881,333.9257 Q 416.7881,333.6445 416.2672,333.6445 Q 415.7881,333.6445 415.4652,333.957 Q 415.1527,334.2695 414.7777,334.8424 L 413.986,334.5612 Q 414.236,333.9882 414.6318,333.3112 Q 415.0277,332.6237 415.5485,332.1237 Q 416.0797,331.6237 416.7152,331.6237 Q 417.3506,331.6237 417.9027,331.9049 Q 418.4547,332.1757 418.9339,332.457 Q 419.4235,332.7278 419.8818,332.7278 Q 420.3297,332.7278 420.6839,332.4362 Q 421.0381,332.1341 421.3922,331.5195 Z"
+       id="path7135"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 464.1057,336.6549 Q 463.3974,336.7903 462.9911,336.9257 Q 462.5849,337.0507 462.4911,337.3424 L 458.5745,348.1653 Q 458.4703,348.4778 458.1057,348.707 Q 457.7516,348.9361 457.3141,349.0924 Q 456.887,349.2486 456.5432,349.332 L 451.8036,337.3424 Q 451.6995,337.0716 451.3766,336.9049 Q 451.0641,336.7382 450.4078,336.6549 V 335.8945 H 455.7203 V 336.6549 Q 454.887,336.7174 454.6161,336.8737 Q 454.3453,337.0195 454.4599,337.3216 L 457.8453,346.0403 L 460.939,337.3424 Q 461.0432,337.0403 460.7516,336.9049 Q 460.4599,336.7591 459.6161,336.6549 V 335.8945 H 464.1057 Z"
+       id="path7138"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 488.649,349.332 Q 487.3366,349.332 486.2845,348.7903 Q 485.2428,348.2382 484.5032,347.3007 Q 483.7741,346.3632 483.3886,345.1653 Q 483.0032,343.957 483.0032,342.6445 Q 483.0032,341.2278 483.4616,339.957 Q 483.9199,338.6757 484.7532,337.6966 Q 485.5866,336.707 486.7324,336.1445 Q 487.8782,335.582 489.2532,335.582 Q 490.6282,335.582 491.6803,336.1445 Q 492.7428,336.707 493.4511,337.6653 Q 494.1699,338.6132 494.5345,339.8112 Q 494.9095,341.0091 494.9095,342.2799 Q 494.9095,343.6966 494.4095,344.9674 Q 493.9095,346.2382 493.0449,347.2278 Q 492.1803,348.207 491.0449,348.7695 Q 489.9199,349.332 488.649,349.332 Z M 489.1074,347.9257 Q 490.4824,347.9257 491.3782,346.582 Q 492.274,345.2278 492.274,342.4674 Q 492.274,341.0299 491.8261,339.7695 Q 491.3782,338.5091 490.5761,337.7278 Q 489.7845,336.9362 488.722,336.9362 Q 487.222,336.9362 486.4199,338.3632 Q 485.6282,339.7903 485.6282,342.3424 Q 485.6282,343.8945 486.097,345.1653 Q 486.5761,346.4361 487.3678,347.1861 Q 488.1595,347.9257 489.1074,347.9257 Z M 488.3053,332.8945 Q 488.3053,333.6549 487.8157,334.1966 Q 487.3366,334.7382 486.6699,334.7382 Q 485.4407,334.7382 485.4407,333.4674 Q 485.4407,332.707 485.9303,332.1757 Q 486.4303,331.6341 487.0657,331.6341 Q 487.649,331.6341 487.972,331.957 Q 488.3053,332.2695 488.3053,332.8945 Z M 492.7011,332.8945 Q 492.7011,333.6549 492.222,334.1966 Q 491.7428,334.7382 491.0761,334.7382 Q 489.8365,334.7382 489.8365,333.4674 Q 489.8365,332.707 490.3261,332.1757 Q 490.8261,331.6341 491.472,331.6341 Q 492.0449,331.6341 492.3678,331.957 Q 492.7011,332.2695 492.7011,332.8945 Z"
+       id="path7141"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 533.8463,345.3111 Q 533.8463,347.082 532.4088,348.1236 Q 530.9713,349.1653 528.4609,349.1653 Q 527.763,349.1653 526.8567,349.1341 Q 525.9505,349.1132 525.0338,349.082 Q 524.1171,349.0507 523.3671,349.0195 L 526.4609,347.7591 Q 526.7838,347.9361 527.19,347.9986 Q 527.6067,348.0507 528.0755,348.0507 Q 529.5754,348.0507 530.3463,347.3632 Q 531.1171,346.6757 531.1171,345.5091 Q 531.1171,344.7382 530.8359,344.0195 Q 530.5546,343.3007 529.8671,342.832 Q 529.1796,342.3632 527.9713,342.3632 Q 527.2838,342.3632 526.8359,342.4362 Q 526.388,342.5091 526.0025,342.6028 L 525.8984,341.3112 H 526.763 Q 528.1484,341.3112 528.8567,340.957 Q 529.565,340.6028 529.8046,340.0507 Q 530.0546,339.4987 530.0546,338.9049 Q 530.0546,337.8632 529.3879,337.2799 Q 528.7213,336.6862 526.94,336.6862 Q 526.388,336.6862 525.5755,336.7487 Q 524.763,336.8007 523.94,336.8945 Q 523.1171,336.9778 522.5338,337.082 L 522.3984,336.207 Q 523.013,336.0507 523.9088,335.9153 Q 524.815,335.7695 525.7838,335.6757 Q 526.763,335.582 527.5963,335.582 Q 529.9817,335.582 531.3359,336.332 Q 532.69,337.082 532.69,338.3945 Q 532.69,339.5091 532.0859,340.3216 Q 531.4817,341.1237 530.315,341.4882 Q 531.3567,341.6549 532.1484,342.1966 Q 532.9504,342.7382 533.3984,343.5403 Q 533.8463,344.3424 533.8463,345.3111 Z M 522.5338,349.0195 V 348.2591 Q 523.9609,347.9674 523.9609,347.6236 V 336.4153 L 526.565,336.1966 V 347.6966 Q 526.565,347.8216 526.8255,348.0091 Q 527.0859,348.1966 527.8463,348.332 V 349.0195 Z"
+       id="path7144"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 557.312,344.5403 L 556.312,347.5507 Q 556.2183,347.8736 556.5724,348.0195 Q 556.9266,348.1653 557.7808,348.2591 V 349.0195 H 553.2287 V 348.2591 Q 553.937,348.1341 554.312,347.9986 Q 554.6974,347.8632 554.8016,347.5507 L 558.437,336.4466 Q 558.9266,336.0195 559.562,335.7382 Q 560.2079,335.457 560.7495,335.3007 L 565.1245,347.5507 Q 565.2287,347.8424 565.4787,348.0091 Q 565.7391,348.1757 566.4162,348.2591 V 349.0195 H 561.2391 V 348.2591 Q 562.0412,348.207 562.3329,348.0507 Q 562.6245,347.8945 562.5099,347.5507 L 561.4474,344.5403 Z M 561.0099,343.2903 L 559.2912,338.4466 L 557.7287,343.2903 Z M 563.3537,334.1549 Q 563.2287,334.3528 563.062,334.5716 Q 562.9058,334.7799 562.7287,334.8528 L 559.812,333.082 L 556.9162,334.8528 Q 556.7391,334.7799 556.5516,334.5716 Q 556.3641,334.3528 556.2079,334.1549 L 559.1141,330.6966 H 560.5412 Z"
+       id="path7147"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 605.6292,336.6549 Q 604.8792,336.7591 604.5355,336.957 Q 604.1917,337.1549 604.1917,337.3007 V 348.6861 L 602.6292,348.2799 V 337.3007 Q 602.6292,337.1757 602.3272,336.9778 Q 602.0355,336.7695 601.2022,336.6549 V 335.8945 H 605.6292 Z M 604.1917,349.332 Q 603.2022,349.2486 602.5876,348.9466 Q 601.9834,348.6341 601.7022,348.2486 L 594.3792,338.1028 Q 593.9522,337.5091 593.4209,337.1237 Q 592.8897,336.7382 592.348,336.6549 V 335.8945 H 595.2542 Q 595.5563,335.8945 595.7126,336.0299 Q 595.8688,336.1653 596.2542,336.707 L 602.8063,345.7799 Q 602.9209,345.9361 603.1397,346.2278 Q 603.3688,346.5091 603.6084,346.8111 Q 603.848,347.1132 604.0146,347.3216 Q 604.1917,347.5299 604.1917,347.5299 Z M 592.348,349.0195 V 348.2591 Q 593.1084,348.1653 593.4417,347.9674 Q 593.7751,347.7591 593.7751,347.6236 V 336.8737 L 595.3376,336.3007 V 347.6236 Q 595.3376,347.7486 595.6501,347.9466 Q 595.9626,348.1445 596.7751,348.2591 V 349.0195 Z"
+       id="path7150"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 628.004,349.0195 V 348.2591 Q 629.431,347.9674 629.431,347.6236 V 337.3007 Q 629.431,337.1757 629.0873,336.9882 Q 628.754,336.8007 628.004,336.6549 V 335.8945 H 633.4727 V 336.6549 Q 632.0352,336.957 632.0352,337.3007 V 347.6236 Q 632.0352,347.7486 632.379,347.9361 Q 632.7227,348.1132 633.4727,348.2591 V 349.0195 Z M 634.2644,334.1549 Q 634.1394,334.3528 633.9727,334.5716 Q 633.8165,334.7799 633.6394,334.8528 L 630.7227,333.082 L 627.8269,334.8528 Q 627.6498,334.7799 627.4623,334.5716 Q 627.2748,334.3528 627.1186,334.1549 L 630.0248,330.6966 H 631.4519 Z"
+       id="path7153"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 672.7832,349.0195 V 348.2591 Q 673.4811,348.1132 673.8978,347.9361 Q 674.3145,347.7591 674.3145,347.6236 L 674.2103,337.2799 L 676.6061,336.6862 L 676.7103,347.6236 Q 676.7103,347.7486 677.0853,347.9361 Q 677.4707,348.1132 678.2207,348.2591 V 349.0195 Z M 677.9395,336.6549 Q 677.4707,336.6549 676.752,336.8945 Q 676.0436,337.1237 675.4082,337.5299 Q 674.7832,337.9257 674.5541,338.4257 L 669.8145,349.0195 H 669.7728 Q 669.6166,348.1445 669.4916,347.6341 Q 669.3666,347.1132 669.3353,346.8111 Q 669.3041,346.5091 669.3978,346.2903 L 673.6686,336.7695 Q 673.9395,336.1549 674.0749,336.0299 Q 674.2103,335.8945 674.4082,335.8945 H 677.9395 Z M 670.127,346.2695 Q 670.2728,346.5924 670.1478,347.1549 Q 670.0332,347.707 669.7728,349.0195 H 668.8353 L 664.0749,338.1966 Q 663.8041,337.5716 663.3562,337.2382 Q 662.9187,336.9049 662.4395,336.7799 Q 661.9603,336.6549 661.5853,336.6549 V 335.8945 H 665.1895 Q 665.3978,335.8945 665.5332,336.0507 Q 665.6791,336.207 665.9291,336.7695 Z M 661.4812,349.0195 V 348.2591 Q 662.9082,347.9778 662.9082,347.6236 L 663.0124,336.8737 L 664.5332,336.6132 L 664.4187,347.6236 Q 664.4187,347.7486 664.7624,347.9361 Q 665.1062,348.1132 665.8562,348.2591 V 349.0195 Z"
+       id="path7156"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 698.3041,349.0195 V 348.2591 Q 699.7312,347.9674 699.7312,347.6236 V 337.3007 Q 699.7312,337.1757 699.3874,336.9882 Q 699.0541,336.8007 698.3041,336.6549 V 335.8945 H 703.7728 V 336.6549 Q 702.3353,336.957 702.3353,337.3007 V 347.6236 Q 702.3353,347.7486 702.6791,347.9361 Q 703.0228,348.1132 703.7728,348.2591 V 349.0195 Z M 699.502,334.8737 Q 699.3249,334.7903 699.1062,334.5403 Q 698.8978,334.2903 698.8041,334.1445 L 702.6478,330.6028 Q 702.752,330.6549 703.0437,330.8112 Q 703.3457,330.957 703.6895,331.1445 Q 704.0332,331.3216 704.3145,331.4882 Q 704.6061,331.6445 704.6999,331.7278 L 704.8041,332.3632 Z"
+       id="path7159"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 745.0088,339.7695 Q 744.9567,339.9882 744.8213,340.457 Q 744.6963,340.9153 744.6338,341.1132 L 736.7588,343.9466 L 736.4255,343.5403 Q 736.4776,343.3216 736.6026,342.9049 Q 736.7276,342.4778 736.8213,342.2695 L 744.6755,339.4362 Z M 745.0088,345.5507 Q 744.7796,345.7695 744.4984,346.0403 Q 744.2171,346.3111 743.9047,346.5091 L 736.7588,343.9466 L 736.4255,343.5403 Q 736.4776,343.3216 736.6026,342.9049 Q 736.7276,342.4778 736.8213,342.2695 L 744.7588,345.1028 Z"
+       id="path7162"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 768.947,348.9882 Q 768.7074,349.1028 768.2907,349.1757 Q 767.8741,349.2591 767.5928,349.332 L 767.3324,349.0195 L 776.5928,336.4882 Q 776.8011,336.4049 777.2386,336.3007 Q 777.6865,336.1966 777.9157,336.1549 L 778.1761,336.4466 Z M 778.3949,346.7799 Q 778.1136,347.1549 777.8011,347.3528 H 777.4886 V 348.332 Q 777.4886,348.4049 777.6449,348.4778 Q 777.8011,348.5403 778.2907,348.6341 V 349.0195 H 774.8636 V 348.6341 Q 775.6345,348.5195 775.8636,348.4466 Q 776.0928,348.3632 776.0928,348.2799 V 347.3528 H 773.2907 L 773.0407,347.1549 L 775.8949,343.1861 Q 776.1761,343.1028 776.572,342.9882 Q 776.9678,342.8736 777.2282,342.7903 L 777.4886,343.0091 V 346.6236 H 778.2386 Z M 776.0928,344.1341 L 774.2178,346.6236 H 776.0928 Z M 766.6241,342.3841 V 341.9466 Q 767.5511,341.8528 767.8741,341.7278 Q 768.197,341.6028 768.197,341.4987 V 337.8528 Q 768.197,337.4674 768.0928,337.3632 Q 768.0303,337.3007 767.7074,337.3007 Q 767.3949,337.3007 766.6136,337.4362 L 766.447,337.0091 Q 766.7803,336.9466 767.3741,336.7903 Q 767.9678,336.6237 768.5407,336.4466 Q 769.1241,336.2591 769.4053,336.1549 L 769.6657,336.3737 V 341.4987 Q 769.6657,341.5924 769.947,341.7278 Q 770.2282,341.8528 771.1241,341.9466 V 342.3841 Z"
+       id="path7165"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 815.8749,342.4049 Q 815.8124,342.6757 815.6874,343.0507 Q 815.5728,343.4153 815.4791,343.6757 L 807.6249,346.5091 L 807.2916,346.1653 Q 807.3437,345.957 807.4687,345.4986 Q 807.6041,345.0299 807.677,344.832 L 813.1562,342.8528 L 807.5416,340.8424 L 807.2916,340.3841 Q 807.5208,340.1862 807.8124,339.9049 Q 808.1145,339.6237 808.3957,339.4362 L 815.5416,341.9882 Z"
+       id="path7168"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 839.8854,348.9882 Q 839.6354,349.1028 839.2187,349.1757 Q 838.802,349.2591 838.5208,349.332 L 838.2604,349.0195 L 847.5312,336.4882 Q 847.7291,336.4049 848.1666,336.3007 Q 848.6145,336.1966 848.8437,336.1549 L 849.1041,336.4466 Z M 842.2291,340.4778 Q 842.2291,341.3216 841.4687,341.9257 Q 840.7187,342.5299 839.5312,342.5299 Q 839.0416,342.5299 838.3958,342.332 Q 837.75,342.1237 837.2187,341.6862 L 837.4687,341.207 Q 838.0104,341.5403 838.4583,341.6757 Q 838.9062,341.8112 839.3437,341.8112 Q 839.8958,341.8112 840.2812,341.5299 Q 840.6666,341.2382 840.6666,340.6028 Q 840.6666,339.9153 840.2187,339.6549 Q 839.7812,339.3841 839.3958,339.3841 Q 839.2291,339.3841 839.1562,339.3945 Q 839.0937,339.3945 838.9062,339.4257 L 838.8125,338.957 Q 839.8125,338.7278 840.0625,338.3632 Q 840.3229,337.9882 840.3229,337.6862 Q 840.3229,337.3424 840.1458,337.082 Q 839.9791,336.8112 839.5312,336.8112 Q 839.2291,336.8112 839.0312,337.0299 Q 838.8333,337.2487 838.9479,337.5924 Q 838.7083,337.707 838.3125,337.8112 Q 837.927,337.9153 837.5937,337.9362 L 837.3958,337.6237 Q 837.3958,337.3528 837.7083,337.0195 Q 838.0312,336.6862 838.5833,336.4466 Q 839.1458,336.207 839.875,336.207 Q 840.9583,336.207 841.4166,336.6445 Q 841.875,337.082 841.875,337.5924 Q 841.875,337.9674 841.5312,338.3528 Q 841.1979,338.7382 840.6354,338.8945 Q 841.3541,338.957 841.7916,339.4153 Q 842.2291,339.8632 842.2291,340.4778 Z M 849.3541,346.7799 Q 849.0729,347.1549 848.7604,347.3528 H 848.4479 V 348.332 Q 848.4479,348.4049 848.6041,348.4778 Q 848.7604,348.5403 849.2499,348.6341 V 349.0195 H 845.8229 V 348.6341 Q 846.5937,348.5195 846.8229,348.4466 Q 847.052,348.3632 847.052,348.2799 V 347.3528 H 844.2499 L 843.9999,347.1549 L 846.8541,343.1861 Q 847.1354,343.1028 847.5312,342.9882 Q 847.927,342.8736 848.1874,342.7903 L 848.4479,343.0091 V 346.6236 H 849.1979 Z M 847.052,344.1341 L 845.177,346.6236 H 847.052 Z"
+       id="path7171"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 886.6205,336.8841 Q 886.6205,337.8216 886.2559,338.5716 Q 885.8913,339.3112 885.3497,339.9466 Q 884.808,340.5716 884.2559,341.1653 Q 883.7038,341.7487 883.308,342.3737 Q 882.9226,342.9986 882.8809,343.7278 L 882.8184,344.7278 Q 882.6205,344.8736 882.3497,344.9778 Q 882.0788,345.082 881.7872,345.1549 L 881.4538,344.8632 L 881.3705,343.7278 Q 881.3705,343.6861 881.3705,343.6549 Q 881.3705,343.6132 881.3705,343.5611 Q 881.3705,342.6966 881.7455,341.8945 Q 882.1309,341.082 882.6309,340.3216 Q 883.1309,339.5507 883.5163,338.8112 Q 883.9017,338.0716 883.9017,337.3528 Q 883.9017,336.0716 883.4747,335.457 Q 883.0476,334.832 882.3288,334.832 Q 881.808,334.832 881.4017,335.3424 Q 881.0059,335.8528 881.0059,336.6653 Q 881.0059,336.8112 881.0372,337.0091 Q 881.0788,337.1966 881.1309,337.3424 Q 880.9017,337.457 880.433,337.5924 Q 879.9643,337.7278 879.4643,337.8424 Q 878.9643,337.9466 878.6622,337.9778 L 878.2976,337.582 Q 878.2872,337.5091 878.2768,337.3424 Q 878.2768,337.1653 878.2768,337.082 Q 878.2768,336.1028 878.9434,335.3216 Q 879.6101,334.5299 880.7038,334.0716 Q 881.7976,333.6028 883.0684,333.6028 Q 884.7872,333.6028 885.7038,334.5195 Q 886.6205,335.4257 886.6205,336.8841 Z M 883.933,347.6549 Q 883.933,348.4986 883.3705,348.9674 Q 882.808,349.4361 882.0267,349.4361 Q 881.4122,349.4361 880.9642,349.1028 Q 880.5163,348.7695 880.5163,348.0299 Q 880.5163,347.2174 881.0892,346.7382 Q 881.6726,346.2486 882.433,346.2486 Q 883.0059,346.2486 883.4642,346.5924 Q 883.933,346.9257 883.933,347.6549 Z"
+       id="path7174"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 916.091,340.4153 Q 916.091,341.2382 915.5077,341.7278 Q 914.9348,342.207 914.1744,342.207 Q 913.591,342.207 913.1327,341.8737 Q 912.6744,341.5299 912.6744,340.7903 Q 912.6744,339.957 913.2369,339.4882 Q 913.7994,339.0195 914.5806,339.0195 Q 915.1848,339.0195 915.6327,339.3528 Q 916.091,339.6862 916.091,340.4153 Z M 913.7994,343.7278 Q 913.9869,343.582 914.2577,343.4778 Q 914.5285,343.3736 914.8202,343.3007 L 915.1535,343.5924 L 915.2369,344.7278 Q 915.289,345.6236 914.914,346.457 Q 914.539,347.2903 914.0285,348.0716 Q 913.5181,348.8528 913.1223,349.6028 Q 912.7265,350.3632 912.7265,351.1028 Q 912.7265,352.3841 913.1431,352.9986 Q 913.5598,353.6236 914.2785,353.6236 Q 914.7994,353.6236 915.2056,353.1132 Q 915.6119,352.6028 915.6119,351.7903 Q 915.6119,351.6445 915.5702,351.4466 Q 915.5285,351.2591 915.4765,351.1132 Q 915.7056,350.9882 916.1744,350.8528 Q 916.6431,350.7174 917.1431,350.6132 Q 917.6431,350.5091 917.9556,350.4778 L 918.3098,350.8736 Q 918.3306,350.9466 918.3306,351.1132 Q 918.3306,351.2903 918.3306,351.3632 Q 918.3306,352.3528 917.6639,353.1341 Q 916.9973,353.9257 915.9035,354.384 Q 914.8202,354.8528 913.5494,354.8528 Q 911.8202,354.8528 910.8931,353.9361 Q 909.9765,353.0299 909.9765,351.5716 Q 909.9765,350.6341 910.341,349.8841 Q 910.7056,349.1445 911.2473,348.5195 Q 911.789,347.8841 912.341,347.3007 Q 912.8931,346.707 913.289,346.082 Q 913.6848,345.457 913.7369,344.7278 Z"
+       id="path7177"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 96.96005,302.7928 Q 96.96005,303.6366 96.39754,304.1053 Q 95.83503,304.5741 95.05376,304.5741 Q 94.43917,304.5741 93.99124,304.2408 Q 93.54331,303.9074 93.54331,303.1678 Q 93.54331,302.3553 94.11624,301.8761 Q 94.69958,301.3865 95.46002,301.3865 Q 96.03294,301.3865 96.49129,301.7303 Q 96.96005,302.0636 96.96005,302.7928 Z M 102.8247,302.7928 Q 102.8247,303.6366 102.2622,304.1053 Q 101.6997,304.5741 100.9185,304.5741 Q 100.3039,304.5741 99.85594,304.2408 Q 99.40802,303.9074 99.40802,303.1678 Q 99.40802,302.3553 99.98094,301.8761 Q 100.5643,301.3865 101.3247,301.3865 Q 101.8976,301.3865 102.356,301.7303 Q 102.8247,302.0636 102.8247,302.7928 Z M 108.679,302.7928 Q 108.679,303.6366 108.1165,304.1053 Q 107.554,304.5741 106.7727,304.5741 Q 106.1582,304.5741 105.7102,304.2408 Q 105.2623,303.9074 105.2623,303.1678 Q 105.2623,302.3553 105.8352,301.8761 Q 106.4186,301.3865 107.179,301.3865 Q 107.7519,301.3865 108.2102,301.7303 Q 108.679,302.0636 108.679,302.7928 Z"
+       id="path7180"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 156.8158,303.7824 Q 156.8158,304.5428 156.4721,305.3241 Q 156.1283,306.1054 155.5554,306.7721 Q 154.9825,307.4387 154.3159,307.8658 L 153.6387,307.345 Q 154.0138,306.8554 154.2638,306.1991 Q 154.5138,305.5533 154.5138,304.8762 Q 154.5138,304.3033 154.1179,303.9387 Q 153.7324,303.5637 153.0241,303.5428 L 152.8574,302.7616 Q 152.9512,302.6366 153.3366,302.4491 Q 153.7324,302.2615 154.2221,302.0845 Q 154.7221,301.897 155.1596,301.7824 Q 155.5971,301.6574 155.7846,301.6678 Q 156.8158,302.4491 156.8158,303.7824 Z M 151.8158,303.7824 Q 151.8158,304.5428 151.4616,305.3241 Q 151.1178,306.1054 150.5449,306.7721 Q 149.9824,307.4387 149.3157,307.8658 L 148.6282,307.345 Q 149.0032,306.8554 149.2532,306.1991 Q 149.5033,305.5533 149.5033,304.8762 Q 149.5033,304.3033 149.1177,303.9387 Q 148.7323,303.5637 148.0136,303.5428 L 147.8469,302.7616 Q 147.9407,302.6366 148.3261,302.4491 Q 148.7219,302.2615 149.2219,302.0845 Q 149.722,301.897 150.1491,301.7824 Q 150.5866,301.6574 150.7741,301.6678 Q 151.8158,302.4491 151.8158,303.7824 Z"
+       id="path7183"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 214.5835,302.9595 Q 213.9792,303.3657 213.3438,303.7095 Q 212.7084,304.0532 212.198,304.2616 Q 211.698,304.4699 211.4896,304.4699 Q 210.948,304.4699 210.7084,303.772 Q 210.4688,303.0636 210.4688,301.324 V 295.4802 Q 210.9063,295.3031 211.5834,294.9593 Q 212.2605,294.6051 212.8542,294.1572 L 213.2709,294.5426 Q 213.2709,294.5426 213.1876,294.9072 Q 213.1146,295.2614 213.0417,295.8135 Q 212.9688,296.3552 212.9688,296.9385 V 300.8865 Q 212.9688,301.5115 213.0001,301.9074 Q 213.0417,302.3032 213.1459,302.397 Q 213.2501,302.5011 213.5001,302.4803 Q 213.7605,302.4491 214.2918,302.199 Q 214.2918,302.1886 214.3647,302.3866 Q 214.4377,302.5741 214.5106,302.772 Q 214.5835,302.9595 214.5835,302.9595 Z M 211.2501,301.9178 Q 210.4376,302.897 209.8126,303.4491 Q 209.1979,304.0012 208.6354,304.2303 Q 208.0729,304.4699 207.4166,304.4699 Q 206.5312,304.4699 205.7187,303.9074 Q 204.9062,303.3449 204.3853,302.2511 Q 203.8749,301.1574 203.8749,299.574 Q 203.8749,298.6469 204.2082,297.699 Q 204.5415,296.7406 205.1771,295.9385 Q 205.8229,295.1364 206.7396,294.6468 Q 207.6562,294.1572 208.8229,294.1572 Q 209.4479,294.1572 209.9792,294.3968 Q 210.5105,294.626 211.1459,295.3239 Q 211.1459,296.6156 210.5417,297.001 Q 210.323,296.3448 209.7917,295.9385 Q 209.2708,295.5322 208.6666,295.5322 Q 208.0937,295.5322 207.5625,295.8448 Q 207.0416,296.1468 206.7083,296.8969 Q 206.375,297.6365 206.375,298.9386 Q 206.375,300.1157 206.6875,300.9074 Q 207.0104,301.699 207.4896,302.0949 Q 207.9791,302.4907 208.4791,302.4907 Q 208.9271,302.4907 209.3958,302.2199 Q 209.8751,301.949 210.7813,301.0636 Q 210.8751,301.1053 210.9688,301.2928 Q 211.0626,301.4803 211.1355,301.6782 Q 211.2188,301.8657 211.2501,301.9178 Z"
+       id="path7186"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 246.2831,302.9595 Q 245.6789,303.3657 245.0435,303.7095 Q 244.4081,304.0532 243.8977,304.2616 Q 243.3977,304.4699 243.1894,304.4699 Q 242.6477,304.4699 242.4081,303.772 Q 242.1685,303.0636 242.1685,301.324 V 295.4802 Q 242.606,295.3031 243.2831,294.9593 Q 243.9602,294.6051 244.5539,294.1572 L 244.9706,294.5426 Q 244.9706,294.5426 244.8873,294.9072 Q 244.8144,295.2614 244.7414,295.8135 Q 244.6685,296.3552 244.6685,296.9385 V 300.8865 Q 244.6685,301.5115 244.6998,301.9074 Q 244.7414,302.3032 244.8456,302.397 Q 244.9498,302.5011 245.1998,302.4803 Q 245.4602,302.4491 245.9914,302.199 Q 245.9914,302.1886 246.0644,302.3866 Q 246.1373,302.5741 246.2102,302.772 Q 246.2831,302.9595 246.2831,302.9595 Z M 242.9498,301.9178 Q 242.1373,302.897 241.5122,303.4491 Q 240.8976,304.0012 240.3351,304.2303 Q 239.7726,304.4699 239.1163,304.4699 Q 238.2309,304.4699 237.4184,303.9074 Q 236.6058,303.3449 236.085,302.2511 Q 235.5746,301.1574 235.5746,299.574 Q 235.5746,298.6469 235.9079,297.699 Q 236.2412,296.7406 236.8767,295.9385 Q 237.5226,295.1364 238.4393,294.6468 Q 239.3559,294.1572 240.5226,294.1572 Q 241.1476,294.1572 241.6788,294.3968 Q 242.2102,294.626 242.8456,295.3239 Q 242.8456,296.6156 242.2414,297.001 Q 242.0227,296.3448 241.4913,295.9385 Q 240.9705,295.5322 240.3663,295.5322 Q 239.7934,295.5322 239.2622,295.8448 Q 238.7413,296.1468 238.408,296.8969 Q 238.0747,297.6365 238.0747,298.9386 Q 238.0747,300.1157 238.3872,300.9074 Q 238.7101,301.699 239.1893,302.0949 Q 239.6788,302.4907 240.1788,302.4907 Q 240.6268,302.4907 241.0955,302.2199 Q 241.5747,301.949 242.481,301.0636 Q 242.5748,301.1053 242.6685,301.2928 Q 242.7623,301.4803 242.8352,301.6782 Q 242.9185,301.8657 242.9498,301.9178 Z M 240.2934,293.3239 Q 240.1059,293.2926 239.8038,293.1364 Q 239.5018,292.9697 239.3872,292.8759 L 241.5955,288.4071 Q 241.7101,288.4175 242.0435,288.4696 Q 242.3769,288.5217 242.7727,288.5842 Q 243.1789,288.6467 243.5123,288.7092 Q 243.8456,288.7717 243.9602,288.8029 L 244.2831,289.3655 Z"
+       id="path7189"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 283.7631,301.2094 Q 283.7631,302.3136 283.2943,302.9699 Q 282.8359,303.6262 282.1484,303.9491 Q 281.4609,304.272 280.7734,304.3658 Q 280.0859,304.4699 279.6276,304.4699 Q 278.9609,304.4699 278.1067,304.2824 Q 277.2525,304.1053 276.5546,303.7095 Q 276.4921,303.6678 276.4504,303.3449 Q 276.4192,303.0116 276.4192,302.5324 Q 276.4296,302.0428 276.4713,301.5428 Q 276.5233,301.0428 276.6275,300.6574 L 277.4713,300.7719 Q 277.69,301.8865 278.3879,302.5428 Q 279.0964,303.1886 279.9922,303.1886 Q 281.4714,303.1886 281.4714,302.022 Q 281.4714,301.2199 280.7422,300.7094 Q 280.0234,300.1886 278.9609,299.6365 Q 278.3879,299.3344 277.8254,298.9594 Q 277.2733,298.5844 276.8983,298.0948 Q 276.5338,297.6052 276.5338,296.9385 Q 276.5338,296.0739 277.065,295.4593 Q 277.6067,294.8343 278.4608,294.501 Q 279.3151,294.1572 280.2526,294.1572 Q 281.1484,294.1572 282.0234,294.376 Q 282.9089,294.5947 283.388,294.9593 Q 283.4505,295.0114 283.4089,295.3031 Q 283.3776,295.5947 283.2734,295.9802 Q 283.1797,296.3552 283.0443,296.7094 Q 282.9089,297.0531 282.7839,297.2198 L 282.0651,297.1364 Q 281.5339,295.251 280.138,295.251 Q 279.513,295.251 279.1693,295.5427 Q 278.8254,295.8343 278.8254,296.2614 Q 278.8254,296.8864 279.3984,297.3031 Q 279.9818,297.7094 281.2109,298.3344 Q 281.8151,298.6469 282.3984,299.0219 Q 282.9922,299.3865 283.3776,299.9073 Q 283.7631,300.4282 283.7631,301.2094 Z"
+       id="path7192"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 316.7192,299.1052 Q 316.7192,300.1469 316.313,301.1053 Q 315.9066,302.0636 315.1983,302.8241 Q 314.49,303.5845 313.5629,304.0324 Q 312.6358,304.4699 311.6046,304.4699 Q 310.167,304.4699 309.1045,303.8241 Q 308.042,303.1782 307.4586,302.0636 Q 306.8753,300.949 306.8753,299.5323 Q 306.8753,298.5011 307.2503,297.5427 Q 307.6253,296.5739 308.3128,295.8135 Q 309.0003,295.0427 309.9378,294.6051 Q 310.8857,294.1572 312.0108,294.1572 Q 313.4275,294.1572 314.49,294.8031 Q 315.5525,295.4489 316.1359,296.5635 Q 316.7192,297.6781 316.7192,299.1052 Z M 314.0941,299.574 Q 314.0941,298.4698 313.792,297.5427 Q 313.49,296.6052 312.9483,296.0323 Q 312.4171,295.4593 311.7087,295.4593 Q 310.844,295.4593 310.3649,295.9593 Q 309.8857,296.4489 309.6982,297.3031 Q 309.5107,298.1573 309.5107,299.2302 Q 309.5107,300.324 309.8336,301.2199 Q 310.167,302.1157 310.7086,302.647 Q 311.2503,303.1678 311.8962,303.1678 Q 313.1358,303.1678 313.615,302.2303 Q 314.0941,301.2928 314.0941,299.574 Z M 311.3962,293.3239 Q 311.2086,293.2926 310.9065,293.1364 Q 310.6045,292.9697 310.4899,292.8759 L 312.6983,288.4071 Q 312.8129,288.4175 313.1462,288.4696 Q 313.4795,288.5217 313.8754,288.5842 Q 314.2816,288.6467 314.615,288.7092 Q 314.9483,288.7717 315.0629,288.8029 L 315.3858,289.3655 Z"
+       id="path7195"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 356.5606,302.9699 Q 355.9252,303.397 355.2793,303.7408 Q 354.6439,304.0741 354.1543,304.272 Q 353.6648,304.4699 353.4668,304.4699 Q 352.4355,304.4699 352.4355,301.0115 V 291.1988 Q 352.4355,290.428 352.3626,290.0738 Q 352.3001,289.7092 351.998,289.5842 Q 351.6959,289.4592 351.0084,289.4071 V 288.6884 Q 352.1438,288.5738 353.071,288.3863 Q 353.9981,288.1884 354.5398,288.0113 L 354.9356,288.3967 V 301.0428 Q 354.9356,301.772 354.9877,302.0636 Q 355.0502,302.3449 355.1752,302.4282 Q 355.2898,302.5011 355.4981,302.4803 Q 355.7064,302.4491 356.2689,302.2095 Z M 353.2064,301.9178 Q 352.3522,302.8345 351.7272,303.397 Q 351.1022,303.9595 350.5084,304.2095 Q 349.9251,304.4699 349.1647,304.4699 Q 348.2375,304.4699 347.3625,303.8866 Q 346.4875,303.2928 345.9146,302.1886 Q 345.3521,301.074 345.3521,299.5323 Q 345.3521,298.1365 345.9979,296.9177 Q 346.6437,295.6885 347.7791,294.9281 Q 348.9251,294.1572 350.4147,294.1572 Q 351.0397,294.1572 351.6751,294.3656 Q 352.3105,294.5739 353.1231,295.3239 Q 353.1231,296.5531 352.5084,296.9177 Q 352.1334,296.2614 351.5501,295.8968 Q 350.9772,295.5322 350.248,295.5322 Q 349.2167,295.5322 348.5292,296.3552 Q 347.8521,297.1677 347.8521,298.9698 Q 347.8521,300.074 348.2062,300.8657 Q 348.5605,301.647 349.1022,302.074 Q 349.6438,302.4907 350.2167,302.4907 Q 350.8417,302.4907 351.4147,302.147 Q 351.998,301.7928 352.748,301.0636 Q 352.8313,301.1053 352.9251,301.2928 Q 353.0293,301.4803 353.1023,301.6782 Q 353.1856,301.8657 353.2064,301.9178 Z"
+       id="path7198"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 388.0153,302.9595 Q 387.4111,303.3657 386.7757,303.7095 Q 386.1403,304.0532 385.6299,304.2616 Q 385.1298,304.4699 384.9214,304.4699 Q 384.3798,304.4699 384.1402,303.772 Q 383.9006,303.0636 383.9006,301.324 V 295.4802 Q 384.3381,295.3031 385.0152,294.9593 Q 385.6924,294.6051 386.2861,294.1572 L 386.7028,294.5426 Q 386.7028,294.5426 386.6195,294.9072 Q 386.5465,295.2614 386.4736,295.8135 Q 386.4007,296.3552 386.4007,296.9385 V 300.8865 Q 386.4007,301.5115 386.432,301.9074 Q 386.4736,302.3032 386.5778,302.397 Q 386.682,302.5011 386.932,302.4803 Q 387.1924,302.4491 387.7236,302.199 Q 387.7236,302.1886 387.7965,302.3866 Q 387.8695,302.5741 387.9424,302.772 Q 388.0153,302.9595 388.0153,302.9595 Z M 384.6819,301.9178 Q 383.8694,302.897 383.2444,303.4491 Q 382.6298,304.0012 382.0673,304.2303 Q 381.5048,304.4699 380.8485,304.4699 Q 379.963,304.4699 379.1505,303.9074 Q 378.338,303.3449 377.8172,302.2511 Q 377.3068,301.1574 377.3068,299.574 Q 377.3068,298.6469 377.6401,297.699 Q 377.9734,296.7406 378.6089,295.9385 Q 379.2547,295.1364 380.1714,294.6468 Q 381.0881,294.1572 382.2548,294.1572 Q 382.8798,294.1572 383.411,294.3968 Q 383.9423,294.626 384.5777,295.3239 Q 384.5777,296.6156 383.9735,297.001 Q 383.7548,296.3448 383.2235,295.9385 Q 382.7027,295.5322 382.0985,295.5322 Q 381.5256,295.5322 380.9944,295.8448 Q 380.4734,296.1468 380.1401,296.8969 Q 379.8068,297.6365 379.8068,298.9386 Q 379.8068,300.1157 380.1193,300.9074 Q 380.4422,301.699 380.9215,302.0949 Q 381.411,302.4907 381.911,302.4907 Q 382.3589,302.4907 382.8277,302.2199 Q 383.3069,301.949 384.2131,301.0636 Q 384.3069,301.1053 384.4006,301.2928 Q 384.4944,301.4803 384.5673,301.6782 Q 384.6506,301.8657 384.6819,301.9178 Z M 381.8902,290.9488 Q 381.8902,291.7093 381.4006,292.2509 Q 380.9215,292.7926 380.2547,292.7926 Q 379.0255,292.7926 379.0255,291.5217 Q 379.0255,290.7613 379.5151,290.2301 Q 380.0047,289.6884 380.6505,289.6884 Q 381.2235,289.6884 381.5569,290.0113 Q 381.8902,290.3238 381.8902,290.9488 Z M 386.2861,290.9488 Q 386.2861,291.7093 385.807,292.2509 Q 385.3277,292.7926 384.661,292.7926 Q 383.4214,292.7926 383.4214,291.5217 Q 383.4214,290.7613 383.911,290.2301 Q 384.411,289.6884 385.0464,289.6884 Q 385.6299,289.6884 385.9528,290.0113 Q 386.2861,290.3238 386.2861,290.9488 Z"
+       id="path7201"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 426.273,289.0113 Q 426.273,289.2405 425.9189,289.6259 Q 425.5751,290.0113 425.1689,290.3551 Q 424.7626,290.6884 424.5543,290.7926 Q 424.0647,290.178 423.5855,289.9071 Q 423.1168,289.6259 422.7834,289.6259 Q 422.4292,289.6259 422.1167,289.9488 Q 421.8042,290.2613 421.6063,291.1155 Q 421.4188,291.9697 421.4188,293.5739 V 294.4697 H 424.0126 L 424.398,294.8447 Q 424.2001,295.1989 423.8772,295.5947 Q 423.5647,295.9802 423.3772,296.1364 Q 423.1272,296.0114 422.6897,295.8968 Q 422.2521,295.7718 421.4188,295.7718 V 302.7824 Q 421.4188,302.9074 421.8563,303.0428 Q 422.3042,303.1678 423.523,303.397 V 304.1574 H 417.5437 V 303.397 Q 418.2521,303.272 418.5854,303.0949 Q 418.9188,302.9074 418.9188,302.7824 V 295.7718 H 417.6791 L 417.3874,295.3968 L 418.2,294.4697 H 418.9188 V 294.1468 Q 418.9188,292.428 419.3771,291.3342 Q 419.8459,290.2301 420.6792,289.4384 Q 421.45,288.6988 422.2833,288.355 Q 423.1272,288.0113 423.7626,288.0113 Q 424.3876,288.0113 424.9605,288.2092 Q 425.5334,288.4071 425.898,288.6467 Q 426.273,288.8863 426.273,289.0113 Z"
+       id="path7204"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 448.8096,304.4699 Q 448.3096,304.4699 447.7575,304.2303 Q 447.2054,304.0012 446.82,303.4803 Q 446.4346,302.9491 446.4346,302.0636 Q 446.4346,300.824 447.3929,299.8448 Q 448.3512,298.8656 450.5076,298.3448 Q 450.7888,298.2719 451.2992,298.2302 Q 451.8097,298.1781 452.3409,298.1573 V 297.3344 Q 452.3409,295.5114 451.018,295.5114 Q 450.6534,295.5114 450.2576,295.6885 Q 449.8721,295.8656 449.6429,296.1885 Q 449.4137,296.5114 449.5387,296.9594 Q 449.5596,297.0635 449.2054,297.2198 Q 448.8512,297.3656 448.3512,297.5115 Q 447.8616,297.6469 447.4242,297.7302 Q 446.9971,297.8135 446.8721,297.7823 L 446.6533,297.251 Q 446.9658,296.4281 447.6012,295.8448 Q 448.2471,295.251 449.0283,294.8864 Q 449.82,294.5114 450.5805,294.3343 Q 451.3409,294.1572 451.8826,294.1572 Q 452.6534,294.1572 453.2263,294.4176 Q 453.8097,294.6676 454.1638,295.2406 Q 454.8409,294.6364 455.6014,294.3968 Q 456.3723,294.1572 456.9973,294.1572 Q 458.2264,294.1572 459.0493,294.7718 Q 459.8828,295.3864 460.2994,296.3656 Q 460.7161,297.3344 460.7161,298.4281 Q 460.5182,298.6469 460.0807,298.9073 Q 459.6536,299.1573 459.3202,299.2927 H 454.6951 Q 454.6951,299.3552 454.6847,299.4282 Q 454.6847,299.5011 454.6847,299.5636 Q 454.6847,300.2094 454.9556,300.949 Q 455.2368,301.6782 455.7785,302.1886 Q 456.3202,302.6991 457.1327,302.6991 Q 457.7889,302.6991 458.4452,302.4491 Q 459.1118,302.1886 460.0911,301.4595 Q 460.2265,301.5324 460.4036,301.7928 Q 460.5911,302.0428 460.6328,302.1261 Q 459.7994,303.0428 459.1222,303.5532 Q 458.4452,304.0637 457.7577,304.2616 Q 457.0806,304.4699 456.2368,304.4699 Q 455.341,304.4699 454.3722,303.897 Q 453.4138,303.3137 452.8409,302.272 Q 451.893,303.4387 450.8305,303.9595 Q 449.7783,304.4699 448.8096,304.4699 Z M 450.0491,302.647 Q 450.5388,302.647 451.1638,302.3761 Q 451.7888,302.1053 452.4763,301.4074 Q 452.3409,300.8761 452.3409,300.3032 V 299.3344 Q 451.9867,299.3448 451.6534,299.3761 Q 451.3305,299.3969 451.1951,299.4177 Q 449.9762,299.6782 449.4866,300.2407 Q 449.0075,300.8032 449.0075,301.4595 Q 449.0075,302.1157 449.3616,302.3866 Q 449.7158,302.647 450.0491,302.647 Z M 454.768,298.1156 H 457.966 Q 458.3618,298.1156 458.3618,297.7406 Q 458.3618,296.626 457.8931,295.9906 Q 457.4348,295.3552 456.6952,295.3552 Q 456.3723,295.3552 455.9764,295.5427 Q 455.5806,295.7197 455.2368,296.3135 Q 454.9035,296.8969 454.768,298.1156 Z"
+       id="path7207"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 495.5214,301.6053 Q 494.7089,302.7303 494.0734,303.3553 Q 493.438,303.9803 492.8339,304.2199 Q 492.2401,304.4699 491.5108,304.4699 Q 490.615,304.4699 489.7713,303.9387 Q 488.9379,303.397 488.3963,302.3866 Q 487.8546,301.3657 487.8546,299.9282 Q 487.8546,299.0323 488.1879,298.0323 Q 488.5317,297.0323 489.1775,296.1573 Q 489.8338,295.2718 490.7713,294.7197 Q 491.7192,294.1572 492.9172,294.1572 Q 493.5422,294.1572 494.063,294.376 Q 494.5943,294.5947 495.4172,295.4072 Q 495.4172,296.626 494.7922,297.001 Q 494.4693,296.3448 493.9589,295.9385 Q 493.4589,295.5322 492.8339,295.5322 Q 491.615,295.5322 490.9796,296.6052 Q 490.3546,297.6781 490.3546,299.3761 Q 490.3546,300.3761 490.6879,301.074 Q 491.0213,301.7615 491.5421,302.1261 Q 492.0734,302.4907 492.6464,302.4907 Q 493.0318,302.4907 493.6047,302.2303 Q 494.1776,301.9595 495.1359,300.9074 Q 495.2505,300.9699 495.3547,301.2511 Q 495.4589,301.522 495.5214,301.6053 Z M 497.5423,294.5426 Q 497.4381,294.8343 497.3235,295.4177 Q 497.2194,296.001 497.2298,296.6885 L 497.386,302.8553 Q 497.4277,304.2824 497.0319,305.3449 Q 496.6464,306.4179 496.0005,307.1679 Q 495.3547,307.9283 494.5943,308.3867 Q 493.8339,308.8554 493.1047,309.0638 Q 492.3859,309.2825 491.8546,309.2825 Q 490.8338,309.2825 489.9692,309.0013 Q 489.1046,308.7304 488.5838,308.3554 Q 488.0629,307.9908 488.0629,307.7096 Q 488.0629,307.6054 488.3025,307.345 Q 488.5525,307.095 488.8963,306.8033 Q 489.2504,306.5116 489.5733,306.2825 Q 489.9067,306.0637 490.0733,306.0116 Q 490.7713,306.8866 491.3963,307.2721 Q 492.0318,307.6679 492.6984,307.6679 Q 493.2609,307.6679 493.7609,307.3971 Q 494.2609,307.1262 494.5526,306.2616 Q 494.8547,305.4074 494.8339,303.6678 L 494.7297,295.4802 Q 494.9589,295.4072 495.4276,295.1677 Q 495.9068,294.9281 496.3859,294.6468 Q 496.8756,294.3551 497.1464,294.1468 Z"
+       id="path7210"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 528.7148,302.1782 Q 527.8085,303.1991 527.0794,303.6887 Q 526.3502,304.1783 525.7044,304.3241 Q 525.069,304.4699 524.4127,304.4699 Q 523.2772,304.4699 522.2876,303.8866 Q 521.3085,303.2928 520.6939,302.1886 Q 520.0897,301.074 520.0897,299.5323 Q 520.0897,298.0323 520.8085,296.8135 Q 521.5272,295.5947 522.798,294.876 Q 524.0689,294.1572 525.7148,294.1572 Q 526.1731,294.1572 526.7669,294.2614 Q 527.3606,294.3656 527.8815,294.5531 Q 528.4023,294.7301 528.6315,294.9802 Q 528.6523,295.1052 528.569,295.4906 Q 528.4856,295.8656 528.3398,296.3239 Q 528.194,296.7823 528.0481,297.1781 Q 527.9023,297.5635 527.8085,297.699 L 527.1106,297.5948 Q 526.7669,296.5739 526.2669,296.0218 Q 525.7669,295.4593 524.9335,295.4593 Q 524.319,295.4593 523.7876,295.8343 Q 523.2564,296.2093 522.923,297.0427 Q 522.5897,297.8656 522.5897,299.2094 Q 522.5897,300.8657 523.3814,301.7928 Q 524.1834,302.7199 525.319,302.7199 Q 525.7148,302.7199 526.0794,302.647 Q 526.444,302.5741 526.9231,302.3241 Q 527.4127,302.0636 528.1523,301.5115 Z M 526.9648,306.5429 Q 526.9648,307.0533 526.4752,307.5221 Q 525.996,307.9908 525.1419,308.3242 Q 524.298,308.6679 523.2147,308.7825 L 522.8293,308.0325 Q 523.7251,307.9075 524.1209,307.595 Q 524.5169,307.2929 524.5169,306.9491 Q 524.5169,306.6054 524.2668,306.4491 Q 524.0168,306.2929 523.5584,306.2512 Q 523.5584,306.2512 523.6418,306.0741 Q 523.7355,305.9075 523.9439,305.3345 Q 524.1626,304.772 524.5273,303.6157 L 525.8085,303.6366 L 525.2773,305.0845 Q 526.069,305.2304 526.5169,305.595 Q 526.9648,305.9595 526.9648,306.5429 Z"
+       id="path7213"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 564.1382,304.1574 V 303.397 Q 564.8882,303.1991 565.2007,303.0532 Q 565.5132,302.897 565.5132,302.7616 V 298.1886 Q 565.5132,296.9177 565.232,296.4906 Q 564.9612,296.0531 564.3362,296.0531 Q 563.732,296.0531 563.0757,296.4385 Q 562.4195,296.8135 561.607,297.501 V 302.7616 Q 561.607,303.1053 562.9924,303.397 V 304.1574 H 557.7319 V 303.397 Q 559.1069,303.0324 559.1069,302.7616 V 290.9488 Q 559.1069,290.3655 559.0444,290.1051 Q 558.9819,289.8446 558.6902,289.7509 Q 558.3986,289.6467 557.7319,289.5738 V 288.8446 Q 558.8986,288.6779 559.6381,288.5009 Q 560.3777,288.3134 561.1486,288.0113 L 561.607,288.4384 V 296.0114 Q 562.7945,295.0427 563.8466,294.6051 Q 564.8987,294.1572 565.7112,294.1572 Q 566.6071,294.1572 567.305,294.7614 Q 568.0133,295.3656 568.0133,296.8239 V 302.7616 Q 568.0133,302.897 568.2946,303.0428 Q 568.5758,303.1886 569.3987,303.397 V 304.1574 Z"
+       id="path7216"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 599.7543,298.4281 Q 599.5668,298.6469 599.098,298.9073 Q 598.6293,299.1573 598.2959,299.2823 H 592.0041 L 592.0249,298.1156 H 596.8688 Q 597.1084,298.1156 597.1813,298.0427 Q 597.2646,297.9594 597.2646,297.7406 Q 597.2646,297.324 597.0979,296.7823 Q 596.9417,296.2302 596.5354,295.8239 Q 596.1396,295.4072 595.4313,295.4072 Q 594.2959,295.4072 593.8271,296.4073 Q 593.3687,297.3969 593.3687,299.0532 Q 593.3687,300.6365 594.0355,301.6782 Q 594.7125,302.7199 595.9834,302.7199 Q 596.4209,302.7199 596.8375,302.647 Q 597.2542,302.5636 597.7959,302.2928 Q 598.3375,302.022 599.1501,301.4595 Q 599.2855,301.5324 599.4626,301.7928 Q 599.6501,302.0428 599.6918,302.1261 Q 598.723,303.1053 598.0042,303.6157 Q 597.2854,304.1157 596.6084,304.2928 Q 595.9417,304.4699 595.1084,304.4699 Q 593.9209,304.4699 592.9416,303.8553 Q 591.9624,303.2407 591.3687,302.1365 Q 590.7854,301.0219 590.7854,299.5532 Q 590.7854,296.7094 592.9312,295.1364 Q 593.4833,294.7301 594.2438,294.4489 Q 595.0146,294.1572 595.8063,294.1572 Q 597.1709,294.1572 598.0354,294.7614 Q 598.9105,295.3656 599.3272,296.3448 Q 599.7543,297.3135 599.7543,298.4281 Z M 597.025,292.8447 Q 596.8896,292.9697 596.5979,293.126 Q 596.3063,293.2718 596.1292,293.3239 L 592.1499,289.3967 L 592.452,288.8134 Q 592.5562,288.7925 592.8687,288.73 Q 593.1916,288.6675 593.577,288.5946 Q 593.9625,288.5217 594.2959,288.4696 Q 594.6292,288.4175 594.7542,288.4071 Z"
+       id="path7219"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 638.3817,291.0217 Q 638.3817,291.7197 637.8817,292.1676 Q 637.3921,292.6051 636.6421,292.6051 Q 636.0588,292.6051 635.6317,292.3239 Q 635.2045,292.0426 635.2045,291.4488 Q 635.2045,290.7405 635.715,290.3134 Q 636.2254,289.8759 636.9546,289.8759 Q 637.5171,289.8759 637.9442,290.1467 Q 638.3817,290.4176 638.3817,291.0217 Z M 637.9546,303.0428 Q 637.9546,304.647 637.59,305.6158 Q 637.2358,306.5846 636.6838,307.1575 Q 636.1421,307.7408 635.59,308.1679 Q 635.0274,308.6054 634.2566,308.9388 Q 633.4857,309.2825 632.9128,309.2825 Q 632.3712,309.2825 631.8087,309.1054 Q 631.2462,308.9388 630.8712,308.7096 Q 630.4856,308.4908 630.4856,308.3346 Q 630.4856,308.1887 630.7044,307.9283 Q 630.9128,307.6783 631.2253,307.4075 Q 631.5378,307.1366 631.8295,306.9179 Q 632.1212,306.6991 632.2774,306.6262 Q 632.6107,307.0325 633.1628,307.2616 Q 633.7149,307.4908 634.1003,307.4908 Q 634.4649,307.4908 634.767,307.1991 Q 635.0795,306.9075 635.267,306.0845 Q 635.4546,305.272 635.4546,303.7095 V 297.4073 Q 635.4546,296.6989 635.392,296.3448 Q 635.3399,295.9906 635.0482,295.8552 Q 634.7566,295.7197 634.0795,295.6364 V 294.9072 Q 634.8087,294.8031 635.3087,294.6989 Q 635.8192,294.5947 636.2567,294.4697 Q 636.7046,294.3343 637.2567,294.1572 H 637.9546 Z"
+       id="path7222"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 670.6219,298.4281 Q 670.4344,298.6469 669.9657,298.9073 Q 669.4969,299.1573 669.1636,299.2823 H 662.8718 L 662.8926,298.1156 H 667.7364 Q 667.9761,298.1156 668.049,298.0427 Q 668.1324,297.9594 668.1324,297.7406 Q 668.1324,297.324 667.9657,296.7823 Q 667.8093,296.2302 667.4031,295.8239 Q 667.0073,295.4072 666.2989,295.4072 Q 665.1635,295.4072 664.6948,296.4073 Q 664.2364,297.3969 664.2364,299.0532 Q 664.2364,300.6365 664.9031,301.6782 Q 665.5802,302.7199 666.851,302.7199 Q 667.2885,302.7199 667.7052,302.647 Q 668.1219,302.5636 668.6636,302.2928 Q 669.2053,302.022 670.0178,301.4595 Q 670.1532,301.5324 670.3303,301.7928 Q 670.5178,302.0428 670.5594,302.1261 Q 669.5907,303.1053 668.8719,303.6157 Q 668.1532,304.1157 667.476,304.2928 Q 666.8093,304.4699 665.976,304.4699 Q 664.7885,304.4699 663.8094,303.8553 Q 662.8301,303.2407 662.2363,302.1365 Q 661.653,301.0219 661.653,299.5532 Q 661.653,296.7094 663.7989,295.1364 Q 664.351,294.7301 665.1114,294.4489 Q 665.8823,294.1572 666.6739,294.1572 Q 668.0386,294.1572 668.9032,294.7614 Q 669.7782,295.3656 670.1949,296.3448 Q 670.6219,297.3135 670.6219,298.4281 Z M 670.0803,292.6259 Q 669.9553,292.8239 669.799,293.0426 Q 669.6532,293.251 669.4761,293.3239 L 666.5385,291.0009 L 663.6427,293.3239 Q 663.4656,293.251 663.2781,293.0426 Q 663.0905,292.8239 662.9343,292.6259 L 665.8406,288.5946 H 667.2677 Z"
+       id="path7225"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 710.6092,295.2302 Q 710.1509,295.2718 709.6925,295.4489 Q 709.2341,295.6156 708.7862,295.9489 L 704.7757,298.9906 L 703.4215,298.6781 L 706.2549,296.1468 Q 706.7029,295.7406 706.7445,295.5427 Q 706.7862,295.3447 706.557,295.2927 Q 706.3279,295.2302 705.9633,295.2302 V 294.4697 H 710.6092 Z M 699.6298,304.1574 V 303.397 Q 700.3174,303.2199 700.6611,303.0845 Q 701.0153,302.9491 701.0153,302.7616 V 290.9697 Q 701.0153,290.3551 700.9111,290.0842 Q 700.8174,289.8134 700.5257,289.73 Q 700.234,289.6363 699.6298,289.5738 V 288.8446 Q 700.6403,288.6988 701.4944,288.5113 Q 702.3486,288.3238 703.0465,288.0113 L 703.5153,288.4384 V 302.7616 Q 703.5153,302.9178 703.7028,303.0428 Q 703.8903,303.1574 704.6611,303.397 V 304.1574 Z M 710.9738,303.8137 Q 710.5675,303.9074 710.0467,304.0116 Q 709.5259,304.1157 709.0883,304.1887 Q 708.6612,304.2616 708.5154,304.2616 Q 707.6508,304.2616 707.2341,303.7095 L 703.4424,298.6781 L 705.2341,297.8865 L 709.3904,302.6053 Q 709.6821,302.9491 709.9946,303.022 Q 710.3071,303.0949 710.9113,303.0532 Z"
+       id="path7228"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 741.4896,298.4281 Q 741.3021,298.6469 740.8333,298.9073 Q 740.3646,299.1573 740.0313,299.2823 H 733.7395 L 733.7603,298.1156 H 738.6042 Q 738.8438,298.1156 738.9167,298.0427 Q 739,297.9594 739,297.7406 Q 739,297.324 738.8333,296.7823 Q 738.6771,296.2302 738.2708,295.8239 Q 737.875,295.4072 737.1666,295.4072 Q 736.0312,295.4072 735.5624,296.4073 Q 735.1041,297.3969 735.1041,299.0532 Q 735.1041,300.6365 735.7708,301.6782 Q 736.4478,302.7199 737.7188,302.7199 Q 738.1563,302.7199 738.5729,302.647 Q 738.9896,302.5636 739.5313,302.2928 Q 740.0729,302.022 740.8854,301.4595 Q 741.0208,301.5324 741.1979,301.7928 Q 741.3854,302.0428 741.4271,302.1261 Q 740.4583,303.1053 739.7396,303.6157 Q 739.0208,304.1157 738.3438,304.2928 Q 737.6771,304.4699 736.8437,304.4699 Q 735.6562,304.4699 734.677,303.8553 Q 733.6978,303.2407 733.1041,302.1365 Q 732.5207,301.0219 732.5207,299.5532 Q 732.5207,296.7094 734.6666,295.1364 Q 735.2187,294.7301 735.9791,294.4489 Q 736.7499,294.1572 737.5417,294.1572 Q 738.9063,294.1572 739.7708,294.7614 Q 740.6458,295.3656 741.0625,296.3448 Q 741.4896,297.3135 741.4896,298.4281 Z M 736.6562,290.9488 Q 736.6562,291.7093 736.1666,292.2509 Q 735.6874,292.7926 735.0208,292.7926 Q 733.7916,292.7926 733.7916,291.5217 Q 733.7916,290.7613 734.2812,290.2301 Q 734.7708,289.6884 735.4166,289.6884 Q 735.9895,289.6884 736.3228,290.0113 Q 736.6562,290.3238 736.6562,290.9488 Z M 741.0521,290.9488 Q 741.0521,291.7093 740.5729,292.2509 Q 740.0938,292.7926 739.4271,292.7926 Q 738.1875,292.7926 738.1875,291.5217 Q 738.1875,290.7613 738.6771,290.2301 Q 739.1771,289.6884 739.8125,289.6884 Q 740.3958,289.6884 740.7188,290.0113 Q 741.0521,290.3238 741.0521,290.9488 Z"
+       id="path7231"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 773.4342,304.1574 V 303.397 Q 774.3301,303.2407 774.6218,303.0845 Q 774.9134,302.9282 774.9134,302.7616 V 290.9697 Q 774.9134,290.3551 774.8093,290.0842 Q 774.7051,289.8134 774.4134,289.73 Q 774.1217,289.6363 773.5383,289.5738 V 288.8446 Q 774.5801,288.6988 775.3613,288.5217 Q 776.1426,288.3446 776.9655,288.0113 L 777.4134,288.4384 V 302.7616 Q 777.4134,302.9178 777.7259,303.0845 Q 778.0488,303.2512 778.903,303.397 V 304.1574 Z"
+       id="path7234"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 805.695,304.1574 V 303.397 Q 806.3929,303.2512 806.7263,303.0741 Q 807.0701,302.897 807.0701,302.7616 V 297.4073 Q 807.0701,296.6989 807.0284,296.3448 Q 806.9867,295.9906 806.7055,295.8552 Q 806.4241,295.7093 805.695,295.6364 V 294.9072 Q 806.5804,294.7822 807.3826,294.6051 Q 808.1951,294.4176 808.9034,294.1572 H 809.5701 V 302.7616 Q 809.5701,302.8866 809.8826,303.0741 Q 810.1951,303.2512 810.9555,303.397 V 304.1574 Z M 809.6638,292.8447 Q 809.5284,292.9697 809.2367,293.126 Q 808.9451,293.2718 808.768,293.3239 L 804.7887,289.3967 L 805.0908,288.8134 Q 805.195,288.7925 805.5075,288.73 Q 805.8304,288.6675 806.2158,288.5946 Q 806.6012,288.5217 806.9346,288.4696 Q 807.268,288.4175 807.393,288.4071 Z"
+       id="path7237"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 849.0751,303.4282 Q 849.0751,304.1678 848.6689,305.0533 Q 848.2625,305.9387 847.5646,306.7512 Q 846.8771,307.5742 846.0438,308.1158 L 845.3354,307.595 Q 845.9188,306.9179 846.2521,306.1783 Q 846.5854,305.4491 846.5854,304.5428 Q 846.5854,304.0845 846.2104,303.6991 Q 845.8354,303.3032 845.1583,303.3553 L 844.9917,302.5532 Q 845.0854,302.4282 845.4604,302.2511 Q 845.8458,302.0636 846.3458,301.8865 Q 846.8563,301.699 847.325,301.574 Q 847.8042,301.449 848.075,301.4595 Q 848.5751,301.6886 848.8251,302.147 Q 849.0751,302.6053 849.0751,303.4282 Z M 848.8564,295.2406 Q 848.8564,296.0843 848.2938,296.5531 Q 847.7313,297.0219 846.95,297.0219 Q 846.3354,297.0219 845.8875,296.6885 Q 845.4396,296.3552 845.4396,295.6156 Q 845.4396,294.8031 846.0125,294.3239 Q 846.5958,293.8343 847.3563,293.8343 Q 847.9292,293.8343 848.3876,294.1781 Q 848.8564,294.5114 848.8564,295.2406 Z"
+       id="path7240"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 878.9769,299.699 L 874.8414,304.1366 L 874.2476,303.6678 L 876.331,299.324 L 874.2372,294.9593 L 874.8414,294.4906 L 878.9873,298.9386 Z M 883.227,299.699 L 879.0915,304.1366 L 878.4873,303.6678 L 880.581,299.324 L 878.4873,294.9593 L 879.0915,294.4906 L 883.2374,298.9386 Z"
+       id="path7243"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 918.6129,295.4697 Q 918.4566,295.5531 917.9983,295.626 Q 917.5399,295.6885 917.3003,295.6885 L 916.4357,289.6155 Q 916.5503,289.553 916.894,289.4175 Q 917.2378,289.2821 917.644,289.1363 Q 918.0504,288.9905 918.3941,288.8759 Q 918.7379,288.7613 918.8421,288.7404 L 919.3733,289.0321 Z"
+       id="path7246"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 949.0995,304.4699 Q 948.4328,304.4699 947.5787,304.2616 Q 946.7245,304.0637 946.0266,303.6783 Q 945.9537,303.647 945.912,303.3241 Q 945.8808,302.9907 945.8808,302.5116 Q 945.8912,302.022 945.9433,301.522 Q 945.9953,301.0219 946.0995,300.6365 L 946.9328,300.7511 Q 947.162,301.8553 947.8599,302.5324 Q 948.5578,303.2095 949.4641,303.2095 Q 950.2142,303.2095 950.5684,302.9595 Q 950.9329,302.6991 950.9329,302.074 Q 950.9329,301.522 950.5059,301.1157 Q 950.0891,300.7094 949.4537,300.3865 Q 948.8287,300.0532 948.1933,299.7094 Q 947.537,299.3657 946.8808,298.8761 Q 946.2245,298.3865 945.787,297.699 Q 945.3598,297.001 945.3598,296.0427 Q 945.3598,295.3447 945.7662,294.6676 Q 946.1724,293.9906 946.8391,293.5114 Q 947.5162,293.0218 948.287,292.8655 L 949.1724,293.8551 Q 948.5578,293.8968 948.0683,294.4176 Q 947.5787,294.9385 947.5787,295.5322 Q 947.5787,296.1468 947.8808,296.5739 Q 948.1828,297.001 948.7974,297.4073 Q 949.412,297.8031 950.36,298.3344 Q 950.9642,298.6365 951.6309,299.0219 Q 952.2975,299.4073 952.7559,299.949 Q 953.2246,300.4803 953.2246,301.2615 Q 953.2246,302.3657 952.7559,303.0116 Q 952.2975,303.6574 951.61,303.9699 Q 950.9225,304.2824 950.235,304.3762 Q 949.5474,304.4699 949.0995,304.4699 Z M 951.4954,300.574 L 950.162,299.5532 Q 950.735,299.5115 951.1829,299.0115 Q 951.6309,298.5115 951.6309,297.8656 Q 951.6309,297.1677 951.3184,296.6885 Q 951.0163,296.1989 950.3809,295.7614 Q 949.7453,295.3239 948.7453,294.7926 Q 948.1412,294.4697 947.5058,294.0531 Q 946.8703,293.626 946.4328,293.0947 Q 946.0058,292.5634 946.0058,291.8863 Q 946.0058,291.0217 946.537,290.4176 Q 947.0787,289.803 947.9224,289.48 Q 948.7766,289.1571 949.7245,289.1571 Q 950.61,289.1571 951.485,289.3863 Q 952.3704,289.6155 952.8496,289.9801 Q 952.9225,290.0426 952.8809,290.3342 Q 952.8392,290.6155 952.735,291.0009 Q 952.6413,291.3863 952.5059,291.7405 Q 952.3809,292.0843 952.2559,292.2509 L 951.5371,292.1676 Q 951.2767,291.2509 950.7767,290.7509 Q 950.2871,290.2509 949.6099,290.2509 Q 948.9745,290.2509 948.6308,290.5217 Q 948.2974,290.7822 948.2974,291.2405 Q 948.2974,291.928 949.0162,292.3551 Q 949.7349,292.7822 950.9121,293.4072 Q 951.5996,293.7718 952.2767,294.251 Q 952.9538,294.7301 953.4017,295.4385 Q 953.8496,296.1364 953.8496,297.1885 Q 953.8496,298.1156 953.485,298.824 Q 953.1308,299.5323 952.5788,299.9907 Q 952.0371,300.4386 951.4954,300.574 Z"
+       id="path7249"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 992.9146,307.6471 Q 992.748,307.595 992.4146,307.4804 Q 992.0813,307.3762 991.7687,307.2512 Q 991.4562,307.1262 991.3312,307.0325 L 984.1853,287.7925 L 984.654,287.4904 Q 984.9561,287.5633 985.4353,287.73 Q 985.9249,287.8967 986.2165,288.0738 L 993.3521,307.3033 Z"
+       id="path7252"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 1027.087,291.7926 Q 1025.65,292.0947 1025.65,292.4384 V 298.699 Q 1025.65,300.5219 1024.983,301.8136 Q 1024.327,303.1053 1023.16,303.7928 Q 1022.004,304.4699 1020.504,304.4699 Q 1019.077,304.4699 1017.889,303.9387 Q 1016.702,303.4074 1015.993,302.3136 Q 1015.285,301.2199 1015.285,299.5323 V 292.4384 Q 1015.285,292.3134 1014.941,292.1259 Q 1014.608,291.9384 1013.858,291.7926 V 291.0322 H 1019.327 V 291.7926 Q 1017.889,292.0947 1017.889,292.4384 V 298.8552 Q 1017.889,300.8553 1018.629,301.9074 Q 1019.368,302.9595 1021.15,302.9595 Q 1022.139,302.9595 1022.722,302.397 Q 1023.306,301.824 1023.566,300.9178 Q 1023.827,300.0011 1023.827,298.9698 V 292.4384 Q 1023.827,292.3134 1023.483,292.1259 Q 1023.15,291.9384 1022.4,291.7926 V 291.0322 H 1027.087 Z M 1019.848,288.0321 Q 1019.848,288.7925 1019.358,289.3342 Q 1018.879,289.8759 1018.212,289.8759 Q 1016.983,289.8759 1016.983,288.605 Q 1016.983,287.8446 1017.473,287.3133 Q 1017.973,286.7717 1018.608,286.7717 Q 1019.191,286.7717 1019.514,287.0946 Q 1019.848,287.4071 1019.848,288.0321 Z M 1024.243,288.0321 Q 1024.243,288.7925 1023.764,289.3342 Q 1023.285,289.8759 1022.618,289.8759 Q 1021.379,289.8759 1021.379,288.605 Q 1021.379,287.8446 1021.868,287.3133 Q 1022.368,286.7717 1023.014,286.7717 Q 1023.587,286.7717 1023.91,287.0946 Q 1024.243,287.4071 1024.243,288.0321 Z"
+       id="path7255"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00002" />
+    <path
+       d="M 106.1249,276.2546 Q 105.2915,277.2026 104.5728,277.7026 Q 103.8645,278.1921 103.2082,278.3588 Q 102.5624,278.5359 101.9166,278.5359 Q 100.6562,278.5359 99.56241,277.8276 Q 98.46866,277.1088 97.79158,275.6921 Q 97.1145,274.2651 97.1145,272.1401 Q 97.1145,268.6922 98.65616,267.0255 Q 100.2082,265.3588 102.8541,265.3588 Q 103.8853,265.3588 104.7499,265.6713 Q 105.6249,265.9734 106.1665,266.4005 Q 106.2186,266.4422 106.104,266.7234 Q 105.9895,266.9942 105.7915,267.3588 Q 105.5936,267.713 105.3853,268.0255 Q 105.1874,268.338 105.0728,268.463 L 104.3957,268.3172 Q 103.9166,267.5567 103.3749,267.1505 Q 102.8332,266.7338 102.052,266.7338 Q 101.6666,266.7338 101.2603,266.9317 Q 100.8645,267.1297 100.5103,267.6817 Q 100.1666,268.2234 99.95824,269.2651 Q 99.74991,270.3067 99.74991,271.9942 Q 99.74991,273.9526 100.1978,275.0567 Q 100.6457,276.1505 101.3124,276.5984 Q 101.9895,277.0463 102.6666,277.0463 Q 103.2291,277.0463 103.8645,276.7859 Q 104.5103,276.5151 105.5832,275.5567 Q 105.729,275.6921 105.8645,275.8901 Q 105.9999,276.088 106.1249,276.2546 Z M 102.9999,273.6713 H 96.34367 L 96.04158,273.3276 Q 96.08325,273.1713 96.177,272.8797 Q 96.28117,272.588 96.34367,272.4213 H 102.9999 L 103.3436,272.7338 Z M 103.6249,271.2234 H 96.65617 L 96.35408,270.8797 Q 96.39575,270.7234 96.4895,270.4317 Q 96.59367,270.1401 96.65617,269.9734 H 103.6249 L 103.9686,270.2859 Z"
+       id="path7258"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 206.7185,273.7442 L 205.7185,276.7546 Q 205.6248,277.0776 205.9789,277.2234 Q 206.3331,277.3692 207.1873,277.463 V 278.2234 H 202.6352 V 277.463 Q 203.3435,277.338 203.7185,277.2026 Q 204.104,277.0671 204.2081,276.7546 L 207.8435,265.6505 Q 208.3331,265.2234 208.9685,264.9422 Q 209.6144,264.6609 210.156,264.5047 L 214.531,276.7546 Q 214.6352,277.0463 214.8852,277.213 Q 215.1456,277.3796 215.8227,277.463 V 278.2234 H 210.6456 V 277.463 Q 211.4477,277.4109 211.7394,277.2546 Q 212.031,277.0984 211.9164,276.7546 L 210.8539,273.7442 Z M 210.4164,272.4942 L 208.6977,267.6505 L 207.1352,272.4942 Z"
+       id="path7264"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 238.4182,273.7442 L 237.4182,276.7546 Q 237.3245,277.0776 237.6786,277.2234 Q 238.0328,277.3692 238.887,277.463 V 278.2234 H 234.3349 V 277.463 Q 235.0432,277.338 235.4182,277.2026 Q 235.8036,277.0671 235.9078,276.7546 L 239.5432,265.6505 Q 240.0328,265.2234 240.6682,264.9422 Q 241.3141,264.6609 241.8557,264.5047 L 246.2307,276.7546 Q 246.3349,277.0463 246.5849,277.213 Q 246.8453,277.3796 247.5224,277.463 V 278.2234 H 242.3453 V 277.463 Q 243.1474,277.4109 243.439,277.2546 Q 243.7307,277.0984 243.6161,276.7546 L 242.5536,273.7442 Z M 242.1161,272.4942 L 240.3974,267.6505 L 238.8349,272.4942 Z M 239.3974,264.0776 Q 239.2203,263.9942 239.0016,263.7442 Q 238.7932,263.4942 238.6995,263.3484 L 242.5432,259.8068 Q 242.6474,259.8588 242.9391,260.0151 Q 243.2411,260.1609 243.5849,260.3484 Q 243.9286,260.5255 244.2099,260.6922 Q 244.5015,260.8484 244.5953,260.9318 L 244.6995,261.5672 Z"
+       id="path7267"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 283.0545,267.7547 L 282.367,267.6922 Q 281.9087,266.713 281.2108,266.3484 Q 280.5233,265.9838 279.9295,265.9838 Q 278.8879,265.9838 278.4295,266.4838 Q 277.9712,266.9838 277.9712,267.5776 Q 277.9712,268.2338 278.4504,268.713 Q 278.9295,269.1817 279.6795,269.5776 Q 280.44,269.9734 281.2837,270.3797 Q 282.1275,270.7859 282.8775,271.3067 Q 283.6379,271.8276 284.117,272.5463 Q 284.5962,273.2651 284.5962,274.2963 Q 284.5962,274.9942 284.2733,275.7338 Q 283.9608,276.4734 283.315,277.1088 Q 282.6795,277.7442 281.7004,278.1401 Q 280.7316,278.5359 279.4087,278.5359 Q 278.9087,278.5359 278.2316,278.4109 Q 277.5545,278.2859 276.8775,278.0567 Q 276.2108,277.8276 275.7212,277.5151 Q 275.6587,277.4734 275.6171,277.1088 Q 275.5858,276.7442 275.5858,276.2234 Q 275.5858,275.7026 275.6379,275.1609 Q 275.69,274.6192 275.8046,274.2234 L 276.5441,274.2755 Q 277.0129,275.5046 277.8879,276.2755 Q 278.7733,277.0463 279.8358,277.0463 Q 280.7733,277.0463 281.5129,276.5255 Q 282.2525,275.9942 282.2525,275.0046 Q 282.2525,274.1609 281.7733,273.5984 Q 281.2941,273.0359 280.5441,272.6401 Q 279.8045,272.2338 278.9608,271.8588 Q 278.1275,271.4838 277.3775,271.0255 Q 276.6275,270.5672 276.1483,269.9005 Q 275.6796,269.2338 275.6796,268.2234 Q 275.6796,267.7442 275.9504,267.1505 Q 276.2316,266.5567 276.8045,266.0255 Q 277.3879,265.4838 278.2941,265.1401 Q 279.2004,264.7859 280.4608,264.7859 Q 281.5858,264.7859 282.5754,265.0567 Q 283.565,265.3276 283.9504,265.7442 Q 284.0129,265.8172 283.9295,266.088 Q 283.8566,266.3588 283.69,266.7026 Q 283.5337,267.0463 283.3566,267.3484 Q 283.1795,267.6401 283.0545,267.7547 Z"
+       id="path7270"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 311.4875,278.5359 Q 310.175,278.5359 309.1229,277.9942 Q 308.0812,277.4421 307.3416,276.5046 Q 306.6125,275.5671 306.227,274.3692 Q 305.8416,273.1609 305.8416,271.8484 Q 305.8416,270.4317 306.3,269.1609 Q 306.7583,267.8797 307.5916,266.9005 Q 308.425,265.9109 309.5708,265.3484 Q 310.7166,264.7859 312.0916,264.7859 Q 313.4666,264.7859 314.5187,265.3484 Q 315.5812,265.9109 316.2895,266.8692 Q 317.0083,267.8172 317.3729,269.0151 Q 317.7479,270.213 317.7479,271.4838 Q 317.7479,272.9005 317.2479,274.1713 Q 316.7479,275.4421 315.8833,276.4317 Q 315.0187,277.4109 313.8833,277.9734 Q 312.7583,278.5359 311.4875,278.5359 Z M 311.9458,277.1296 Q 313.3208,277.1296 314.2166,275.7859 Q 315.1125,274.4317 315.1125,271.6713 Q 315.1125,270.2338 314.6645,268.9734 Q 314.2166,267.713 313.4145,266.9317 Q 312.6229,266.1401 311.5604,266.1401 Q 310.0604,266.1401 309.2583,267.5672 Q 308.4666,268.9942 308.4666,271.5463 Q 308.4666,273.0984 308.9354,274.3692 Q 309.4145,275.6401 310.2062,276.3901 Q 310.9979,277.1296 311.9458,277.1296 Z M 310.3833,264.0776 Q 310.2062,263.9942 309.9875,263.7442 Q 309.7791,263.4942 309.6854,263.3484 L 313.5291,259.8068 Q 313.6333,259.8588 313.925,260.0151 Q 314.227,260.1609 314.5708,260.3484 Q 314.9145,260.5255 315.1958,260.6922 Q 315.4875,260.8484 315.5812,260.9318 L 315.6854,261.5672 Z"
+       id="path7273"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 344.8903,278.2234 V 277.463 Q 346.3174,277.1713 346.3174,276.8276 V 266.1609 Q 345.9112,266.2234 345.5466,266.2755 Q 345.182,266.3276 344.8903,266.3692 L 344.7549,265.4109 Q 345.4424,265.2338 346.432,265.0984 Q 347.432,264.9526 348.4945,264.8692 Q 349.5674,264.7859 350.4632,264.7859 Q 353.6507,264.7859 355.4007,266.4734 Q 357.1611,268.1609 357.1611,271.1817 Q 357.1611,273.1297 356.5882,274.4838 Q 356.0153,275.8276 355.0882,276.6609 Q 354.1611,277.4838 353.057,277.8588 Q 351.9632,278.2234 350.8903,278.2234 H 350.0466 Q 348.8278,278.2234 347.7757,278.2234 Q 346.7341,278.2234 345.2966,278.2234 Z M 350.5049,277.1088 Q 351.1091,277.1088 351.7757,276.7963 Q 352.4528,276.4838 353.0361,275.8171 Q 353.6299,275.1505 353.9945,274.1088 Q 354.3695,273.0567 354.3695,271.588 Q 354.3695,268.8172 353.1716,267.3588 Q 351.9841,265.8901 349.7132,265.8901 Q 349.5257,265.8901 349.3278,265.9005 Q 349.1299,265.9109 348.9216,265.9213 V 276.463 Q 348.9216,276.8796 349.4007,276.9942 Q 349.8799,277.1088 350.5049,277.1088 Z"
+       id="path7276"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 380.1505,273.7442 L 379.1505,276.7546 Q 379.0568,277.0776 379.411,277.2234 Q 379.7651,277.3692 380.6193,277.463 V 278.2234 H 376.0672 V 277.463 Q 376.7755,277.338 377.1505,277.2026 Q 377.536,277.0671 377.6401,276.7546 L 381.2755,265.6505 Q 381.7651,265.2234 382.4005,264.9422 Q 383.0464,264.6609 383.588,264.5047 L 387.963,276.7546 Q 388.0672,277.0463 388.3172,277.213 Q 388.5776,277.3796 389.2547,277.463 V 278.2234 H 384.0776 V 277.463 Q 384.8797,277.4109 385.1714,277.2546 Q 385.463,277.0984 385.3484,276.7546 L 384.2859,273.7442 Z M 383.8484,272.4942 L 382.1297,267.6505 L 380.5672,272.4942 Z M 381.8901,262.0984 Q 381.8901,262.8588 381.4005,263.4005 Q 380.9214,263.9422 380.2547,263.9422 Q 379.0255,263.9422 379.0255,262.6713 Q 379.0255,261.9109 379.5151,261.3797 Q 380.0151,260.838 380.6505,260.838 Q 381.2339,260.838 381.5568,261.1609 Q 381.8901,261.4734 381.8901,262.0984 Z M 386.2859,262.0984 Q 386.2859,262.8588 385.8068,263.4005 Q 385.3276,263.9422 384.6609,263.9422 Q 383.4214,263.9422 383.4214,262.6713 Q 383.4214,261.9109 383.9109,261.3797 Q 384.4109,260.838 385.0568,260.838 Q 385.6297,260.838 385.9526,261.1609 Q 386.2859,261.4734 386.2859,262.0984 Z"
+       id="path7279"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 426.6625,265.4317 Q 426.6521,265.7859 426.5792,266.3692 Q 426.5167,266.9526 426.4229,267.5047 Q 426.3396,268.0567 426.2562,268.3276 H 425.4542 Q 425.3917,266.3484 424.6,266.3484 H 420.475 L 420.7771,265.0984 H 426.2667 Z M 425.2146,270.9317 Q 425.0167,271.2859 424.7354,271.6922 Q 424.4542,272.088 424.2354,272.2442 Q 423.9333,271.9422 423.4854,271.8067 Q 423.0479,271.6713 422.1833,271.6713 H 419.0688 L 420.2667,270.5672 H 424.8396 Z M 416.9854,278.2234 V 277.463 Q 418.4125,277.1713 418.4125,276.8276 V 266.5047 Q 418.4125,266.3797 418.0688,266.1922 Q 417.7354,266.0047 416.9854,265.8588 V 265.0984 H 422.5271 V 265.8588 Q 421.9229,265.9317 421.4646,266.0359 Q 421.0167,266.1297 421.0167,266.2755 V 276.8276 Q 421.0167,276.9526 421.3708,277.1088 Q 421.7354,277.2651 422.7667,277.463 V 278.2234 Z"
+       id="path7282"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 461.9098,275.0567 Q 461.8473,275.6505 461.764,276.3171 Q 461.6911,276.9734 461.6077,277.4942 Q 461.5348,278.0151 461.4827,278.2234 H 451.6494 V 277.463 Q 453.0557,277.1817 453.0557,276.8276 V 271.7234 H 450.3994 L 448.3577,276.7546 Q 448.2223,277.0567 448.4619,277.213 Q 448.7119,277.3692 449.4827,277.463 V 278.2234 H 445.1494 V 277.463 Q 445.7848,277.3692 446.1598,277.213 Q 446.5348,277.0567 446.6598,276.7546 L 450.7119,266.7338 Q 450.8577,266.3797 450.4932,266.2234 Q 450.139,266.0567 449.1182,265.8588 V 265.0984 H 454.639 H 456.389 H 460.8369 L 461.2223,265.4317 Q 461.2015,265.7859 461.139,266.3692 Q 461.0765,266.9526 460.9827,267.5047 Q 460.8994,268.0567 460.7952,268.3276 H 460.014 Q 459.9202,266.3484 459.1598,266.3484 H 455.6598 V 270.5672 H 459.8056 L 460.1598,270.9317 Q 459.9827,271.2234 459.6911,271.6713 Q 459.4098,272.1192 459.2015,272.2963 Q 459.0036,272.088 458.7015,271.963 Q 458.4098,271.838 458.1702,271.7859 Q 457.9411,271.7234 457.9098,271.7234 H 455.6598 V 276.3067 Q 455.6598,276.5046 455.8161,276.6609 Q 455.9723,276.8067 456.4306,276.8901 Q 456.8994,276.9734 457.8161,276.9734 H 458.8056 Q 459.7744,276.9734 460.2327,276.4942 Q 460.7015,276.0046 461.1494,274.7859 Z M 453.0557,266.5776 Q 453.0557,266.3484 452.7952,266.3692 Q 452.5452,266.3901 452.3994,266.7547 L 450.8473,270.5672 H 453.0557 Z"
+       id="path7285"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 498.6011,272.4734 Q 498.0074,272.6088 497.799,272.8484 Q 497.5907,273.088 497.5907,273.3276 V 276.463 Q 497.5907,276.463 497.2053,276.5984 Q 496.8303,276.7338 496.3303,276.9005 Q 495.8407,277.0671 495.4657,277.1713 Q 495.0907,277.2755 495.0907,277.2026 V 273.3276 Q 495.0907,273.1713 494.9969,273.0359 Q 494.9032,272.8901 494.549,272.7547 Q 494.1949,272.6088 493.4136,272.4734 V 271.713 H 498.6011 Z M 497.6115,265.8484 Q 497.6844,265.9005 497.5594,266.1922 Q 497.4449,266.4838 497.2365,266.8588 Q 497.0282,267.2338 496.8094,267.5567 Q 496.5907,267.8797 496.4553,268.0047 L 495.799,267.8588 Q 495.1115,266.8588 494.3824,266.4734 Q 493.6532,266.088 492.7469,266.088 Q 492.3615,266.088 491.799,266.3484 Q 491.2365,266.5984 490.6845,267.213 Q 490.1428,267.8276 489.7782,268.9005 Q 489.4136,269.963 489.4136,271.588 Q 489.4136,273.4422 489.9553,274.6192 Q 490.5074,275.7859 491.3824,276.338 Q 492.2678,276.8901 493.2469,276.8901 Q 494.299,276.8901 494.9553,276.5671 Q 495.6219,276.2338 496.1636,275.7234 Q 496.2574,275.7651 496.5803,275.9317 Q 496.9136,276.088 497.2261,276.2546 Q 497.549,276.4109 497.5907,276.463 Q 496.0386,277.7234 494.8928,278.1296 Q 493.7469,278.5359 492.799,278.5359 Q 491.6636,278.5359 490.5907,278.1505 Q 489.5178,277.7546 488.6532,276.963 Q 487.799,276.1713 487.2886,274.9734 Q 486.7782,273.7651 486.7782,272.1609 Q 486.7782,269.8484 487.7261,268.2026 Q 488.6845,266.5463 490.3303,265.6713 Q 491.9761,264.7859 494.0386,264.7859 Q 494.4969,264.7859 495.1636,264.9109 Q 495.8303,265.0359 496.4969,265.2755 Q 497.1636,265.5047 497.6115,265.8484 Z"
+       id="path7288"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 529.6849,276.0255 Q 528.3515,277.3901 527.0911,277.963 Q 525.8307,278.5359 524.6328,278.5359 Q 523.5807,278.5359 522.5911,278.1088 Q 521.6015,277.6713 520.8099,276.8484 Q 520.0286,276.0151 519.5599,274.8276 Q 519.1015,273.6297 519.1015,272.1192 Q 519.1015,269.9005 519.9765,268.2547 Q 520.862,266.6088 522.362,265.7026 Q 523.862,264.7859 525.7265,264.7859 Q 526.8411,264.7859 527.8932,265.0984 Q 528.9453,265.4005 529.4869,265.8276 Q 529.539,265.8692 529.4244,266.1713 Q 529.3099,266.4734 529.1119,266.8692 Q 528.914,267.2547 528.7057,267.588 Q 528.5078,267.9213 528.3932,268.0463 L 527.7161,267.9005 Q 527.1953,266.9942 526.4974,266.5776 Q 525.8099,266.1609 525.0078,266.1609 Q 524.4765,266.1609 523.9036,266.4317 Q 523.3307,266.7026 522.8307,267.338 Q 522.3411,267.963 522.039,269.0359 Q 521.737,270.1088 521.737,271.7338 Q 521.737,273.5047 522.3203,274.6296 Q 522.914,275.7546 523.8099,276.2859 Q 524.7057,276.8171 525.6224,276.8171 Q 526.1849,276.8171 527.1119,276.5255 Q 528.0494,276.2234 529.1432,275.3171 Q 529.2474,275.4005 529.4349,275.6713 Q 529.6328,275.9421 529.6849,276.0255 Z M 527.0599,280.6088 Q 527.0599,281.1192 526.5703,281.588 Q 526.0911,282.0567 525.2369,282.3901 Q 524.3932,282.7338 523.3099,282.8484 L 522.9245,282.0984 Q 523.8203,281.9734 524.2161,281.6609 Q 524.6119,281.3588 524.6119,281.0151 Q 524.6119,280.6713 524.3619,280.5151 Q 524.112,280.3588 523.6536,280.3171 Q 523.6536,280.3171 523.737,280.1401 Q 523.8307,279.9734 524.039,279.4005 Q 524.2578,278.838 524.6224,277.6817 L 525.9036,277.7026 L 525.3724,279.1505 Q 526.164,279.2963 526.6119,279.6609 Q 527.0599,280.0255 527.0599,280.6088 Z"
+       id="path7291"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 564.8317,278.2234 V 277.463 Q 566.2588,277.1713 566.2588,276.8276 V 266.5047 Q 566.2588,266.3797 565.915,266.1922 Q 565.5817,266.0047 564.8317,265.8588 V 265.0984 H 570.3005 V 265.8588 Q 568.863,266.1609 568.863,266.5047 V 276.8276 Q 568.863,276.9526 569.2067,277.1401 Q 569.5505,277.3171 570.3005,277.463 V 278.2234 Z M 560.5505,271.9734 V 270.7234 H 566.4671 V 271.9734 Z M 556.8109,278.2234 V 277.463 Q 558.238,277.1713 558.238,276.8276 V 266.5047 Q 558.238,266.3797 557.8942,266.1922 Q 557.5609,266.0047 556.8109,265.8588 V 265.0984 H 562.2796 V 265.8588 Q 560.8421,266.1609 560.8421,266.5047 V 276.8276 Q 560.8421,276.9526 561.1755,277.1401 Q 561.5192,277.3171 562.2796,277.463 V 278.2234 Z"
+       id="path7294"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 599.7144,265.4317 Q 599.6936,265.7859 599.6207,266.3692 Q 599.5582,266.9526 599.4644,267.5047 Q 599.3707,268.0567 599.2874,268.3276 H 598.5061 Q 598.4124,266.3484 597.6519,266.3484 H 593.6103 L 593.9124,265.0984 H 599.2978 Z M 598.6415,270.9317 Q 598.4749,271.2234 598.1936,271.6609 Q 597.9124,272.088 597.6832,272.2442 Q 597.3603,271.9422 596.9228,271.8067 Q 596.4957,271.6713 595.6207,271.6713 H 593.4645 L 593.6936,270.5672 H 598.2978 Z M 600.3915,275.0567 Q 600.3394,275.6505 600.2561,276.3171 Q 600.1832,276.9734 600.0999,277.4942 Q 600.0269,278.0151 599.9644,278.2234 H 590.1207 V 277.463 Q 591.5478,277.1713 591.5478,276.8276 V 266.5047 Q 591.5478,266.3797 591.204,266.1922 Q 590.8707,266.0047 590.1207,265.8588 V 265.0984 H 595.6624 V 265.8588 Q 594.9644,265.9317 594.5582,266.0359 Q 594.152,266.1297 594.152,266.2755 V 276.3067 Q 594.152,276.5046 594.2978,276.6609 Q 594.454,276.8067 594.9019,276.8901 Q 595.3603,276.9734 596.2769,276.9734 H 597.3082 Q 598.2665,276.9734 598.7249,276.4942 Q 599.1832,276.0046 599.6311,274.7859 Z M 597.2249,263.3692 Q 597.1311,263.5567 596.9124,263.7859 Q 596.6936,264.0047 596.5269,264.1088 L 591.3082,261.463 L 591.3915,260.8068 Q 591.5061,260.7234 591.9332,260.4943 Q 592.3707,260.2651 592.8082,260.0463 Q 593.2561,259.8172 593.4124,259.7443 Z"
+       id="path7297"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 639.0475,265.8588 Q 637.61,266.1609 637.61,266.5047 V 276.3171 Q 637.61,277.8484 637.2142,278.8171 Q 636.8287,279.7963 636.2558,280.4005 Q 635.6933,281.0151 635.1517,281.4526 Q 634.5892,281.9109 633.7871,282.2338 Q 632.9954,282.5671 632.2975,282.5671 Q 631.6829,282.5671 631.11,282.3901 Q 630.5371,282.213 630.1725,281.9734 Q 629.7975,281.7442 629.7975,281.5776 Q 629.7975,281.463 630.0163,281.213 Q 630.2246,280.9734 630.5371,280.6921 Q 630.8392,280.4109 631.1308,280.1921 Q 631.4121,279.9734 631.5579,279.9109 Q 632.1308,280.4109 632.6204,280.6088 Q 633.11,280.8171 633.5163,280.8171 Q 633.8808,280.8171 634.2142,280.5567 Q 634.5579,280.3067 634.7767,279.5046 Q 635.0058,278.7026 635.0058,277.0671 V 266.5047 Q 635.0058,266.3797 634.6517,266.213 Q 634.3079,266.0359 633.0579,265.8588 V 265.0984 H 639.0475 Z"
+       id="path7300"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 670.5805,265.4317 Q 670.5597,265.7859 670.4868,266.3692 Q 670.4243,266.9526 670.3305,267.5047 Q 670.2368,268.0567 670.1534,268.3276 H 669.3722 Q 669.2784,266.3484 668.518,266.3484 H 664.4764 L 664.7785,265.0984 H 670.1639 Z M 669.5076,270.9317 Q 669.3409,271.2234 669.0597,271.6609 Q 668.7784,272.088 668.5493,272.2442 Q 668.2264,271.9422 667.7889,271.8067 Q 667.3618,271.6713 666.4868,271.6713 H 664.3305 L 664.5597,270.5672 H 669.1639 Z M 671.2576,275.0567 Q 671.2055,275.6505 671.1222,276.3171 Q 671.0493,276.9734 670.9659,277.4942 Q 670.893,278.0151 670.8305,278.2234 H 660.9868 V 277.463 Q 662.4139,277.1713 662.4139,276.8276 V 266.5047 Q 662.4139,266.3797 662.0701,266.1922 Q 661.7368,266.0047 660.9868,265.8588 V 265.0984 H 666.5285 V 265.8588 Q 665.8305,265.9317 665.4243,266.0359 Q 665.018,266.1297 665.018,266.2755 V 276.3067 Q 665.018,276.5046 665.1639,276.6609 Q 665.3201,276.8067 665.768,276.8901 Q 666.2264,276.9734 667.143,276.9734 H 668.1743 Q 669.1326,276.9734 669.5909,276.4942 Q 670.0493,276.0046 670.4972,274.7859 Z M 669.6534,263.3588 Q 669.5284,263.5567 669.3618,263.7755 Q 669.2055,263.9838 669.0284,264.0567 L 666.1118,262.2859 L 663.216,264.0567 Q 663.0389,263.9838 662.8514,263.7755 Q 662.6639,263.5567 662.5076,263.3588 L 665.4139,259.9005 H 666.841 Z"
+       id="path7303"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 710.9808,265.8588 Q 710.3141,265.9422 710.0016,266.0567 Q 709.6891,266.1609 709.3662,266.5047 L 704.5745,271.5255 H 702.8141 L 706.8349,266.7859 Q 707.3037,266.2234 707.2099,266.0776 Q 707.1162,265.9317 706.2933,265.8588 V 265.0984 H 710.9808 Z M 711.6474,277.6817 Q 711.2412,277.8067 710.7203,277.9734 Q 710.2099,278.1296 709.7203,278.2442 Q 709.2412,278.3692 708.9078,278.3692 Q 708.5953,278.3692 708.3662,278.2755 Q 708.137,278.1817 707.9287,277.9213 L 702.8141,271.5255 L 704.4599,270.713 L 709.9183,276.5046 Q 710.2516,276.8692 710.637,276.9317 Q 711.0328,276.9838 711.5745,276.9213 Z M 698.9287,278.2234 V 277.463 Q 700.3558,277.1713 700.3558,276.8276 V 266.5047 Q 700.3558,266.3797 700.012,266.1922 Q 699.6787,266.0047 698.9287,265.8588 V 265.0984 H 704.3974 V 265.8588 Q 702.9599,266.1609 702.9599,266.5047 V 276.8276 Q 702.9599,276.9526 703.2933,277.1401 Q 703.637,277.3171 704.3974,277.463 V 278.2234 Z"
+       id="path7306"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 741.4467,265.4317 Q 741.4259,265.7859 741.353,266.3692 Q 741.2905,266.9526 741.1967,267.5047 Q 741.103,268.0567 741.0197,268.3276 H 740.2384 Q 740.1447,266.3484 739.3842,266.3484 H 735.3426 L 735.6447,265.0984 H 741.0301 Z M 740.3738,270.9317 Q 740.2072,271.2234 739.9259,271.6609 Q 739.6447,272.088 739.4155,272.2442 Q 739.0926,271.9422 738.6551,271.8067 Q 738.228,271.6713 737.353,271.6713 H 735.1968 L 735.4259,270.5672 H 740.0301 Z M 742.1238,275.0567 Q 742.0717,275.6505 741.9884,276.3171 Q 741.9155,276.9734 741.8322,277.4942 Q 741.7592,278.0151 741.6967,278.2234 H 731.853 V 277.463 Q 733.2801,277.1713 733.2801,276.8276 V 266.5047 Q 733.2801,266.3797 732.9363,266.1922 Q 732.603,266.0047 731.853,265.8588 V 265.0984 H 737.3947 V 265.8588 Q 736.6967,265.9317 736.2905,266.0359 Q 735.8842,266.1297 735.8842,266.2755 V 276.3067 Q 735.8842,276.5046 736.0301,276.6609 Q 736.1863,276.8067 736.6342,276.8901 Q 737.0926,276.9734 738.0092,276.9734 H 739.0405 Q 739.9988,276.9734 740.4572,276.4942 Q 740.9155,276.0046 741.3634,274.7859 Z M 736.2176,262.0984 Q 736.2176,262.8588 735.728,263.4005 Q 735.2488,263.9422 734.5822,263.9422 Q 733.353,263.9422 733.353,262.6713 Q 733.353,261.9109 733.8426,261.3797 Q 734.3426,260.838 734.978,260.838 Q 735.5613,260.838 735.8842,261.1609 Q 736.2176,261.4734 736.2176,262.0984 Z M 740.6134,262.0984 Q 740.6134,262.8588 740.1342,263.4005 Q 739.6551,263.9422 738.9884,263.9422 Q 737.7488,263.9422 737.7488,262.6713 Q 737.7488,261.9109 738.2384,261.3797 Q 738.7384,260.838 739.3842,260.838 Q 739.9572,260.838 740.2801,261.1609 Q 740.6134,261.4734 740.6134,262.0984 Z"
+       id="path7309"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 781.2372,275.0567 Q 781.1851,275.6505 781.1018,276.3171 Q 781.0289,276.9734 780.9455,277.4942 Q 780.8622,278.0151 780.8101,278.2234 H 771.0705 V 277.463 Q 772.4976,277.1713 772.4976,276.8276 V 266.5047 Q 772.4976,266.3797 772.1539,266.1922 Q 771.8205,266.0047 771.0705,265.8588 V 265.0984 H 776.5393 V 265.8588 Q 775.1018,266.1609 775.1018,266.5047 V 276.2026 Q 775.1018,276.5671 775.4976,276.7755 Q 775.9039,276.9734 777.0393,276.9734 H 778.2164 Q 778.8622,276.9734 779.2476,276.7651 Q 779.633,276.5567 779.9039,276.0776 Q 780.1851,275.5984 780.4768,274.7859 Z"
+       id="path7312"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 805.7294,278.2234 V 277.463 Q 807.1565,277.1713 807.1565,276.8276 V 266.5047 Q 807.1565,266.3797 806.8127,266.1922 Q 806.4794,266.0047 805.7294,265.8588 V 265.0984 H 811.1981 V 265.8588 Q 809.7606,266.1609 809.7606,266.5047 V 276.8276 Q 809.7606,276.9526 810.1044,277.1401 Q 810.4481,277.3171 811.1981,277.463 V 278.2234 Z M 810.4273,263.3692 Q 810.3335,263.5567 810.1148,263.7859 Q 809.896,264.0047 809.7294,264.1088 L 804.5106,261.463 L 804.594,260.8068 Q 804.7085,260.7234 805.1356,260.4943 Q 805.5731,260.2651 806.0106,260.0463 Q 806.4585,259.8172 806.6148,259.7443 Z"
+       id="path7315"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 848.7247,276.8588 Q 848.7247,277.7026 848.1622,278.1713 Q 847.5997,278.6401 846.8184,278.6401 Q 846.2038,278.6401 845.7559,278.3067 Q 845.308,277.9734 845.308,277.2338 Q 845.308,276.4213 845.8809,275.9421 Q 846.4642,275.4526 847.2247,275.4526 Q 847.7976,275.4526 848.2559,275.7963 Q 848.7247,276.1296 848.7247,276.8588 Z M 848.7247,269.3067 Q 848.7247,270.1505 848.1622,270.6192 Q 847.5997,271.088 846.8184,271.088 Q 846.2038,271.088 845.7559,270.7547 Q 845.308,270.4213 845.308,269.6817 Q 845.308,268.8692 845.8809,268.3901 Q 846.4642,267.9005 847.2247,267.9005 Q 847.7976,267.9005 848.2559,268.2442 Q 848.7247,268.5776 848.7247,269.3067 Z"
+       id="path7318"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 882.0071,265.1635 Q 882.0071,266.0619 881.5253,266.8953 Q 881.0435,267.7156 880.2623,268.2494 Q 879.481,268.7703 878.5696,268.7703 Q 877.1243,268.7703 876.2779,267.8197 Q 875.4316,266.8692 875.4316,265.4369 Q 875.4316,264.5385 875.8612,263.7051 Q 876.304,262.8588 877.0722,262.3249 Q 877.8534,261.7781 878.8691,261.7781 Q 880.2753,261.7781 881.1347,262.7676 Q 882.0071,263.7572 882.0071,265.1635 Z M 875.5618,270.5932 V 269.4473 H 881.8769 V 270.5932 Z M 880.2363,265.476 Q 880.2363,264.3822 879.8196,263.5229 Q 879.4029,262.6505 878.6217,262.6505 Q 877.8404,262.6505 877.5149,263.3406 Q 877.2024,264.0307 877.2024,265.1374 Q 877.2024,266.2442 877.6842,267.0775 Q 878.1659,267.9109 878.817,267.9109 Q 879.5982,267.9109 879.9107,267.2468 Q 880.2363,266.5828 880.2363,265.476 Z"
+       style="font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path7321" />
+    <path
+       d="M 920.6934,269.5359 Q 920.5372,269.6192 920.0788,269.6922 Q 919.6205,269.7547 919.3809,269.7547 L 918.5163,263.6817 Q 918.6309,263.6192 918.9642,263.4838 Q 919.308,263.3484 919.7142,263.2026 Q 920.1309,263.0568 920.4747,262.9422 Q 920.8184,262.8276 920.9226,262.8068 L 921.4538,263.0984 Z M 916.4955,269.5359 Q 916.3392,269.6192 915.8809,269.6922 Q 915.4226,269.7547 915.183,269.7547 L 914.3184,263.6817 Q 914.433,263.6192 914.7768,263.4838 Q 915.1205,263.3484 915.5267,263.2026 Q 915.933,263.0568 916.2767,262.9422 Q 916.6205,262.8276 916.7247,262.8068 L 917.2559,263.0984 Z"
+       id="path7324"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 950.6308,278.1505 Q 950.2454,278.4838 949.7141,278.6505 L 949.3808,278.3067 V 265.7338 Q 949.662,265.5567 949.8079,265.4422 Q 949.9537,265.3276 950.2766,265.2547 L 950.6308,265.5567 Z M 954.0579,274.4942 Q 953.1516,275.5151 952.4433,276.0255 Q 951.735,276.5359 951.0787,276.713 Q 950.4225,276.8796 949.6829,276.8796 Q 948.9329,276.8796 948.1308,276.5776 Q 947.3287,276.2651 946.6412,275.6609 Q 945.9641,275.0567 945.537,274.1713 Q 945.1204,273.2755 945.1204,272.1192 Q 945.1204,270.6401 945.86,269.4838 Q 946.61,268.3172 947.9225,267.6505 Q 949.2454,266.9838 950.985,266.9838 Q 951.4433,266.9838 952.0579,267.088 Q 952.6725,267.1817 953.2141,267.3692 Q 953.7558,267.5567 953.9849,267.8172 Q 954.0162,267.9734 953.8599,268.4422 Q 953.7037,268.9109 953.4954,269.3901 Q 953.287,269.8588 953.162,270.0359 L 952.485,269.8588 Q 952.3495,269.6088 952.0475,269.2547 Q 951.7558,268.9005 951.2558,268.6192 Q 950.7662,268.338 950.0475,268.338 Q 949.412,268.338 948.7975,268.6713 Q 948.1933,268.9942 947.7975,269.7547 Q 947.412,270.5151 947.412,271.8067 Q 947.412,273.5984 948.2975,274.4734 Q 949.1829,275.338 950.4329,275.338 Q 950.8808,275.338 951.2975,275.2234 Q 951.7141,275.1088 952.2141,274.7755 Q 952.7141,274.4317 953.412,273.7546 Z"
+       id="path7327"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 989.6332,282.0671 Q 989.4457,282.2338 988.9978,282.4109 Q 988.5603,282.5984 988.3103,282.6921 L 987.8624,282.3692 V 261.4109 Q 988.154,261.2443 988.5082,261.0776 Q 988.8728,260.9005 989.1853,260.8276 L 989.6332,261.1297 Z"
+       id="path7330"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1026.234,277.0567 Q 1025.723,277.3901 1025.088,277.7338 Q 1024.463,278.0776 1023.942,278.3067 Q 1023.421,278.5359 1023.255,278.5359 Q 1022.88,278.5359 1022.567,278.213 Q 1022.255,277.8796 1022.13,276.8067 Q 1021.265,277.5567 1020.63,277.9317 Q 1019.994,278.2963 1019.505,278.4109 Q 1019.015,278.5359 1018.567,278.5359 Q 1017.921,278.5359 1017.317,278.2755 Q 1016.713,278.0151 1016.317,277.3171 Q 1015.932,276.6192 1015.932,275.3171 V 271.0463 Q 1015.932,270.3901 1015.869,270.0984 Q 1015.817,269.8067 1015.546,269.713 Q 1015.286,269.6192 1014.671,269.5567 V 268.8276 Q 1015.713,268.7338 1016.452,268.6192 Q 1017.202,268.4942 1018.067,268.2234 L 1018.432,268.7026 V 274.6609 Q 1018.432,275.9526 1018.744,276.3484 Q 1019.057,276.7338 1019.64,276.7338 Q 1020.077,276.7338 1020.671,276.4838 Q 1021.275,276.2338 1022.13,275.4942 V 271.0463 Q 1022.13,270.4213 1022.046,270.1192 Q 1021.973,269.8172 1021.682,269.7026 Q 1021.39,269.588 1020.755,269.5567 V 268.8276 Q 1021.796,268.7338 1022.64,268.5776 Q 1023.494,268.4109 1024.244,268.2234 L 1024.63,268.7026 V 275.2651 Q 1024.63,275.9005 1024.682,276.1609 Q 1024.734,276.4109 1024.869,276.5151 Q 1024.984,276.6088 1025.213,276.5567 Q 1025.442,276.5046 1025.973,276.2755 Z M 1019.567,265.0151 Q 1019.567,265.7755 1019.077,266.3172 Q 1018.598,266.8588 1017.932,266.8588 Q 1016.702,266.8588 1016.702,265.588 Q 1016.702,264.8276 1017.192,264.2963 Q 1017.682,263.7547 1018.327,263.7547 Q 1018.9,263.7547 1019.234,264.0776 Q 1019.567,264.3901 1019.567,265.0151 Z M 1023.963,265.0151 Q 1023.963,265.7755 1023.484,266.3172 Q 1023.005,266.8588 1022.338,266.8588 Q 1021.098,266.8588 1021.098,265.588 Q 1021.098,264.8276 1021.588,264.2963 Q 1022.088,263.7547 1022.723,263.7547 Q 1023.307,263.7547 1023.63,264.0776 Q 1023.963,264.3901 1023.963,265.0151 Z"
+       id="path7333"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 156.8233,223.2651 Q 156.7192,223.3901 156.3233,223.588 Q 155.9379,223.7755 155.4379,223.963 Q 154.9483,224.1401 154.5107,224.2651 Q 154.0732,224.3797 153.8962,224.3588 Q 152.8545,223.588 152.8545,222.2546 Q 152.8545,221.4838 153.1982,220.7129 Q 153.542,219.9316 154.1149,219.2649 Q 154.6879,218.5982 155.3546,218.1712 L 156.0421,218.692 Q 155.6567,219.1816 155.4067,219.8378 Q 155.1671,220.4838 155.1671,221.1608 Q 155.1671,221.7338 155.5421,222.0983 Q 155.9275,222.463 156.6463,222.4839 Z M 151.8127,223.2651 Q 151.719,223.3901 151.3231,223.588 Q 150.9273,223.7755 150.4273,223.963 Q 149.9376,224.1401 149.5001,224.2651 Q 149.073,224.3797 148.8855,224.3588 Q 147.8438,223.5984 147.8438,222.2546 Q 147.8438,221.4838 148.1876,220.7129 Q 148.5418,219.9316 149.1043,219.2649 Q 149.6772,218.5982 150.3544,218.1712 L 151.0315,218.692 Q 150.6461,219.1816 150.3961,219.8378 Q 150.1564,220.4838 150.1564,221.1608 Q 150.1564,221.7338 150.5419,222.0983 Q 150.9273,222.463 151.6461,222.4839 Z"
+       id="path7336"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 191.3093,238.2762 V 237.5157 Q 192.2781,237.3698 192.6739,237.2032 Q 193.0802,237.0469 193.0802,236.8698 V 224.6714 Q 193.2469,224.6194 193.5906,224.4526 Q 193.9345,224.2755 194.3199,224.0568 Q 194.7157,223.8276 195.0386,223.6193 Q 195.372,223.4005 195.497,223.2755 L 195.9032,223.6609 Q 195.9032,223.6609 195.8199,223.9943 Q 195.7365,224.3276 195.6532,224.8694 Q 195.5803,225.411 195.5803,226.036 V 236.8698 Q 195.5803,237.0365 195.8615,237.2032 Q 196.1533,237.3698 196.945,237.5157 V 238.2762 Z M 193.8511,231.0362 Q 192.9864,231.953 192.3406,232.5155 Q 191.6948,233.078 191.0697,233.3281 Q 190.4447,233.5885 189.653,233.5885 Q 188.8404,233.5885 188.0071,233.0051 Q 187.1841,232.4113 186.6216,231.3072 Q 186.0695,230.1925 186.0695,228.6507 Q 186.0695,227.432 186.4549,226.5569 Q 186.8403,225.6714 187.3925,225.0881 Q 187.9446,224.5047 188.4342,224.1818 Q 189.0175,223.8068 189.7572,223.5463 Q 190.4968,223.2755 191.1322,223.2755 Q 191.7573,223.2755 192.351,223.4943 Q 192.9552,223.713 193.7677,224.5255 Q 193.7677,225.7444 193.1531,226.1194 Q 192.8302,225.4631 192.1635,225.0569 Q 191.4968,224.6506 190.8926,224.6506 Q 189.903,224.6506 189.2363,225.4423 Q 188.5696,226.2339 188.5696,228.0153 Q 188.5696,229.7862 189.2779,230.7029 Q 189.9968,231.6092 190.8613,231.6092 Q 191.4968,231.6092 192.0698,231.2447 Q 192.6531,230.88 193.3823,230.1821 Q 193.476,230.2237 193.5698,230.4112 Q 193.6635,230.5987 193.7364,230.7966 Q 193.8199,230.9841 193.8511,231.0362 Z"
+       id="path7339"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 223.7826,233.2759 V 232.5155 Q 224.5327,232.3176 224.8452,232.1717 Q 225.1577,232.0155 225.1577,231.8801 V 227.1507 Q 225.1577,226.0048 224.9181,225.5881 Q 224.6786,225.1714 224.0639,225.1714 Q 223.5639,225.1714 222.9076,225.4735 Q 222.2618,225.7652 221.2513,226.6194 V 231.8801 Q 221.2513,232.2238 222.6368,232.5155 V 233.2759 H 217.3761 V 232.5155 Q 218.7512,232.1509 218.7512,231.8801 V 226.0985 Q 218.7512,225.5569 218.6887,225.3069 Q 218.6262,225.0464 218.3345,224.9423 Q 218.0533,224.8381 217.3761,224.7548 V 224.0255 Q 218.3658,223.9213 219.1262,223.7443 Q 219.897,223.5672 220.6575,223.2755 L 221.095,223.713 L 221.2096,225.2131 Q 222.4181,224.1818 223.4806,223.7338 Q 224.5431,223.2755 225.3556,223.2755 Q 226.2515,223.2755 226.9495,223.8797 Q 227.6578,224.4838 227.6578,225.9423 V 231.8801 Q 227.6578,232.0155 227.9391,232.1613 Q 228.2203,232.3072 229.0433,232.5155 V 233.2759 Z M 227.2203,219.1712 Q 226.9807,219.7337 226.5849,220.39 Q 226.1994,221.0463 225.6473,221.515 Q 225.1056,221.9838 224.4077,221.9838 Q 223.8972,221.9838 223.4493,221.7129 Q 223.0014,221.4421 222.5847,221.1713 Q 222.1785,220.89 221.7721,220.89 Q 221.418,220.89 221.0638,221.2442 Q 220.72,221.5983 220.3555,222.1713 L 219.4908,221.8588 Q 219.7304,221.2858 220.1159,220.6296 Q 220.5117,219.9732 221.0534,219.5045 Q 221.595,219.0357 222.2931,219.0357 Q 222.866,219.0357 223.3139,219.317 Q 223.7618,219.5878 224.1472,219.8691 Q 224.5431,220.1399 224.9181,220.1399 Q 225.2515,220.1399 225.6265,219.7857 Q 226.0015,219.4212 226.3556,218.8066 Z"
+       id="path7342"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 269.884,224.3484 Q 269.3007,224.4943 269.1028,224.6298 Q 268.9153,224.7548 268.8424,224.9944 L 266.5402,232.6613 Q 266.4569,232.9634 266.1548,233.1613 Q 265.8631,233.3489 265.5401,233.4427 Q 265.2172,233.5468 265.0401,233.5885 L 262.0817,226.807 L 262.5504,223.588 Q 262.5504,223.588 262.8525,223.588 Q 263.165,223.588 263.29,223.588 L 265.9048,229.9112 L 267.4048,224.9944 Q 267.4777,224.7548 267.3423,224.6089 Q 267.2173,224.463 266.4985,224.3484 V 223.588 H 269.884 Z M 260.2691,232.6613 Q 260.1649,232.9842 259.8836,233.1717 Q 259.6024,233.3593 259.2899,233.4531 Q 258.9877,233.5468 258.8002,233.5885 L 255.998,224.9944 Q 255.8626,224.5776 254.8626,224.3484 V 223.588 H 259.5816 V 224.3484 Q 258.6856,224.4526 258.519,224.6298 Q 258.3627,224.7964 258.4356,224.9944 L 259.9982,229.9112 L 262.4879,223.588 Q 262.6337,223.588 262.9254,223.588 Q 263.2171,223.588 263.2171,223.588 L 263.2796,225.3069 Z"
+       id="path7345"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 298.0158,226.9945 Q 297.9533,227.2236 297.7762,227.609 Q 297.6095,227.9945 297.5366,228.1611 H 290.4634 L 290.1301,227.8382 Q 290.1822,227.6195 290.3488,227.2445 Q 290.5155,226.8695 290.6092,226.6714 H 297.672 Z M 295.1824,224.4734 Q 295.1824,225.0777 294.8178,225.5152 Q 294.4636,225.9527 293.9324,225.9527 Q 293.026,225.9527 293.026,224.911 Q 293.026,224.2963 293.3906,223.8797 Q 293.7552,223.4526 294.2761,223.4526 Q 295.1824,223.4526 295.1824,224.4734 Z M 295.1824,229.9008 Q 295.1824,230.4946 294.8178,230.9425 Q 294.4636,231.3801 293.9324,231.3801 Q 293.026,231.3801 293.026,230.3279 Q 293.026,229.7237 293.3906,229.2966 Q 293.7552,228.8695 294.2761,228.8695 Q 295.1824,228.8695 295.1824,229.9008 Z"
+       id="path7348"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 337.7234,227.5465 Q 337.5359,227.7653 337.0671,228.0257 Q 336.5983,228.2757 336.265,228.4007 H 329.973 L 329.9939,227.234 H 334.8378 Q 335.0774,227.234 335.1504,227.1611 Q 335.2337,227.0778 335.2337,226.859 Q 335.2337,226.4423 335.067,225.9006 Q 334.9107,225.3485 334.5045,224.9423 Q 334.1086,224.5255 333.4003,224.5255 Q 332.2648,224.5255 331.7961,225.5256 Q 331.3377,226.5152 331.3377,228.1715 Q 331.3377,229.755 332.0044,230.7966 Q 332.6815,231.8384 333.9524,231.8384 Q 334.3899,231.8384 334.8066,231.7655 Q 335.2233,231.6822 335.765,231.4113 Q 336.3067,231.1405 337.1192,230.5779 Q 337.2546,230.6508 337.4318,230.9112 Q 337.6193,231.1613 337.6609,231.2447 Q 336.6921,232.2238 335.9733,232.7342 Q 335.2546,233.2342 334.5774,233.4114 Q 333.9107,233.5885 333.0774,233.5885 Q 331.8898,233.5885 330.9106,232.9738 Q 329.9314,232.3592 329.3376,231.2551 Q 328.7543,230.1404 328.7543,228.6715 Q 328.7543,225.8277 330.9002,224.2547 Q 331.4523,223.8484 332.2127,223.5672 Q 332.9837,223.2755 333.7753,223.2755 Q 335.14,223.2755 336.0046,223.8797 Q 336.8796,224.4838 337.2963,225.4631 Q 337.7234,226.4319 337.7234,227.5465 Z"
+       id="path7351"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 370.2934,232.078 Q 369.6891,232.4842 369.0537,232.828 Q 368.4183,233.1717 367.9079,233.3802 Q 367.4078,233.5885 367.1994,233.5885 Q 366.6578,233.5885 366.4182,232.8905 Q 366.1786,232.1822 366.1786,230.4425 V 224.5984 Q 366.6161,224.4213 367.2932,224.0776 Q 367.9704,223.7234 368.5641,223.2755 L 368.9808,223.6609 Q 368.9808,223.6609 368.8975,224.0255 Q 368.8245,224.3797 368.7516,224.9319 Q 368.6787,225.4735 368.6787,226.0569 V 230.005 Q 368.6787,230.63 368.71,231.0258 Q 368.7516,231.4217 368.8558,231.5155 Q 368.96,231.6197 369.21,231.5988 Q 369.4704,231.5676 370.0017,231.3176 Q 370.0017,231.3072 370.0746,231.5051 Q 370.1476,231.6926 370.2205,231.8905 Q 370.2934,232.078 370.2934,232.078 Z M 366.9599,231.0362 Q 366.1474,232.0155 365.5223,232.5676 Q 364.9077,233.1197 364.3452,233.3489 Q 363.7827,233.5885 363.1263,233.5885 Q 362.2409,233.5885 361.4284,233.0259 Q 360.6158,232.4634 360.095,231.3697 Q 359.5846,230.2758 359.5846,228.6924 Q 359.5846,227.7653 359.9179,226.8174 Q 360.2512,225.8589 360.8867,225.0569 Q 361.5326,224.2547 362.4493,223.7651 Q 363.3659,223.2755 364.5327,223.2755 Q 365.1577,223.2755 365.689,223.5151 Q 366.2203,223.7443 366.8557,224.4422 Q 366.8557,225.7339 366.2515,226.1194 Q 366.0328,225.4631 365.5014,225.0569 Q 364.9806,224.6506 364.3764,224.6506 Q 363.8035,224.6506 363.2722,224.9631 Q 362.7513,225.2652 362.418,226.0152 Q 362.0847,226.7548 362.0847,228.057 Q 362.0847,229.2341 362.3972,230.0258 Q 362.7201,230.8175 363.1993,231.2134 Q 363.6889,231.6092 364.1889,231.6092 Q 364.6369,231.6092 365.1056,231.3384 Q 365.5849,231.0675 366.4911,230.1821 Q 366.5849,230.2237 366.6786,230.4112 Q 366.7724,230.5987 366.8453,230.7966 Q 366.9286,230.9841 366.9599,231.0362 Z M 367.1161,219.6607 Q 367.1161,220.4108 366.7515,221.015 Q 366.3974,221.6192 365.8244,221.9838 Q 365.2618,222.3379 364.616,222.3379 Q 363.7931,222.3379 363.2826,221.8379 Q 362.7722,221.3275 362.7722,220.4942 Q 362.7722,219.7545 363.1159,219.1399 Q 363.4702,218.5253 364.0327,218.1712 Q 364.6056,217.8065 365.2618,217.8065 Q 366.1057,217.8065 366.6057,218.3274 Q 367.1057,218.8482 367.1161,219.6607 Z M 365.7099,220.0878 Q 365.7099,219.5878 365.491,219.3274 Q 365.2827,219.067 365.0431,219.067 Q 364.616,219.067 364.3973,219.3795 Q 364.1785,219.692 364.1785,220.067 Q 364.1785,220.5463 364.3869,220.8171 Q 364.5952,221.0775 364.8348,221.0775 Q 365.2514,221.0775 365.4806,220.7963 Q 365.7099,220.515 365.7099,220.0878 Z"
+       id="path7354"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 408.3925,223.7338 Q 408.4862,223.7963 408.4446,224.2338 Q 408.4029,224.6714 408.2779,225.2756 Q 408.1529,225.8694 407.9966,226.4214 Q 407.8404,226.9632 407.7154,227.2445 H 406.955 Q 406.8821,226.4006 406.5903,225.8069 Q 406.2986,225.2027 405.7986,225.2027 Q 405.5278,225.2027 405.184,225.3589 Q 404.8403,225.5048 404.4548,225.9631 Q 404.0694,226.4214 403.6527,227.3278 V 231.8801 Q 403.6527,232.0363 404.0798,232.203 Q 404.5173,232.3697 405.4965,232.5155 V 233.2759 H 399.7775 V 232.5155 Q 401.1526,232.203 401.1526,231.8801 V 226.3589 Q 401.1526,225.6714 401.0797,225.4006 Q 401.0068,225.1298 400.913,225.036 Q 400.7776,224.9006 400.5588,224.8485 Q 400.3504,224.786 399.7775,224.7548 V 224.0255 Q 400.538,223.9213 401.0484,223.8276 Q 401.5693,223.7234 402.0172,223.5984 Q 402.4755,223.463 403.0589,223.2755 L 403.4964,223.713 L 403.6319,225.2235 Q 404.1944,224.4213 405.0174,223.8484 Q 405.8507,223.2755 406.7465,223.2755 Q 407.6008,223.2755 408.3925,223.7338 Z"
+       id="path7357"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 440.7408,228.2236 Q 440.7408,229.2654 440.3346,230.2237 Q 439.9283,231.1822 439.2199,231.9426 Q 438.5116,232.703 437.5845,233.1509 Q 436.6573,233.5885 435.6261,233.5885 Q 434.1885,233.5885 433.126,232.9426 Q 432.0634,232.2967 431.48,231.1822 Q 430.8967,230.0675 430.8967,228.6507 Q 430.8967,227.6195 431.2717,226.661 Q 431.6467,225.6923 432.3342,224.9319 Q 433.0218,224.1609 433.9593,223.7234 Q 434.9072,223.2755 436.0323,223.2755 Q 437.4491,223.2755 438.5116,223.9213 Q 439.5742,224.5672 440.1575,225.6819 Q 440.7408,226.7965 440.7408,228.2236 Z M 438.1157,228.6924 Q 438.1157,227.5882 437.8137,226.661 Q 437.5116,225.7235 436.9698,225.1506 Q 436.4386,224.5776 435.7302,224.5776 Q 434.8655,224.5776 434.3864,225.0777 Q 433.9072,225.5673 433.7197,226.4214 Q 433.5322,227.2757 433.5322,228.3486 Q 433.5322,229.4425 433.8551,230.3383 Q 434.1885,231.2342 434.7301,231.7655 Q 435.2719,232.2863 435.9177,232.2863 Q 437.1573,232.2863 437.6366,231.3488 Q 438.1157,230.4112 438.1157,228.6924 Z M 437.3866,221.9629 Q 437.2511,222.0879 436.9594,222.2442 Q 436.6677,222.39 436.4906,222.4422 L 432.5113,218.5149 L 432.8134,217.9315 Q 432.9175,217.9106 433.2301,217.8481 Q 433.553,217.7856 433.9385,217.7127 Q 434.3239,217.6398 434.6572,217.5877 Q 434.9905,217.5356 435.1155,217.5252 Z"
+       id="path7360"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 478.7929,231.6613 Q 477.4178,232.6613 476.4491,233.1301 Q 475.4803,233.5885 474.9386,233.5885 Q 474.0427,233.5885 473.3864,232.8905 Q 472.7406,232.1926 472.7406,230.7341 V 224.8902 H 471.4801 L 471.178,224.5151 L 471.9905,223.588 H 472.7406 V 221.4108 L 474.8448,219.8587 L 475.2407,220.2024 V 223.588 H 478.4178 L 478.7929,223.963 Q 478.5949,224.3172 478.272,224.7131 Q 477.9491,225.0985 477.7408,225.2548 Q 477.4908,225.1298 476.9908,225.0152 Q 476.4908,224.8902 475.9386,224.8902 H 475.2407 V 229.7654 Q 475.2407,230.8383 475.4803,231.2655 Q 475.7303,231.6822 476.1261,231.6822 Q 476.4908,231.6822 476.9699,231.5259 Q 477.4595,231.3697 478.3345,230.9008 Z"
+       id="path7363"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 511.6102,228.2236 Q 511.6102,229.2654 511.2039,230.2237 Q 510.7976,231.1822 510.0893,231.9426 Q 509.381,232.703 508.4538,233.1509 Q 507.5267,233.5885 506.4953,233.5885 Q 505.0578,233.5885 503.9952,232.9426 Q 502.9327,232.2967 502.3493,231.1822 Q 501.766,230.0675 501.766,228.6507 Q 501.766,227.6195 502.141,226.661 Q 502.516,225.6923 503.2036,224.9319 Q 503.8911,224.1609 504.8287,223.7234 Q 505.7766,223.2755 506.9017,223.2755 Q 508.3184,223.2755 509.381,223.9213 Q 510.4435,224.5672 511.0268,225.6819 Q 511.6102,226.7965 511.6102,228.2236 Z M 508.985,228.6924 Q 508.985,227.5882 508.6829,226.661 Q 508.3809,225.7235 507.8392,225.1506 Q 507.3079,224.5776 506.5995,224.5776 Q 505.7349,224.5776 505.2558,225.0777 Q 504.7766,225.5673 504.589,226.4214 Q 504.4015,227.2757 504.4015,228.3486 Q 504.4015,229.4425 504.7245,230.3383 Q 505.0578,231.2342 505.5995,231.7655 Q 506.1412,232.2863 506.787,232.2863 Q 508.0267,232.2863 508.5059,231.3488 Q 508.985,230.4112 508.985,228.6924 Z M 510.4435,221.7442 Q 510.3185,221.9421 510.1622,222.1608 Q 510.0164,222.3692 509.8393,222.4422 L 506.9017,220.1191 L 504.0057,222.4422 Q 503.8286,222.3692 503.6411,222.1608 Q 503.4536,221.9421 503.2973,221.7442 L 506.2037,217.7127 H 507.6309 Z"
+       id="path7366"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 551.5245,224.3484 Q 550.8995,224.4943 550.6912,224.6194 Q 550.4932,224.7444 550.3787,225.0569 L 546.8993,234.0468 Q 546.0034,236.349 544.8159,237.3698 Q 543.6387,238.4012 542.3053,238.4012 Q 541.7741,238.4012 541.2844,238.2762 Q 540.8053,238.1616 540.4928,237.9949 Q 540.1803,237.8283 540.1803,237.6929 Q 540.1803,237.6094 540.3573,237.349 Q 540.524,237.0886 540.7844,236.7657 Q 541.0344,236.4532 541.2844,236.1823 Q 541.5448,235.9219 541.7116,235.8178 Q 542.2324,236.1615 542.7533,236.224 Q 543.2845,236.2969 543.6699,236.1615 Q 544.0554,236.0365 544.4929,235.5782 Q 544.9304,235.1302 545.3054,234.2343 L 545.6075,233.5156 L 542.1178,225.0569 Q 541.9095,224.5672 540.9615,224.3484 V 223.588 H 545.6804 V 224.3484 Q 544.9304,224.4422 544.7638,224.588 Q 544.5971,224.7235 544.7429,225.0569 L 546.8889,230.2862 L 548.9306,225.0569 Q 549.0452,224.7444 548.9098,224.5984 Q 548.7744,224.4526 548.118,224.3484 V 223.588 H 551.5245 Z"
+       id="path7369"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 583.3385,232.1092 Q 582.828,232.4426 582.1926,232.7863 Q 581.5676,233.1301 581.0468,233.3593 Q 580.5258,233.5885 580.3592,233.5885 Q 579.9842,233.5885 579.6717,233.2655 Q 579.3592,232.9322 579.2342,231.8592 Q 578.3695,232.6092 577.7341,232.9842 Q 577.0987,233.3489 576.6091,233.4635 Q 576.1194,233.5885 575.6715,233.5885 Q 575.0257,233.5885 574.4215,233.3281 Q 573.8172,233.0676 573.4214,232.3697 Q 573.036,231.6717 573.036,230.3696 V 226.0985 Q 573.036,225.4423 572.9735,225.1506 Q 572.9214,224.8589 572.6506,224.7652 Q 572.3901,224.6714 571.7755,224.6089 V 223.8797 Q 572.8172,223.7859 573.5568,223.6713 Q 574.3069,223.5463 575.1715,223.2755 L 575.5361,223.7547 V 229.7133 Q 575.5361,231.005 575.8486,231.4009 Q 576.1611,231.7863 576.7445,231.7863 Q 577.182,231.7863 577.7758,231.5363 Q 578.3799,231.2863 579.2342,230.5466 V 226.0985 Q 579.2342,225.4735 579.1508,225.1714 Q 579.0779,224.8694 578.7863,224.7548 Q 578.4945,224.6402 577.8591,224.6089 V 223.8797 Q 578.9008,223.7859 579.7446,223.6297 Q 580.5988,223.463 581.3489,223.2755 L 581.7343,223.7547 V 230.3175 Q 581.7343,230.9529 581.7864,231.2134 Q 581.8384,231.4634 581.9739,231.5676 Q 582.0884,231.6613 582.3176,231.6092 Q 582.5468,231.5572 583.0781,231.328 Z M 578.7758,221.9629 Q 578.6404,222.0879 578.3487,222.2442 Q 578.057,222.39 577.8799,222.4422 L 573.9006,218.5149 L 574.2026,217.9315 Q 574.3069,217.9106 574.6194,217.8481 Q 574.9423,217.7856 575.3277,217.7127 Q 575.7132,217.6398 576.0465,217.5877 Q 576.3798,217.5356 576.5049,217.5252 Z"
+       id="path7372"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 622.5068,232.1092 Q 621.9963,232.4426 621.3609,232.7863 Q 620.7359,233.1301 620.2151,233.3593 Q 619.6942,233.5885 619.5275,233.5885 Q 619.1525,233.5885 618.84,233.2655 Q 618.5275,232.9322 618.4025,231.8592 Q 617.5378,232.6092 616.9024,232.9842 Q 616.267,233.3489 615.7774,233.4635 Q 615.2877,233.5885 614.8398,233.5885 Q 614.194,233.5885 613.5898,233.3281 Q 612.9855,233.0676 612.5897,232.3697 Q 612.2043,231.6717 612.2043,230.3696 V 226.0985 Q 612.2043,225.4423 612.1418,225.1506 Q 612.0897,224.8589 611.8189,224.7652 Q 611.5584,224.6714 610.9438,224.6089 V 223.8797 Q 611.9855,223.7859 612.7251,223.6713 Q 613.4752,223.5463 614.3398,223.2755 L 614.7044,223.7547 V 229.7133 Q 614.7044,231.005 615.0169,231.4009 Q 615.3294,231.7863 615.9128,231.7863 Q 616.3503,231.7863 616.9441,231.5363 Q 617.5482,231.2863 618.4025,230.5466 V 226.0985 Q 618.4025,225.4735 618.3192,225.1714 Q 618.2462,224.8694 617.9546,224.7548 Q 617.6628,224.6402 617.0274,224.6089 V 223.8797 Q 618.0692,223.7859 618.9129,223.6297 Q 619.7671,223.463 620.5172,223.2755 L 620.9026,223.7547 V 230.3175 Q 620.9026,230.9529 620.9547,231.2134 Q 621.0067,231.4634 621.1422,231.5676 Q 621.2567,231.6613 621.4859,231.6092 Q 621.7151,231.5572 622.2464,231.328 Z"
+       id="path7375"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 653.349,228.2236 Q 653.349,229.2654 652.9427,230.2237 Q 652.5365,231.1822 651.8281,231.9426 Q 651.1197,232.703 650.1925,233.1509 Q 649.2655,233.5885 648.2342,233.5885 Q 646.7966,233.5885 645.734,232.9426 Q 644.6715,232.2967 644.0882,231.1822 Q 643.5048,230.0675 643.5048,228.6507 Q 643.5048,227.6195 643.8799,226.661 Q 644.2549,225.6923 644.9424,224.9319 Q 645.6298,224.1609 646.5674,223.7234 Q 647.5154,223.2755 648.6405,223.2755 Q 650.0571,223.2755 651.1197,223.9213 Q 652.1822,224.5672 652.7657,225.6819 Q 653.349,226.7965 653.349,228.2236 Z M 650.7239,228.6924 Q 650.7239,227.5882 650.4218,226.661 Q 650.1196,225.7235 649.578,225.1506 Q 649.0467,224.5776 648.3384,224.5776 Q 647.4737,224.5776 646.9945,225.0777 Q 646.5154,225.5673 646.3279,226.4214 Q 646.1404,227.2757 646.1404,228.3486 Q 646.1404,229.4425 646.4633,230.3383 Q 646.7966,231.2342 647.3383,231.7655 Q 647.8799,232.2863 648.5259,232.2863 Q 649.7655,232.2863 650.2446,231.3488 Q 650.7239,230.4112 650.7239,228.6924 Z M 652.6719,219.1712 Q 652.4322,219.7337 652.0364,220.39 Q 651.651,221.0463 651.0989,221.515 Q 650.5572,221.9838 649.8592,221.9838 Q 649.3488,221.9838 648.9009,221.7129 Q 648.453,221.4421 648.0362,221.1713 Q 647.6299,220.89 647.2237,220.89 Q 646.8695,220.89 646.5154,221.2442 Q 646.1716,221.5983 645.8069,222.1713 L 644.9424,221.8588 Q 645.1819,221.2858 645.5673,220.6296 Q 645.9632,219.9732 646.5049,219.5045 Q 647.0466,219.0357 647.7445,219.0357 Q 648.3175,219.0357 648.7655,219.317 Q 649.2134,219.5878 649.5988,219.8691 Q 649.9946,220.1399 650.3697,220.1399 Q 650.7031,220.1399 651.0781,219.7857 Q 651.4531,219.4212 651.8072,218.8066 Z"
+       id="path7378"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 689.2308,220.1399 Q 689.2308,220.8379 688.7308,221.2858 Q 688.2308,221.7233 687.4808,221.7233 Q 686.8974,221.7233 686.4703,221.4421 Q 686.0536,221.1608 686.0536,220.5671 Q 686.0536,219.8587 686.5536,219.4316 Q 687.064,218.9941 687.7933,218.9941 Q 688.3558,218.9941 688.7933,219.2649 Q 689.2308,219.5357 689.2308,220.1399 Z M 684.9598,233.2759 V 232.5155 Q 685.6578,232.3697 685.9911,232.1926 Q 686.3349,232.0155 686.3349,231.8801 V 226.5256 Q 686.3349,225.8173 686.2724,225.4631 Q 686.2203,225.1089 685.9286,224.9735 Q 685.6369,224.8277 684.9598,224.7548 V 224.0255 Q 685.8453,223.9005 686.6474,223.7234 Q 687.46,223.5359 688.1683,223.2755 H 688.835 V 231.8801 Q 688.835,232.0051 689.1475,232.1926 Q 689.46,232.3697 690.2205,232.5155 V 233.2759 Z"
+       id="path7381"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 723.7798,227.5465 Q 723.5923,227.7653 723.1236,228.0257 Q 722.6548,228.2757 722.3215,228.4007 H 716.0295 L 716.0503,227.234 H 720.8943 Q 721.1339,227.234 721.2068,227.1611 Q 721.2901,227.0778 721.2901,226.859 Q 721.2901,226.4423 721.1235,225.9006 Q 720.9672,225.3485 720.561,224.9423 Q 720.1651,224.5255 719.4567,224.5255 Q 718.3213,224.5255 717.8525,225.5256 Q 717.3941,226.5152 717.3941,228.1715 Q 717.3941,229.755 718.0609,230.7966 Q 718.7379,231.8384 720.0089,231.8384 Q 720.4464,231.8384 720.863,231.7655 Q 721.2797,231.6822 721.8214,231.4113 Q 722.3631,231.1405 723.1756,230.5779 Q 723.3111,230.6508 723.4881,230.9112 Q 723.6756,231.1613 723.7173,231.2447 Q 722.7486,232.2238 722.0297,232.7342 Q 721.311,233.2342 720.6339,233.4114 Q 719.9672,233.5885 719.1338,233.5885 Q 717.9463,233.5885 716.967,232.9738 Q 715.9878,232.3592 715.394,231.2551 Q 714.8107,230.1404 714.8107,228.6715 Q 714.8107,225.8277 716.9566,224.2547 Q 717.5087,223.8484 718.2692,223.5672 Q 719.04,223.2755 719.8317,223.2755 Q 721.1964,223.2755 722.061,223.8797 Q 722.9361,224.4838 723.3527,225.4631 Q 723.7798,226.4319 723.7798,227.5465 Z M 719.0817,222.4422 Q 718.8942,222.4108 718.5921,222.2546 Q 718.29,222.0879 718.1754,221.9942 L 720.3839,217.5252 Q 720.4985,217.5356 720.8318,217.5877 Q 721.1651,217.6398 721.561,217.7023 Q 721.9672,217.7648 722.3006,217.8273 Q 722.634,217.8898 722.7486,217.9211 L 723.0715,218.4837 Z"
+       id="path7384"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 763.3828,228.2236 Q 763.3828,229.2654 762.9765,230.2237 Q 762.5703,231.1822 761.862,231.9426 Q 761.1535,232.703 760.2265,233.1509 Q 759.2994,233.5885 758.268,233.5885 Q 756.8304,233.5885 755.7679,232.9426 Q 754.7053,232.2967 754.122,231.1822 Q 753.5387,230.0675 753.5387,228.6507 Q 753.5387,227.6195 753.9137,226.661 Q 754.2887,225.6923 754.9763,224.9319 Q 755.6638,224.1609 756.6013,223.7234 Q 757.5493,223.2755 758.6743,223.2755 Q 760.091,223.2755 761.1535,223.9213 Q 762.2161,224.5672 762.7995,225.6819 Q 763.3828,226.7965 763.3828,228.2236 Z M 760.7577,228.6924 Q 760.7577,227.5882 760.4556,226.661 Q 760.1535,225.7235 759.6119,225.1506 Q 759.0806,224.5776 758.3722,224.5776 Q 757.5076,224.5776 757.0284,225.0777 Q 756.5492,225.5673 756.3617,226.4214 Q 756.1742,227.2757 756.1742,228.3486 Q 756.1742,229.4425 756.4971,230.3383 Q 756.8304,231.2342 757.3722,231.7655 Q 757.9139,232.2863 758.5597,232.2863 Q 759.7994,232.2863 760.2785,231.3488 Q 760.7577,230.4112 760.7577,228.6924 Z"
+       id="path7387"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 787.5344,233.2759 V 232.5155 Q 788.2324,232.3697 788.5657,232.1926 Q 788.9094,232.0155 788.9094,231.8801 V 226.5256 Q 788.9094,225.8173 788.8678,225.4631 Q 788.8261,225.1089 788.5449,224.9735 Q 788.2636,224.8277 787.5344,224.7548 V 224.0255 Q 788.4199,223.9005 789.2219,223.7234 Q 790.0345,223.5359 790.7429,223.2755 H 791.4095 V 231.8801 Q 791.4095,232.0051 791.7221,232.1926 Q 792.0346,232.3697 792.7951,232.5155 V 233.2759 Z M 789.399,220.067 Q 789.399,220.8275 788.9094,221.3692 Q 788.4303,221.9108 787.7636,221.9108 Q 786.5343,221.9108 786.5343,220.64 Q 786.5343,219.8795 787.0239,219.3482 Q 787.5136,218.8066 788.1594,218.8066 Q 788.7324,218.8066 789.0657,219.1295 Q 789.399,219.442 789.399,220.067 Z M 793.795,220.067 Q 793.795,220.8275 793.3159,221.3692 Q 792.8367,221.9108 792.1701,221.9108 Q 790.9304,221.9108 790.9304,220.64 Q 790.9304,219.8795 791.42,219.3482 Q 791.9201,218.8066 792.5555,218.8066 Q 793.1388,218.8066 793.4617,219.1295 Q 793.795,219.442 793.795,220.067 Z"
+       id="path7390"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 830.6527,233.5885 Q 830.0381,233.5885 829.3819,233.3177 Q 828.736,233.0467 827.8297,232.4113 V 236.8698 Q 827.8297,237.0365 828.2151,237.2032 Q 828.6109,237.3698 829.5902,237.5157 V 238.2762 H 823.9545 V 237.5157 Q 825.3296,237.1823 825.3296,236.8698 V 226.0985 Q 825.3296,225.5777 825.2567,225.3069 Q 825.1942,225.0256 824.9025,224.911 Q 824.6108,224.786 823.9545,224.7548 V 224.0255 Q 824.7463,223.9213 825.2775,223.8276 Q 825.8088,223.7234 826.2567,223.5984 Q 826.7047,223.463 827.2359,223.2755 L 827.6734,223.713 L 827.7672,224.9944 Q 828.9235,223.9838 829.7569,223.6297 Q 830.6006,223.2755 831.1945,223.2755 Q 832.1424,223.2755 832.9341,223.7963 Q 833.7362,224.3068 834.2154,225.3694 Q 834.705,226.4319 834.705,228.0674 Q 834.705,229.0987 834.3196,230.0779 Q 833.9342,231.0571 833.3196,231.8592 Q 832.7049,232.6509 831.9966,233.1197 Q 831.2882,233.5885 830.6527,233.5885 Z M 829.9444,225.0464 Q 829.6944,225.0464 829.434,225.1298 Q 829.184,225.2131 828.809,225.4631 Q 828.4443,225.7131 827.8297,226.2131 V 230.9008 Q 828.5693,231.328 829.0485,231.5363 Q 829.5277,231.7342 829.8715,231.7863 Q 830.2152,231.8384 830.5485,231.8384 Q 831.3507,231.8384 831.8507,231.0675 Q 832.3611,230.2862 832.3611,228.8382 Q 832.3611,227.5049 831.9966,226.6714 Q 831.6424,225.8381 831.0903,225.4423 Q 830.5381,225.0464 829.9444,225.0464 Z"
+       id="path7393"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 865.7902,226.9528 Q 865.7902,228.7549 865.3006,230.0258 Q 864.8214,231.2863 864.061,232.078 Q 863.3109,232.8592 862.488,233.2238 Q 861.6651,233.5885 860.9879,233.5885 Q 859.5087,233.5885 858.4461,232.9426 Q 857.394,232.2967 856.821,231.1822 Q 856.2585,230.0675 856.2585,228.6507 Q 856.2585,227.6195 856.6023,226.661 Q 856.9461,225.6923 857.5607,224.9319 Q 858.1857,224.1609 859.019,223.7234 Q 859.8629,223.2755 860.8525,223.2755 Q 861.488,223.2755 862.0401,223.5255 Q 862.5921,223.7651 863.0192,224.213 Q 862.8109,223.4005 862.4567,222.7234 Q 862.1026,222.0358 861.4671,221.3275 L 859.2691,222.2338 Q 858.8836,222.2233 858.6024,222.1921 Q 858.3211,222.1608 857.9669,222.0463 L 857.8524,221.5879 L 860.5816,220.4421 Q 859.9983,220.0149 859.2379,219.7857 Q 858.4878,219.5566 857.5815,219.6816 L 857.4565,218.942 L 860.2483,217.9627 Q 860.8212,218.3378 861.4151,218.7857 Q 862.0088,219.2337 862.4463,219.6295 L 864.3943,218.8274 Q 864.8943,218.8795 865.1756,218.9212 Q 865.4672,218.9628 865.7382,219.0566 L 865.8111,219.4941 L 863.3213,220.5254 Q 864.6651,222.0254 865.2276,223.6401 Q 865.7902,225.2548 865.7902,226.9528 Z M 863.29,226.9007 Q 863.0713,226.1506 862.6234,225.661 Q 862.1859,225.161 861.6546,224.911 Q 861.1337,224.6506 860.6858,224.6506 Q 859.7483,224.6506 859.2795,225.5881 Q 858.8107,226.5256 858.8107,228.1924 Q 858.8107,229.2862 859.1233,230.2237 Q 859.4462,231.1509 859.967,231.7238 Q 860.4879,232.2863 861.092,232.2863 Q 862.238,232.2863 862.7588,231.1196 Q 863.29,229.9425 863.29,227.3799 Q 863.29,227.2757 863.29,227.1403 Q 863.29,226.9945 863.29,226.9007 Z"
+       id="path7396"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 903.0166,235.6303 Q 902.9645,235.8386 902.8395,236.2136 Q 902.7145,236.5886 902.6312,236.7657 H 897.3809 V 216.6086 H 902.5687 L 902.9958,216.9523 Q 902.9437,217.2127 902.8187,217.6086 Q 902.6937,217.994 902.6312,218.1191 H 899.7768 V 235.2552 H 902.5687 Z"
+       id="path7399"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 938.5189,220.9108 Q 937.0813,221.2129 937.0813,221.5567 V 227.8174 Q 937.0813,229.6404 936.4146,230.9321 Q 935.7584,232.2238 934.5916,232.9113 Q 933.4354,233.5885 931.9353,233.5885 Q 930.5081,233.5885 929.3206,233.0572 Q 928.133,232.5259 927.4246,231.4322 Q 926.7163,230.3383 926.7163,228.6507 V 221.5567 Q 926.7163,221.4317 926.3725,221.2442 Q 926.0391,221.0567 925.2891,220.9108 V 220.1503 H 930.7581 V 220.9108 Q 929.3206,221.2129 929.3206,221.5567 V 227.9736 Q 929.3206,229.9737 930.0602,231.0258 Q 930.7997,232.078 932.5811,232.078 Q 933.5708,232.078 934.1541,231.5155 Q 934.7374,230.9425 934.9979,230.0362 Q 935.2584,229.1196 935.2584,228.0882 V 221.5567 Q 935.2584,221.4317 934.9145,221.2442 Q 934.5812,221.0567 933.8312,220.9108 V 220.1503 H 938.5189 Z M 935.5813,218.4107 Q 935.4563,218.6087 935.2896,218.8274 Q 935.1333,219.0357 934.9562,219.1087 L 932.0394,217.3377 L 929.1435,219.1087 Q 928.9664,219.0357 928.7789,218.8274 Q 928.5913,218.6087 928.4351,218.4107 L 931.3415,214.9522 H 932.7686 Z"
+       id="path7402"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 968.704,236.7657 L 968.2769,236.4115 Q 968.3185,236.1511 968.4435,235.7657 Q 968.5685,235.3802 968.631,235.2552 H 971.4853 V 218.1191 H 968.704 L 968.256,217.744 Q 968.2977,217.5356 968.4227,217.1606 Q 968.5581,216.7856 968.631,216.6086 H 973.8812 V 236.7657 Z"
+       id="path7405"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 1009.13,220.9108 Q 1008.421,221.0463 1008.077,221.1921 Q 1007.734,221.3275 1007.588,221.5983 L 1004.014,228.2549 H 1001.858 Q 1001.368,227.0986 1000.681,225.8277 Q 999.9933,224.5463 999.2954,223.4213 Q 998.6079,222.2963 998.087,221.5983 Q 997.8995,221.3692 997.6078,221.2338 Q 997.3161,221.0983 996.4516,221.0983 L 996.4099,220.3379 Q 996.8161,220.2858 997.3474,220.2232 Q 997.8891,220.1503 998.3787,220.0982 Q 998.8787,220.0462 999.16,220.0462 Q 999.4412,220.0462 999.7329,220.1712 Q 1000.035,220.2963 1000.212,220.5254 Q 1000.722,221.2129 1001.295,222.1608 Q 1001.879,223.1088 1002.441,224.1609 Q 1003.014,225.2027 1003.493,226.2027 L 1005.932,221.5983 Q 1006.088,221.3275 1005.827,221.1713 Q 1005.576,221.015 1004.774,220.9108 V 220.1503 H 1009.13 Z M 1000.004,233.2759 V 232.5155 Q 1000.951,232.3176 1001.295,232.1197 Q 1001.639,231.9113 1001.639,231.7655 V 226.6402 H 1004.243 V 231.7655 Q 1004.243,231.9009 1004.576,232.1092 Q 1004.91,232.3176 1005.89,232.5155 V 233.2759 Z M 1001.399,219.1295 Q 1001.222,219.0462 1001.004,218.7962 Q 1000.795,218.5462 1000.701,218.4003 L 1004.545,214.8585 Q 1004.649,214.9105 1004.941,215.0668 Q 1005.243,215.2126 1005.587,215.4001 Q 1005.932,215.5772 1006.213,215.7439 Q 1006.505,215.9001 1006.598,215.9836 L 1006.702,216.619 Z"
+       id="path7408"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005" />
+    <path
+       d="M 1111.866,224.6558 Q 1111.866,226.2313 1111.007,227.221 Q 1110.148,228.2106 1108.767,228.2106 Q 1107.53,228.2106 1106.905,227.3903 Q 1106.293,226.5699 1106.293,225.3068 Q 1106.293,223.7442 1107.192,222.7547 Q 1108.09,221.7519 1109.405,221.7519 Q 1110.59,221.7519 1111.228,222.5724 Q 1111.866,223.3797 1111.866,224.6558 Z"
+       style="font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005"
+       id="path7411" />
+    <path
+       d="M 282.143,375.0162 Q 281.6325,375.3495 280.9971,375.6933 Q 280.3721,376.037 279.8513,376.2662 Q 279.3305,376.4954 279.1638,376.4954 Q 278.7888,376.4954 278.4763,376.1725 Q 278.1638,375.8391 278.0388,374.7662 Q 277.1742,375.5162 276.5388,375.8912 Q 275.9034,376.2558 275.4138,376.3704 Q 274.9242,376.4954 274.4763,376.4954 Q 273.8305,376.4954 273.2263,376.235 Q 272.6221,375.9745 272.2263,375.2766 Q 271.8409,374.5787 271.8409,373.2766 V 369.0058 Q 271.8409,368.3495 271.7784,368.0579 Q 271.7263,367.7662 271.4555,367.6725 Q 271.1951,367.5787 270.5805,367.5162 V 366.787 Q 271.6221,366.6933 272.3617,366.5787 Q 273.1117,366.4537 273.9763,366.1829 L 274.3409,366.662 V 372.6204 Q 274.3409,373.912 274.6534,374.3079 Q 274.9659,374.6933 275.5492,374.6933 Q 275.9867,374.6933 276.5805,374.4433 Q 277.1846,374.1933 278.0388,373.4537 V 369.0058 Q 278.0388,368.3808 277.9555,368.0787 Q 277.8825,367.7766 277.5909,367.662 Q 277.2992,367.5475 276.6638,367.5162 V 366.787 Q 277.7055,366.6933 278.5492,366.537 Q 279.4034,366.3704 280.1534,366.1829 L 280.5388,366.662 V 373.2245 Q 280.5388,373.86 280.5909,374.1204 Q 280.643,374.3704 280.7784,374.4745 Q 280.893,374.5683 281.1221,374.5162 Q 281.3513,374.4641 281.8825,374.235 Z M 275.6117,365.3496 Q 275.4242,365.3183 275.1221,365.1621 Q 274.82,364.9954 274.7055,364.9016 L 276.9138,360.4329 Q 277.0284,360.4433 277.3617,360.4954 Q 277.695,360.5475 278.0909,360.61 Q 278.4971,360.6725 278.8305,360.735 Q 279.1638,360.7975 279.2784,360.8287 L 279.6013,361.3912 Z"
+       id="path7414"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 156.8144,194.6964 Q 156.8144,195.4672 156.4707,196.2484 Q 156.1269,197.0297 155.554,197.6964 Q 154.9811,198.3526 154.3145,198.7797 L 153.6374,198.2589 Q 154.0124,197.7693 154.2624,197.1234 Q 154.5124,196.4672 154.5124,195.7901 Q 154.5124,195.2172 154.1165,194.8526 Q 153.7311,194.488 153.0228,194.4672 L 152.8561,193.686 Q 152.9499,193.561 153.3353,193.3735 Q 153.7311,193.1755 154.2207,192.9985 Q 154.7207,192.811 155.1582,192.6964 Q 155.5957,192.5714 155.7832,192.5922 Q 156.8144,193.363 156.8144,194.6964 Z M 151.8145,194.6964 Q 151.8145,195.4672 151.4603,196.2484 Q 151.1165,197.0297 150.5436,197.6964 Q 149.9811,198.3526 149.3145,198.7797 L 148.627,198.2589 Q 149.002,197.7693 149.252,197.1234 Q 149.502,196.4672 149.502,195.7901 Q 149.502,195.2172 149.1165,194.8526 Q 148.7311,194.488 148.0124,194.4672 L 147.8457,193.686 Q 147.9395,193.561 148.3249,193.3735 Q 148.7207,193.1755 149.2207,192.9985 Q 149.7207,192.811 150.1478,192.6964 Q 150.5853,192.5714 150.7728,192.5922 Q 151.8145,193.363 151.8145,194.6964 Z"
+       id="path7417"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 196.3184,200.9255 Q 196.3184,202.3422 195.8184,203.613 Q 195.3289,204.8838 194.4539,205.8734 Q 193.5893,206.8526 192.4539,207.4151 Q 191.3289,207.9776 190.0685,207.9776 Q 188.7768,207.9776 187.7351,207.4359 Q 186.6935,206.8943 185.9435,205.9672 Q 185.2039,205.0297 184.808,203.8214 Q 184.4122,202.613 184.4122,201.2901 Q 184.4122,199.8734 184.8705,198.6026 Q 185.3289,197.3214 186.1622,196.3422 Q 187.006,195.3526 188.1518,194.7901 Q 189.2976,194.2276 190.6726,194.2276 Q 192.0476,194.2276 193.0997,194.7901 Q 194.1518,195.3526 194.8705,196.3109 Q 195.5893,197.2589 195.9539,198.4568 Q 196.3184,199.6547 196.3184,200.9255 Z M 198.5997,208.9568 Q 198.1101,209.863 197.4955,210.4672 Q 196.8914,211.0713 196.5684,211.0713 Q 195.8497,211.0713 195.1205,210.738 Q 194.4018,210.4151 193.6622,209.9151 Q 192.933,209.4151 192.1935,208.8838 Q 191.4643,208.363 190.7351,207.9672 Q 190.006,207.5713 189.2872,207.4568 Q 189.2872,207.4568 189.5997,207.4047 Q 189.9226,207.3422 190.3601,207.2797 Q 190.808,207.2068 191.1935,207.1651 Q 191.5789,207.1234 191.7247,207.1547 Q 192.6726,207.363 193.5164,207.8109 Q 194.3705,208.2693 195.1414,208.6443 Q 195.9122,209.0193 196.6309,209.0193 Q 196.8914,209.0193 197.1726,208.8838 Q 197.4643,208.7484 198.0893,208.2797 Z M 193.6935,201.113 Q 193.6935,199.6755 193.2455,198.4151 Q 192.7976,197.1547 191.9955,196.3734 Q 191.1935,195.5818 190.131,195.5818 Q 188.631,195.5818 187.8393,197.0089 Q 187.0476,198.4359 187.0476,200.988 Q 187.0476,202.5401 187.5164,203.8109 Q 187.9851,205.0818 188.7768,205.8318 Q 189.5685,206.5713 190.5268,206.5713 Q 191.9018,206.5713 192.7976,205.2276 Q 193.6935,203.8734 193.6935,201.113 Z"
+       id="path7420"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 229.8504,195.3005 Q 229.1004,195.4047 228.7567,195.6026 Q 228.4129,195.8005 228.4129,195.9464 V 207.3318 L 226.8505,206.9255 V 195.9464 Q 226.8505,195.8214 226.5484,195.6234 Q 226.2567,195.4151 225.4234,195.3005 V 194.5401 H 229.8504 Z M 228.4129,207.9776 Q 227.4234,207.8943 226.8088,207.5922 Q 226.2046,207.2797 225.9234,206.8943 L 218.6005,196.7484 Q 218.1734,196.1547 217.6421,195.7693 Q 217.1109,195.3839 216.5692,195.3005 V 194.5401 H 219.4755 Q 219.7775,194.5401 219.9338,194.6755 Q 220.09,194.8109 220.4755,195.3526 L 227.0275,204.4255 Q 227.1421,204.5818 227.3609,204.8734 Q 227.59,205.1547 227.8296,205.4568 Q 228.0692,205.7588 228.2359,205.9672 Q 228.4129,206.1755 228.4129,206.1755 Z M 216.5692,207.6651 V 206.9047 Q 217.3296,206.8109 217.663,206.613 Q 217.9963,206.4047 217.9963,206.2693 V 195.5193 L 219.5588,194.9464 V 206.2693 Q 219.5588,206.3943 219.8713,206.5922 Q 220.1838,206.7901 220.9963,206.9047 V 207.6651 Z M 227.2984,190.488 Q 227.0588,191.0505 226.6525,191.7276 Q 226.2567,192.4047 225.7255,192.9047 Q 225.2046,193.3943 224.5692,193.3943 Q 223.965,193.3943 223.4338,193.1235 Q 222.913,192.8422 222.4025,192.5714 Q 221.9025,192.2901 221.3817,192.2901 Q 220.9025,192.2901 220.5796,192.6026 Q 220.2671,192.9151 219.8921,193.488 L 219.1005,193.2068 Q 219.3505,192.6339 219.7463,191.9568 Q 220.1421,191.2693 220.663,190.7693 Q 221.1942,190.2693 221.8296,190.2693 Q 222.465,190.2693 223.0171,190.5505 Q 223.5692,190.8214 224.0484,191.1026 Q 224.538,191.3735 224.9963,191.3735 Q 225.4442,191.3735 225.7984,191.0818 Q 226.1525,190.7797 226.5067,190.1651 Z"
+       id="path7423"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 271.2899,195.3005 Q 270.3733,195.488 270.0504,195.6339 Q 269.7379,195.7797 269.7066,195.9464 L 267.3212,207.0505 Q 267.2587,207.3422 266.967,207.5401 Q 266.6858,207.7276 266.342,207.8213 Q 266.0087,207.9255 265.8004,207.9776 L 262.2483,198.5297 L 259.2587,207.0505 Q 259.1025,207.4984 258.5608,207.6859 Q 258.0295,207.8838 257.6025,207.9776 L 254.8941,196.0297 Q 254.8421,195.7693 254.5191,195.6026 Q 254.1962,195.4359 253.4566,195.3005 V 194.5401 H 258.5504 V 195.3005 Q 257.8733,195.363 257.5816,195.4776 Q 257.29,195.5922 257.2379,195.738 Q 257.1858,195.8734 257.2171,196.0297 L 258.9983,203.6547 L 262.04,194.5401 H 263.0816 L 266.5712,203.6547 L 268.2483,195.9464 Q 268.2899,195.7068 267.8108,195.5609 Q 267.342,195.4151 266.6441,195.3005 V 194.5401 H 271.2899 Z"
+       id="path7426"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 297.5761,204.6651 Q 297.3677,204.7588 296.9198,204.9047 Q 296.4823,205.0401 296.274,205.0818 L 290.5865,199.3943 L 290.5761,198.9255 Q 290.774,198.8318 291.2115,198.7276 Q 291.6594,198.6234 291.8886,198.5714 L 297.5761,204.2589 Z M 290.6073,204.238 L 296.274,198.5714 Q 296.4927,198.6234 296.9198,198.7484 Q 297.3469,198.863 297.5552,198.988 V 199.4151 L 291.8886,205.0818 Q 291.6907,205.0401 291.274,204.9359 Q 290.8677,204.8213 290.6073,204.6651 Z"
+       id="path7429"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 337.698,194.8734 Q 337.6771,195.2276 337.6042,195.8109 Q 337.5417,196.3943 337.448,196.9464 Q 337.3542,197.4984 337.2709,197.7693 H 336.4896 Q 336.3959,195.7901 335.6355,195.7901 H 331.5938 L 331.8959,194.5401 H 337.2813 Z M 336.625,200.3734 Q 336.4584,200.6651 336.1771,201.1026 Q 335.8959,201.5297 335.6667,201.6859 Q 335.3438,201.3839 334.9063,201.2484 Q 334.4792,201.113 333.6042,201.113 H 331.448 L 331.6771,200.0089 H 336.2813 Z M 338.375,204.4984 Q 338.323,205.0922 338.2396,205.7588 Q 338.1667,206.4151 338.0834,206.9359 Q 338.0105,207.4568 337.948,207.6651 H 328.1042 V 206.9047 Q 329.5313,206.613 329.5313,206.2693 V 195.9464 Q 329.5313,195.8214 329.1876,195.6339 Q 328.8542,195.4464 328.1042,195.3005 V 194.5401 H 333.6459 V 195.3005 Q 332.948,195.3734 332.5417,195.4776 Q 332.1355,195.5714 332.1355,195.7172 V 205.7484 Q 332.1355,205.9463 332.2813,206.1026 Q 332.4376,206.2484 332.8855,206.3318 Q 333.3438,206.4151 334.2605,206.4151 H 335.2917 Q 336.25,206.4151 336.7084,205.9359 Q 337.1667,205.4463 337.6146,204.2276 Z"
+       id="path7432"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 362.4282,203.1859 L 361.4282,206.1963 Q 361.3345,206.5193 361.6887,206.6651 Q 362.0428,206.8109 362.897,206.9047 V 207.6651 H 358.3449 V 206.9047 Q 359.0532,206.7797 359.4282,206.6443 Q 359.8137,206.5088 359.9178,206.1963 L 363.5532,195.0922 Q 364.0428,194.6651 364.6782,194.3839 Q 365.3241,194.1026 365.8657,193.9464 L 370.2407,206.1963 Q 370.3449,206.488 370.5949,206.6547 Q 370.8553,206.8213 371.5324,206.9047 V 207.6651 H 366.3553 V 206.9047 Q 367.1574,206.8526 367.4491,206.6963 Q 367.7407,206.5401 367.6261,206.1963 L 366.5636,203.1859 Z M 366.1261,201.9359 L 364.4074,197.0922 L 362.8449,201.9359 Z M 367.1261,190.7172 Q 367.1261,191.4672 366.7616,192.0714 Q 366.4074,192.6755 365.8345,193.0401 Q 365.272,193.3943 364.6261,193.3943 Q 363.8032,193.3943 363.2928,192.8943 Q 362.7824,192.3839 362.7824,191.5505 Q 362.7824,190.811 363.1262,190.1964 Q 363.4803,189.5818 364.0428,189.2276 Q 364.6157,188.863 365.272,188.863 Q 366.1157,188.863 366.6157,189.3839 Q 367.1157,189.9047 367.1261,190.7172 Z M 365.7199,191.1443 Q 365.7199,190.6443 365.5011,190.3839 Q 365.2928,190.1235 365.0532,190.1235 Q 364.6261,190.1235 364.4074,190.436 Q 364.1887,190.7485 364.1887,191.1235 Q 364.1887,191.6026 364.397,191.8735 Q 364.6053,192.1339 364.8449,192.1339 Q 365.2616,192.1339 365.4907,191.8526 Q 365.7199,191.5714 365.7199,191.1443 Z"
+       id="path7435"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 408.2192,197.3839 Q 408.2192,198.7172 407.5213,199.6547 Q 406.8234,200.5922 405.6463,201.0818 Q 404.4796,201.5714 403.0525,201.5714 Q 402.7609,201.5714 402.4484,201.5401 Q 402.1463,201.4984 401.8234,201.4255 L 401.7609,200.2797 Q 402.1255,200.3422 402.365,200.363 Q 402.615,200.3839 402.8754,200.3839 Q 404.2817,200.3839 404.9379,199.6755 Q 405.5942,198.9672 405.5942,197.7068 Q 405.5942,197.0609 405.3234,196.5297 Q 405.0525,195.988 404.3859,195.6651 Q 403.7192,195.3318 402.5213,195.3318 Q 401.9067,195.3318 401.1046,195.4151 Q 400.3025,195.488 399.4588,195.5922 Q 398.6255,195.6964 397.9171,195.8109 L 397.7817,194.8526 Q 398.8755,194.613 400.1775,194.4255 Q 401.49,194.2276 402.9796,194.2276 Q 404.865,194.2276 406.0109,194.6443 Q 407.1671,195.0609 407.6879,195.7797 Q 408.2192,196.488 408.2192,197.3839 Z M 410.4275,207.1234 Q 409.9692,207.2693 409.3754,207.4359 Q 408.7921,207.5922 408.2609,207.6963 Q 407.74,207.8109 407.4692,207.8109 Q 407.1775,207.8109 406.8859,207.6443 Q 406.5942,207.4672 406.4484,207.238 L 403.3234,201.2901 L 404.8754,200.6026 L 408.5942,205.7484 Q 408.9275,206.1859 409.2504,206.3109 Q 409.5734,206.4255 410.2713,206.363 Z M 397.9171,207.6651 V 206.9047 Q 399.3442,206.613 399.3442,206.2693 V 195.1755 H 401.9484 V 206.2693 Q 401.9484,206.3943 402.2817,206.5818 Q 402.6254,206.7588 403.3859,206.9047 V 207.6651 Z"
+       id="path7438"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 435.5013,207.9776 Q 434.1888,207.9776 433.1368,207.4359 Q 432.0951,206.8838 431.3555,205.9463 Q 430.6264,205.0088 430.2409,203.8109 Q 429.8555,202.6026 429.8555,201.2901 Q 429.8555,199.8734 430.3139,198.6026 Q 430.7722,197.3214 431.6055,196.3422 Q 432.4388,195.3526 433.5847,194.7901 Q 434.7305,194.2276 436.1055,194.2276 Q 437.4805,194.2276 438.5326,194.7901 Q 439.5951,195.3526 440.3034,196.3109 Q 441.0222,197.2589 441.3868,198.4568 Q 441.7617,199.6547 441.7617,200.9255 Q 441.7617,202.3422 441.2618,203.613 Q 440.7618,204.8838 439.8972,205.8734 Q 439.0326,206.8526 437.8972,207.4151 Q 436.7722,207.9776 435.5013,207.9776 Z M 435.9597,206.5713 Q 437.3347,206.5713 438.2305,205.2276 Q 439.1263,203.8734 439.1263,201.113 Q 439.1263,199.6755 438.6784,198.4151 Q 438.2305,197.1547 437.4284,196.3734 Q 436.6368,195.5818 435.5743,195.5818 Q 434.0743,195.5818 433.2722,197.0089 Q 432.4805,198.4359 432.4805,200.988 Q 432.4805,202.5401 432.9493,203.8109 Q 433.4284,205.0818 434.2201,205.8318 Q 435.0118,206.5713 435.9597,206.5713 Z M 437.8972,192.811 Q 437.8034,192.9985 437.5847,193.2276 Q 437.3659,193.4464 437.1993,193.5505 L 431.9805,190.9047 L 432.0638,190.2485 Q 432.1784,190.1651 432.6055,189.936 Q 433.043,189.7068 433.4805,189.488 Q 433.9284,189.2589 434.0847,189.186 Z"
+       id="path7441"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 480.9501,194.8734 Q 480.9397,195.2276 480.8772,195.7693 Q 480.8147,196.3109 480.7209,196.8734 Q 480.6376,197.4359 480.5542,197.8734 H 479.773 Q 479.5751,196.9047 479.4501,196.3526 Q 479.3251,195.7901 478.8876,195.7901 H 475.6897 L 475.9917,194.5401 H 480.5542 Z M 471.0647,195.7901 Q 470.7418,195.7901 470.4813,196.2693 Q 470.2209,196.7484 469.7522,197.9672 L 468.9918,197.6859 Q 469.023,197.2797 469.0855,196.6859 Q 469.1584,196.0818 469.2418,195.4984 Q 469.3355,194.9047 469.4084,194.5401 H 474.3772 L 474.5126,195.7901 Z M 472.0855,207.6651 V 206.9047 Q 473.0438,206.7068 473.3772,206.5088 Q 473.7105,206.3005 473.7105,206.1547 V 195.7172 Q 473.7105,195.5922 473.4084,195.5193 Q 473.1063,195.4464 472.3563,195.3005 V 194.5401 H 477.8042 V 195.3005 Q 477.1063,195.4464 476.7105,195.5089 Q 476.3147,195.5714 476.3147,195.7172 V 206.1547 Q 476.3147,206.2901 476.648,206.4984 Q 476.9813,206.7068 477.9501,206.9047 V 207.6651 Z"
+       id="path7444"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 506.3636,207.9776 Q 505.0511,207.9776 503.9991,207.4359 Q 502.9574,206.8838 502.2178,205.9463 Q 501.4887,205.0088 501.1032,203.8109 Q 500.7178,202.6026 500.7178,201.2901 Q 500.7178,199.8734 501.1762,198.6026 Q 501.6345,197.3214 502.4678,196.3422 Q 503.3012,195.3526 504.447,194.7901 Q 505.5928,194.2276 506.9678,194.2276 Q 508.3428,194.2276 509.3949,194.7901 Q 510.4574,195.3526 511.1657,196.3109 Q 511.8845,197.2589 512.2491,198.4568 Q 512.6241,199.6547 512.6241,200.9255 Q 512.6241,202.3422 512.1241,203.613 Q 511.6241,204.8838 510.7595,205.8734 Q 509.8949,206.8526 508.7595,207.4151 Q 507.6345,207.9776 506.3636,207.9776 Z M 506.822,206.5713 Q 508.197,206.5713 509.0928,205.2276 Q 509.9886,203.8734 509.9886,201.113 Q 509.9886,199.6755 509.5407,198.4151 Q 509.0928,197.1547 508.2907,196.3734 Q 507.4991,195.5818 506.4366,195.5818 Q 504.9366,195.5818 504.1345,197.0089 Q 503.3428,198.4359 503.3428,200.988 Q 503.3428,202.5401 503.8116,203.8109 Q 504.2907,205.0818 505.0824,205.8318 Q 505.8741,206.5713 506.822,206.5713 Z M 510.322,192.8005 Q 510.197,192.9985 510.0303,193.2172 Q 509.8741,193.4255 509.697,193.4985 L 506.7803,191.7276 L 503.8845,193.4985 Q 503.7074,193.4255 503.5199,193.2172 Q 503.3324,192.9985 503.1762,192.8005 L 506.0824,189.3422 H 507.5095 Z"
+       id="path7447"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 552.1968,195.3005 Q 551.4884,195.4359 551.1447,195.5818 Q 550.8009,195.7172 550.6551,195.988 L 547.0822,202.6443 H 544.9259 Q 544.4364,201.488 543.7489,200.2172 Q 543.0614,198.9359 542.3634,197.8109 Q 541.6759,196.6859 541.1551,195.988 Q 540.9676,195.7589 540.6759,195.6234 Q 540.3843,195.488 539.5197,195.488 L 539.478,194.7276 Q 539.8843,194.6755 540.4155,194.613 Q 540.9572,194.5401 541.4468,194.488 Q 541.9468,194.4359 542.228,194.4359 Q 542.5093,194.4359 542.8009,194.5609 Q 543.103,194.6859 543.2801,194.9151 Q 543.7905,195.6026 544.3634,196.5505 Q 544.9468,197.4984 545.5093,198.5505 Q 546.0822,199.5922 546.5613,200.5922 L 548.9988,195.988 Q 549.1551,195.7172 548.8947,195.5609 Q 548.6447,195.4047 547.8426,195.3005 V 194.5401 H 552.1968 Z M 543.0718,207.6651 V 206.9047 Q 544.0197,206.7068 544.3634,206.5088 Q 544.7072,206.3005 544.7072,206.1547 V 201.0297 H 547.3113 V 206.1547 Q 547.3113,206.2901 547.6447,206.4984 Q 547.978,206.7068 548.9572,206.9047 V 207.6651 Z"
+       id="path7450"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 584.1517,195.3005 Q 582.7142,195.6026 582.7142,195.9464 V 202.2068 Q 582.7142,204.0297 582.0476,205.3213 Q 581.3913,206.613 580.2247,207.3005 Q 579.0684,207.9776 577.5684,207.9776 Q 576.1413,207.9776 574.9538,207.4463 Q 573.7663,206.9151 573.058,205.8213 Q 572.3497,204.7276 572.3497,203.0401 V 195.9464 Q 572.3497,195.8214 572.0059,195.6339 Q 571.6726,195.4464 570.9226,195.3005 V 194.5401 H 576.3913 V 195.3005 Q 574.9538,195.6026 574.9538,195.9464 V 202.363 Q 574.9538,204.363 575.6934,205.4151 Q 576.433,206.4672 578.2142,206.4672 Q 579.2038,206.4672 579.7872,205.9047 Q 580.3705,205.3318 580.6309,204.4255 Q 580.8913,203.5089 580.8913,202.4776 V 195.9464 Q 580.8913,195.8214 580.5476,195.6339 Q 580.2142,195.4464 579.4642,195.3005 V 194.5401 H 584.1517 Z M 579.6517,192.811 Q 579.558,192.9985 579.3392,193.2276 Q 579.1205,193.4464 578.9538,193.5505 L 573.7351,190.9047 L 573.8184,190.2485 Q 573.933,190.1651 574.3601,189.936 Q 574.7976,189.7068 575.2351,189.488 Q 575.683,189.2589 575.8392,189.186 Z"
+       id="path7453"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 623.3182,195.3005 Q 621.8807,195.6026 621.8807,195.9464 V 202.2068 Q 621.8807,204.0297 621.2141,205.3213 Q 620.5578,206.613 619.3912,207.3005 Q 618.2349,207.9776 616.7349,207.9776 Q 615.3078,207.9776 614.1203,207.4463 Q 612.9328,206.9151 612.2245,205.8213 Q 611.5162,204.7276 611.5162,203.0401 V 195.9464 Q 611.5162,195.8214 611.1724,195.6339 Q 610.8391,195.4464 610.0891,195.3005 V 194.5401 H 615.5578 V 195.3005 Q 614.1203,195.6026 614.1203,195.9464 V 202.363 Q 614.1203,204.363 614.8599,205.4151 Q 615.5995,206.4672 617.3807,206.4672 Q 618.3703,206.4672 618.9537,205.9047 Q 619.537,205.3318 619.7974,204.4255 Q 620.0578,203.5089 620.0578,202.4776 V 195.9464 Q 620.0578,195.8214 619.7141,195.6339 Q 619.3807,195.4464 618.6307,195.3005 V 194.5401 H 623.3182 Z"
+       id="path7456"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 648.096,207.9776 Q 646.7835,207.9776 645.7314,207.4359 Q 644.6897,206.8838 643.9502,205.9463 Q 643.221,205.0088 642.8356,203.8109 Q 642.4502,202.6026 642.4502,201.2901 Q 642.4502,199.8734 642.9085,198.6026 Q 643.3668,197.3214 644.2002,196.3422 Q 645.0335,195.3526 646.1793,194.7901 Q 647.3251,194.2276 648.7001,194.2276 Q 650.0751,194.2276 651.1272,194.7901 Q 652.1897,195.3526 652.8981,196.3109 Q 653.6168,197.2589 653.9814,198.4568 Q 654.3564,199.6547 654.3564,200.9255 Q 654.3564,202.3422 653.8564,203.613 Q 653.3564,204.8838 652.4918,205.8734 Q 651.6272,206.8526 650.4918,207.4151 Q 649.3668,207.9776 648.096,207.9776 Z M 648.5543,206.5713 Q 649.9293,206.5713 650.8251,205.2276 Q 651.721,203.8734 651.721,201.113 Q 651.721,199.6755 651.2731,198.4151 Q 650.8251,197.1547 650.0231,196.3734 Q 649.2314,195.5818 648.1689,195.5818 Q 646.6689,195.5818 645.8668,197.0089 Q 645.0751,198.4359 645.0751,200.988 Q 645.0751,202.5401 645.5439,203.8109 Q 646.0231,205.0818 646.8147,205.8318 Q 647.6064,206.5713 648.5543,206.5713 Z M 652.6168,190.488 Q 652.3772,191.0505 651.971,191.7276 Q 651.5751,192.4047 651.0439,192.9047 Q 650.5231,193.3943 649.8876,193.3943 Q 649.2835,193.3943 648.7522,193.1235 Q 648.2314,192.8422 647.721,192.5714 Q 647.221,192.2901 646.7001,192.2901 Q 646.221,192.2901 645.8981,192.6026 Q 645.5856,192.9151 645.2106,193.488 L 644.4189,193.2068 Q 644.6689,192.6339 645.0647,191.9568 Q 645.4606,191.2693 645.9814,190.7693 Q 646.5126,190.2693 647.1481,190.2693 Q 647.7835,190.2693 648.3356,190.5505 Q 648.8876,190.8214 649.3668,191.1026 Q 649.8564,191.3735 650.3147,191.3735 Q 650.7626,191.3735 651.1168,191.0818 Q 651.471,190.7797 651.8251,190.1651 Z"
+       id="path7459"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 684.8312,207.6651 V 206.9047 Q 686.2583,206.613 686.2583,206.2693 V 195.9464 Q 686.2583,195.8214 685.9145,195.6339 Q 685.5812,195.4464 684.8312,195.3005 V 194.5401 H 690.2999 V 195.3005 Q 688.8624,195.6026 688.8624,195.9464 V 206.2693 Q 688.8624,206.3943 689.2062,206.5818 Q 689.5499,206.7588 690.2999,206.9047 V 207.6651 Z"
+       id="path7462"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 723.7282,194.8734 Q 723.7074,195.2276 723.6345,195.8109 Q 723.572,196.3943 723.4782,196.9464 Q 723.3845,197.4984 723.3012,197.7693 H 722.5199 Q 722.4262,195.7901 721.6657,195.7901 H 717.6241 L 717.9262,194.5401 H 723.3116 Z M 722.6553,200.3734 Q 722.4887,200.6651 722.2074,201.1026 Q 721.9262,201.5297 721.697,201.6859 Q 721.3741,201.3839 720.9366,201.2484 Q 720.5095,201.113 719.6345,201.113 H 717.4782 L 717.7074,200.0089 H 722.3116 Z M 724.4053,204.4984 Q 724.3532,205.0922 724.2699,205.7588 Q 724.197,206.4151 724.1137,206.9359 Q 724.0407,207.4568 723.9782,207.6651 H 714.1345 V 206.9047 Q 715.5616,206.613 715.5616,206.2693 V 195.9464 Q 715.5616,195.8214 715.2178,195.6339 Q 714.8845,195.4464 714.1345,195.3005 V 194.5401 H 719.6762 V 195.3005 Q 718.9782,195.3734 718.572,195.4776 Q 718.1657,195.5714 718.1657,195.7172 V 205.7484 Q 718.1657,205.9463 718.3116,206.1026 Q 718.4678,206.2484 718.9157,206.3318 Q 719.3741,206.4151 720.2907,206.4151 H 721.322 Q 722.2803,206.4151 722.7387,205.9359 Q 723.197,205.4463 723.6449,204.2276 Z M 717.7387,193.5193 Q 717.5616,193.436 717.3428,193.186 Q 717.1345,192.936 717.0407,192.7901 L 720.8845,189.2485 Q 720.9887,189.3005 721.2803,189.4568 Q 721.5824,189.6026 721.9262,189.7901 Q 722.2699,189.9672 722.5512,190.1339 Q 722.8428,190.2901 722.9366,190.3735 L 723.0407,191.0089 Z"
+       id="path7465"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 758.1248,207.9776 Q 756.8123,207.9776 755.7603,207.4359 Q 754.7186,206.8838 753.979,205.9463 Q 753.2499,205.0088 752.8644,203.8109 Q 752.479,202.6026 752.479,201.2901 Q 752.479,199.8734 752.9374,198.6026 Q 753.3957,197.3214 754.229,196.3422 Q 755.0624,195.3526 756.2082,194.7901 Q 757.354,194.2276 758.729,194.2276 Q 760.104,194.2276 761.1561,194.7901 Q 762.2186,195.3526 762.9269,196.3109 Q 763.6457,197.2589 764.0103,198.4568 Q 764.3853,199.6547 764.3853,200.9255 Q 764.3853,202.3422 763.8853,203.613 Q 763.3853,204.8838 762.5207,205.8734 Q 761.6561,206.8526 760.5207,207.4151 Q 759.3957,207.9776 758.1248,207.9776 Z M 758.5832,206.5713 Q 759.9582,206.5713 760.854,205.2276 Q 761.7498,203.8734 761.7498,201.113 Q 761.7498,199.6755 761.3019,198.4151 Q 760.854,197.1547 760.0519,196.3734 Q 759.2603,195.5818 758.1978,195.5818 Q 756.6978,195.5818 755.8957,197.0089 Q 755.104,198.4359 755.104,200.988 Q 755.104,202.5401 755.5728,203.8109 Q 756.0519,205.0818 756.8436,205.8318 Q 757.6353,206.5713 758.5832,206.5713 Z"
+       id="path7468"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 787.4111,207.6651 V 206.9047 Q 788.8382,206.613 788.8382,206.2693 V 195.9464 Q 788.8382,195.8214 788.4945,195.6339 Q 788.1611,195.4464 787.4111,195.3005 V 194.5401 H 792.8799 V 195.3005 Q 791.4424,195.6026 791.4424,195.9464 V 206.2693 Q 791.4424,206.3943 791.7861,206.5818 Q 792.1299,206.7588 792.8799,206.9047 V 207.6651 Z M 789.3695,191.5401 Q 789.3695,192.3005 788.8799,192.8422 Q 788.4007,193.3839 787.734,193.3839 Q 786.5049,193.3839 786.5049,192.113 Q 786.5049,191.3526 786.9945,190.8214 Q 787.4945,190.2797 788.1299,190.2797 Q 788.7132,190.2797 789.0361,190.6026 Q 789.3695,190.9151 789.3695,191.5401 Z M 793.7653,191.5401 Q 793.7653,192.3005 793.2861,192.8422 Q 792.807,193.3839 792.1403,193.3839 Q 790.9007,193.3839 790.9007,192.113 Q 790.9007,191.3526 791.3903,190.8214 Q 791.8903,190.2797 792.5361,190.2797 Q 793.109,190.2797 793.432,190.6026 Q 793.7653,190.9151 793.7653,191.5401 Z"
+       id="path7471"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 834.8034,197.9151 Q 834.8034,198.9984 834.3763,199.8109 Q 833.9597,200.6234 833.2826,201.1651 Q 832.6159,201.7068 831.8451,201.9776 Q 831.0743,202.2484 830.3868,202.2484 Q 829.9076,202.2484 829.4389,202.1755 Q 828.9805,202.0922 828.6368,201.9359 L 828.3139,200.8422 Q 828.7409,201.0401 829.0639,201.1026 Q 829.3972,201.1547 829.7618,201.1547 Q 830.3659,201.1547 830.918,200.863 Q 831.4701,200.5609 831.8243,199.9464 Q 832.1784,199.3214 832.1784,198.3422 Q 832.1784,196.863 831.2409,196.1026 Q 830.3139,195.3318 828.8243,195.3318 Q 828.0951,195.3318 827.2097,195.4047 Q 826.3243,195.4776 825.4597,195.5818 Q 824.5951,195.6859 823.9284,195.8109 L 823.793,194.8526 Q 824.543,194.6651 825.5014,194.5297 Q 826.4597,194.3839 827.4805,194.3109 Q 828.5014,194.2276 829.418,194.2276 Q 831.8347,194.2276 833.3138,195.1755 Q 834.8034,196.1234 834.8034,197.9151 Z M 823.9284,207.6651 V 206.9047 Q 825.3555,206.613 825.3555,206.2693 V 195.2901 H 827.9597 V 206.2693 Q 827.9597,206.3943 828.2826,206.5609 Q 828.6159,206.7276 829.7097,206.9047 V 207.6651 Z"
+       id="path7474"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 861.3711,201.2589 H 855.0169 L 854.7878,201.0089 Q 854.8294,200.8526 854.944,200.5193 Q 855.069,200.1755 855.1315,200.0089 H 861.4857 L 861.7461,200.2484 Z M 854.944,207.6651 V 206.9047 Q 856.3711,206.613 856.3711,206.2693 V 195.6026 Q 855.9648,195.6651 855.6003,195.7172 Q 855.2357,195.7693 854.944,195.8109 L 854.8086,194.8526 Q 855.4961,194.6755 856.4857,194.5401 Q 857.4857,194.3943 858.5482,194.3109 Q 859.6211,194.2276 860.5169,194.2276 Q 863.7044,194.2276 865.4544,195.9151 Q 867.2148,197.6026 867.2148,200.6234 Q 867.2148,202.5714 866.6419,203.9255 Q 866.069,205.2693 865.1419,206.1026 Q 864.2148,206.9255 863.1107,207.3005 Q 862.0169,207.6651 860.944,207.6651 H 860.1003 Q 858.8815,207.6651 857.8294,207.6651 Q 856.7878,207.6651 855.3503,207.6651 Z M 860.5586,206.5505 Q 861.1627,206.5505 861.8294,206.238 Q 862.5065,205.9255 863.0898,205.2588 Q 863.6836,204.5922 864.0482,203.5505 Q 864.4232,202.4984 864.4232,201.0297 Q 864.4232,198.2589 863.2252,196.8005 Q 862.0377,195.3318 859.7669,195.3318 Q 859.5794,195.3318 859.3815,195.3422 Q 859.1836,195.3526 858.9753,195.363 V 205.9047 Q 858.9753,206.3213 859.4544,206.4359 Q 859.9336,206.5505 860.5586,206.5505 Z"
+       id="path7477"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 903.3254,191.8005 Q 902.5129,192.311 901.992,192.9985 Q 901.4816,193.686 901.4816,194.4672 Q 901.4816,195.1964 901.5858,195.7276 Q 901.7004,196.2589 901.8045,196.7901 Q 901.9087,197.3214 901.9087,198.0505 Q 901.9087,198.9151 901.3254,199.6964 Q 900.7525,200.4776 899.8775,200.863 Q 900.9191,201.0505 901.4087,201.7797 Q 901.9087,202.5089 901.9087,203.6547 Q 901.9087,204.4047 901.8045,205.0193 Q 901.7004,205.6338 901.5858,206.1963 Q 901.4816,206.7588 901.4816,207.3734 Q 901.4816,208.2276 901.7941,208.8005 Q 902.117,209.3838 903.2212,209.9984 L 902.8254,210.9463 Q 900.8983,210.238 899.8566,209.4047 Q 898.815,208.5818 898.815,207.0713 Q 898.815,206.3318 898.9191,205.7693 Q 899.0337,205.2068 899.1379,204.6339 Q 899.242,204.0505 899.242,203.2693 Q 899.242,202.4255 898.8775,202.0714 Q 898.5129,201.7172 897.8566,201.7172 Q 897.565,201.7172 897.44,201.7276 Q 897.315,201.738 897.1795,201.7797 L 897.0025,200.9151 Q 898.1587,200.5922 898.7004,200.0297 Q 899.242,199.4568 899.242,198.6755 Q 899.242,197.9047 899.1379,197.3943 Q 899.0337,196.8734 898.9191,196.3526 Q 898.815,195.8318 898.815,195.0609 Q 898.815,194.1234 899.3462,193.3839 Q 899.8879,192.6339 900.815,192.0505 Q 901.742,191.4672 902.8983,190.9985 Z"
+       id="path7480"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 937.6491,206.4984 Q 937.1387,206.8318 936.5033,207.1755 Q 935.8783,207.5193 935.3575,207.7484 Q 934.8366,207.9776 934.67,207.9776 Q 934.295,207.9776 933.9825,207.6547 Q 933.67,207.3213 933.545,206.2484 Q 932.6804,206.9984 932.045,207.3734 Q 931.4096,207.738 930.92,207.8526 Q 930.4304,207.9776 929.9825,207.9776 Q 929.3366,207.9776 928.7325,207.7172 Q 928.1283,207.4568 927.7325,206.7588 Q 927.3471,206.0609 927.3471,204.7588 V 200.488 Q 927.3471,199.8318 927.2846,199.5401 Q 927.2325,199.2484 926.9616,199.1547 Q 926.7012,199.0609 926.0866,198.9984 V 198.2693 Q 927.1283,198.1755 927.8679,198.0609 Q 928.6179,197.9359 929.4825,197.6651 L 929.8471,198.1443 V 204.1026 Q 929.8471,205.3943 930.1596,205.7901 Q 930.4721,206.1755 931.0554,206.1755 Q 931.4929,206.1755 932.0866,205.9255 Q 932.6908,205.6755 933.545,204.9359 V 200.488 Q 933.545,199.863 933.4616,199.5609 Q 933.3887,199.2589 933.0971,199.1443 Q 932.8054,199.0297 932.17,198.9984 V 198.2693 Q 933.2116,198.1755 934.0554,198.0193 Q 934.9096,197.8526 935.6596,197.6651 L 936.045,198.1443 V 204.7068 Q 936.045,205.3422 936.097,205.6026 Q 936.1491,205.8526 936.2845,205.9568 Q 936.3991,206.0505 936.6283,205.9984 Q 936.8575,205.9463 937.3887,205.7172 Z M 935.2741,196.1339 Q 935.1491,196.3318 934.9929,196.5505 Q 934.8471,196.7589 934.67,196.8318 L 931.7325,194.5089 L 928.8366,196.8318 Q 928.6596,196.7589 928.4721,196.5505 Q 928.2846,196.3318 928.1283,196.1339 L 931.0346,192.1026 H 932.4616 Z"
+       id="path7483"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 974.1915,201.0401 Q 973.0353,201.363 972.4936,201.9255 Q 971.952,202.488 971.952,203.2797 Q 971.952,204.0401 972.0561,204.5609 Q 972.1603,205.0713 972.2645,205.5922 Q 972.3686,206.113 972.3686,206.8838 Q 972.3686,207.8213 971.827,208.5609 Q 971.2957,209.3109 970.3686,209.8943 Q 969.452,210.488 968.2957,210.9568 L 967.8686,210.1443 Q 968.6811,209.6338 969.1915,208.9463 Q 969.702,208.2693 969.702,207.4776 Q 969.702,206.7484 969.5978,206.2172 Q 969.4936,205.6859 969.3895,205.1547 Q 969.2853,204.6234 969.2853,203.8943 Q 969.2853,203.0297 969.8582,202.2589 Q 970.4311,201.4776 971.3165,201.0922 Q 970.2749,200.9047 969.7749,200.1755 Q 969.2853,199.4464 969.2853,198.2901 Q 969.2853,197.1651 969.4936,196.3318 Q 969.702,195.4984 969.702,194.5818 Q 969.702,193.7172 969.379,193.1443 Q 969.0665,192.561 967.9728,191.9568 L 968.3686,191.0089 Q 970.2853,191.7068 971.327,192.5401 Q 972.3686,193.3735 972.3686,194.8734 Q 972.3686,195.613 972.2645,196.1755 Q 972.1603,196.738 972.0561,197.3214 Q 971.952,197.8943 971.952,198.6755 Q 971.952,199.5193 972.3165,199.8734 Q 972.6811,200.2276 973.3374,200.2276 Q 973.5978,200.2276 973.7228,200.2172 Q 973.8582,200.2068 974.0145,200.1651 Z"
+       id="path7486"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1008.402,198.738 Q 1007.777,198.8839 1007.569,199.0089 Q 1007.371,199.1339 1007.257,199.4464 L 1003.777,208.4359 Q 1002.882,210.738 1001.694,211.7588 Q 1000.517,212.7901 999.1837,212.7901 Q 998.6524,212.7901 998.1629,212.6651 Q 997.6837,212.5505 997.3712,212.3838 Q 997.0587,212.2172 997.0587,212.0818 Q 997.0587,211.9984 997.2358,211.738 Q 997.4024,211.4776 997.6629,211.1547 Q 997.9129,210.8422 998.1629,210.5713 Q 998.4233,210.3109 998.5899,210.2068 Q 999.1108,210.5505 999.6316,210.613 Q 1000.163,210.6859 1000.548,210.5505 Q 1000.934,210.4255 1001.371,209.9672 Q 1001.809,209.5193 1002.184,208.6234 L 1002.486,207.9047 L 998.9962,199.4464 Q 998.7879,198.9568 997.8399,198.738 V 197.9776 H 1002.559 V 198.738 Q 1001.809,198.8318 1001.642,198.9776 Q 1001.475,199.113 1001.621,199.4464 L 1003.767,204.6755 L 1005.809,199.4464 Q 1005.923,199.1339 1005.788,198.988 Q 1005.652,198.8422 1004.996,198.738 V 197.9776 H 1008.402 Z M 1002.736,196.8318 Q 1002.548,196.8005 1002.246,196.6443 Q 1001.944,196.4776 1001.83,196.3839 L 1004.038,191.9151 Q 1004.152,191.9255 1004.486,191.9776 Q 1004.819,192.0297 1005.215,192.0922 Q 1005.621,192.1547 1005.955,192.2172 Q 1006.288,192.2797 1006.402,192.311 L 1006.725,192.8735 Z"
+       id="path7489"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1113.643,201.8943 Q 1113.58,202.1234 1113.414,202.5193 Q 1113.247,202.9047 1113.164,203.0818 H 1104.757 L 1104.424,202.7484 Q 1104.476,202.5297 1104.643,202.1547 Q 1104.809,201.7693 1104.903,201.5714 H 1113.309 Z"
+       id="path7492"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       id="path461"
+       d="M 0,0 C -0.064,0 -0.126,0.017 -0.181,0.048 C -0.305,0.119 -0.383,0.255 -0.383,0.402 V 3.404 C -0.383,3.552 -0.307,3.69 -0.181,3.759 C -0.067,3.826 0.076,3.823 0.19,3.754 L 2.757,2.219 C 2.931,2.109 2.983,1.878 2.873,1.705 C 2.842,1.657 2.804,1.616 2.757,1.588 L 0.19,0.052 C 0.131,0.019 0.067,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,103.6918,123.5765)"
+       clip-path="url(#clipPath462)" />
+    <path
+       id="path463"
+       d="M 0,0 V 3.026 C 0,3.235 0.171,3.407 0.381,3.407 C 0.59,3.407 0.762,3.235 0.762,3.026 V 0 C 0.762,-0.21 0.59,-0.381 0.381,-0.381 C 0.171,-0.381 0,-0.21 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,108.1071,123.0559)"
+       clip-path="url(#clipPath464)" />
+    <path
+       id="path465"
+       d="M 0,0 V 3.026 C 0,3.235 0.171,3.407 0.381,3.407 C 0.59,3.407 0.762,3.235 0.762,3.026 V 0 C 0.762,-0.21 0.59,-0.381 0.381,-0.381 C 0.171,-0.381 0,-0.21 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,110.1386,123.0559)"
+       clip-path="url(#clipPath466)" />
+    <path
+       id="path467"
+       d="M 0,0 C 0.064,0 0.126,-0.017 0.181,-0.048 C 0.305,-0.119 0.383,-0.255 0.383,-0.402 V -3.404 C 0.383,-3.552 0.307,-3.69 0.181,-3.759 C 0.067,-3.826 -0.076,-3.823 -0.19,-3.754 L -2.757,-2.219 C -2.931,-2.109 -2.983,-1.878 -2.873,-1.705 C -2.843,-1.657 -2.804,-1.616 -2.757,-1.588 L -0.19,-0.052 C -0.131,-0.019 -0.067,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,174.3789,118.4977)"
+       clip-path="url(#clipPath468)" />
+    <path
+       id="path469"
+       d="M 0,0 V -3.026 C 0,-3.235 -0.171,-3.407 -0.381,-3.407 C -0.59,-3.407 -0.762,-3.235 -0.762,-3.026 V 0 C -0.762,0.21 -0.59,0.381 -0.381,0.381 C -0.171,0.381 0,0.21 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,169.9637,119.0183)"
+       clip-path="url(#clipPath470)" />
+    <path
+       id="path471"
+       d="M 0,0 C -0.064,0 -0.126,0.017 -0.181,0.048 C -0.305,0.119 -0.383,0.255 -0.383,0.402 V 3.404 C -0.383,3.552 -0.307,3.69 -0.181,3.759 C -0.067,3.826 0.076,3.823 0.19,3.754 L 2.757,2.219 C 2.931,2.109 2.983,1.878 2.873,1.705 C 2.843,1.657 2.804,1.616 2.757,1.588 L 0.19,0.052 C 0.131,0.019 0.067,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,240.3236,123.5765)"
+       clip-path="url(#clipPath472)" />
+    <path
+       id="path473"
+       d="M 0,0 V 3.026 C 0,3.235 0.171,3.407 0.381,3.407 C 0.59,3.407 0.762,3.235 0.762,3.026 V 0 C 0.762,-0.21 0.59,-0.381 0.381,-0.381 C 0.171,-0.381 0,-0.21 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.333333,0,0,-1.333333,244.7389,123.0559)"
+       clip-path="url(#clipPath474)" />
+    <path
+       d="M 103.0727,148.9654 Q 103.0519,149.3195 102.9789,149.9029 Q 102.9164,150.4862 102.8227,151.0383 Q 102.7289,151.5904 102.6456,151.8613 H 101.8644 Q 101.7706,149.8821 101.0102,149.8821 H 96.96836 L 97.27045,148.632 H 102.656 Z M 101.9998,154.4655 Q 101.8331,154.7572 101.5519,155.1947 Q 101.2706,155.6218 101.0415,155.7781 Q 100.7184,155.476 100.2809,155.3406 Q 99.85387,155.2051 98.97884,155.2051 H 96.82252 L 97.05169,154.1009 H 101.656 Z M 103.7498,158.5907 Q 103.6977,159.1844 103.6144,159.8511 Q 103.5414,160.5074 103.4581,161.0282 Q 103.3852,161.5491 103.3227,161.7574 H 93.47866 V 160.997 Q 94.90579,160.7053 94.90579,160.3616 V 150.0383 Q 94.90579,149.9133 94.56203,149.7258 Q 94.22869,149.5383 93.47866,149.3925 V 148.632 H 99.02051 V 149.3925 Q 98.32256,149.4654 97.91631,149.5695 Q 97.51005,149.6633 97.51005,149.8091 V 159.8407 Q 97.51005,160.0386 97.65588,160.1949 Q 97.81214,160.3407 98.26006,160.4241 Q 98.71842,160.5074 99.63511,160.5074 H 100.6664 Q 101.6248,160.5074 102.0831,160.0282 Q 102.5414,159.5386 102.9894,158.3198 Z"
+       id="path8044"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 112.3855,158.8094 Q 112.3855,159.9136 111.9167,160.5699 Q 111.4584,161.2262 110.7709,161.5491 Q 110.0834,161.872 109.3958,161.9658 Q 108.7083,162.0699 108.25,162.0699 Q 107.5833,162.0699 106.729,161.8824 Q 105.8749,161.7054 105.177,161.3095 Q 105.1145,161.2678 105.0728,160.9449 Q 105.0415,160.6116 105.0415,160.1324 Q 105.052,159.6428 105.0936,159.1428 Q 105.1457,158.6428 105.2499,158.2573 L 106.0936,158.3719 Q 106.3124,159.4865 107.0104,160.1428 Q 107.7187,160.7887 108.6146,160.7887 Q 110.0938,160.7887 110.0938,159.622 Q 110.0938,158.8198 109.3646,158.3094 Q 108.6458,157.7886 107.5833,157.2365 Q 107.0104,156.9344 106.4478,156.5594 Q 105.8957,156.1843 105.5207,155.6947 Q 105.1561,155.2051 105.1561,154.5385 Q 105.1561,153.6738 105.6874,153.0592 Q 106.229,152.4342 107.0833,152.1009 Q 107.9375,151.7571 108.875,151.7571 Q 109.7709,151.7571 110.6459,151.9759 Q 111.5313,152.1946 112.0105,152.5592 Q 112.073,152.6113 112.0313,152.903 Q 112.0001,153.1947 111.8959,153.5801 Q 111.8022,153.9551 111.6667,154.3093 Q 111.5313,154.653 111.4063,154.8197 L 110.6876,154.7364 Q 110.1563,152.8509 108.7604,152.8509 Q 108.1354,152.8509 107.7916,153.1426 Q 107.4479,153.4343 107.4479,153.8614 Q 107.4479,154.4864 108.0208,154.903 Q 108.6041,155.3093 109.8334,155.9343 Q 110.4376,156.2468 111.0209,156.6219 Q 111.6147,156.9864 112.0001,157.5073 Q 112.3855,158.0282 112.3855,158.8094 Z"
+       id="path8046"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 122.4796,159.7782 Q 121.5734,160.7991 120.8441,161.2887 Q 120.1149,161.7783 119.4691,161.9241 Q 118.8337,162.0699 118.1773,162.0699 Q 117.0419,162.0699 116.0523,161.4866 Q 115.0731,160.8928 114.4585,159.7886 Q 113.8543,158.674 113.8543,157.1323 Q 113.8543,155.6322 114.5731,154.4134 Q 115.2918,153.1947 116.5628,152.4759 Q 117.8336,151.7571 119.4795,151.7571 Q 119.9379,151.7571 120.5316,151.8613 Q 121.1254,151.9655 121.6463,152.153 Q 122.1671,152.33 122.3963,152.5801 Q 122.4171,152.7051 122.3338,153.0905 Q 122.2505,153.4655 122.1046,153.9239 Q 121.9588,154.3822 121.813,154.778 Q 121.6671,155.1635 121.5734,155.2989 L 120.8754,155.1947 Q 120.5316,154.1739 120.0316,153.6218 Q 119.5316,153.0592 118.6983,153.0592 Q 118.0836,153.0592 117.5523,153.4343 Q 117.0211,153.8093 116.6878,154.6426 Q 116.3544,155.4656 116.3544,156.8094 Q 116.3544,158.4657 117.1461,159.3928 Q 117.9482,160.3199 119.0837,160.3199 Q 119.4795,160.3199 119.8441,160.247 Q 120.2087,160.1741 120.6879,159.924 Q 121.1774,159.6636 121.9171,159.1115 Z"
+       id="path8048"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 152.271,161.7574 V 160.8928 Q 153.9064,160.6949 154.4898,160.4345 Q 155.0836,160.1741 155.0836,159.9553 V 152.278 Q 155.0836,151.8613 155.0523,151.6321 Q 155.0211,151.3925 154.8961,151.2571 Q 154.7711,151.1217 154.1982,151.1217 Q 153.6251,151.1113 152.2502,151.4029 L 151.9481,150.5592 Q 152.396,150.4654 153.1043,150.2466 Q 153.8231,150.0175 154.6044,149.7466 Q 155.3857,149.4758 156.0627,149.2154 Q 156.7398,148.9549 157.1253,148.7883 L 157.5837,149.2258 V 159.9553 Q 157.5837,160.1532 158.0941,160.4241 Q 158.6149,160.6949 160.1879,160.8928 V 161.7574 Z"
+       id="path8051"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 191.7159,154.2051 Q 191.6534,154.4239 191.4763,154.8093 Q 191.3096,155.1947 191.2367,155.3718 H 184.1636 L 183.8303,155.0385 Q 183.8824,154.8197 184.049,154.4551 Q 184.2157,154.0801 184.3094,153.8718 H 191.3721 Z M 188.5491,158.1219 Q 188.3408,158.2261 187.9658,158.3511 Q 187.6012,158.4761 187.372,158.5282 L 187.0387,158.2157 V 151.0904 Q 187.2262,151.0279 187.6012,150.9029 Q 187.9866,150.7675 188.2158,150.7154 L 188.5491,151.0279 Z M 191.7159,159.4136 Q 191.6534,159.6428 191.4763,160.0282 Q 191.3096,160.4136 191.2367,160.5803 H 184.1636 L 183.8303,160.2574 Q 183.8824,160.0386 184.049,159.6636 Q 184.2157,159.2886 184.3094,159.0907 H 191.3721 Z"
+       id="path8054"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 231.1717,161.7574 H 222.8485 L 222.5464,160.9866 Q 224.3797,158.8407 225.5465,157.3927 Q 226.7236,155.9448 227.3798,154.9864 Q 228.0362,154.0176 228.2966,153.3613 Q 228.5674,152.6946 228.5674,152.1321 Q 228.5674,151.2467 228.182,150.6529 Q 227.8069,150.0591 226.9423,150.0591 Q 226.2548,150.0591 225.8798,150.5071 Q 225.5152,150.955 225.4527,151.5592 Q 225.4111,151.8717 225.4631,152.1842 Q 225.234,152.3092 224.8172,152.4551 Q 224.4005,152.6009 223.9526,152.7155 Q 223.5047,152.8196 223.1922,152.8509 L 222.8276,152.1425 Q 222.8276,151.6113 223.213,151.0383 Q 223.5985,150.4654 224.2651,149.9862 Q 224.9318,149.4966 225.7965,149.1945 Q 226.6715,148.8924 227.6506,148.8924 Q 229.2549,148.8924 230.2237,149.5591 Q 231.1925,150.2258 231.1925,151.5279 Q 231.1925,152.2259 230.8903,152.9551 Q 230.5882,153.6738 229.9007,154.601 Q 229.2132,155.5177 228.0778,156.8198 Q 226.9423,158.1115 225.2756,159.9449 H 229.432 Q 229.7757,159.9449 229.9945,159.6115 Q 230.2237,159.2782 230.3487,158.799 Q 230.4737,158.3094 230.4945,157.8615 L 231.3279,158.0594 Z"
+       id="path8057"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 261.6356,155.2989 H 255.75 L 255.5416,154.8405 Q 256.8229,153.5488 257.6459,152.6842 Q 258.4688,151.8092 258.9271,151.2363 Q 259.3855,150.6529 259.5626,150.2571 Q 259.7501,149.8612 259.7501,149.5279 Q 259.7501,148.9966 259.4896,148.6528 Q 259.2396,148.3091 258.6355,148.3091 Q 258.0521,148.3091 257.7917,148.7049 Q 257.5417,149.0904 257.6355,149.5591 Q 257.3854,149.6737 256.8541,149.7987 Q 256.3229,149.9237 255.9791,149.955 L 255.7396,149.5279 Q 255.7396,149.1008 256.1979,148.6528 Q 256.6666,148.1945 257.4375,147.8924 Q 258.2188,147.5799 259.1355,147.5799 Q 260.2813,147.5799 260.9585,147.9862 Q 261.6356,148.382 261.6356,149.1633 Q 261.6356,149.7258 261.2502,150.3196 Q 260.8752,150.9133 259.9792,151.8092 Q 259.0834,152.7051 257.5313,154.1843 H 260.3855 Q 260.7189,154.1843 260.8752,153.8822 Q 261.0314,153.5801 261.0731,153.278 Q 261.1252,152.9655 261.1252,152.9655 L 261.7397,153.0801 Z"
+       id="path8060"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 302.1755,157.7886 Q 302.1755,158.9553 301.5817,159.9345 Q 300.9879,160.9032 299.915,161.4866 Q 298.8524,162.0699 297.4253,162.0699 Q 296.6024,162.0699 295.4878,161.6637 Q 294.3732,161.2574 293.4357,160.3616 L 293.8628,159.3511 Q 294.8107,160.0491 295.5815,160.3407 Q 296.3524,160.6324 297.1337,160.6324 Q 298.1128,160.6324 298.8003,160.0074 Q 299.4984,159.3824 299.4984,158.049 Q 299.4984,157.0906 299.1129,156.5385 Q 298.7378,155.976 298.2066,155.7364 Q 297.6858,155.4968 297.2274,155.4968 Q 296.9566,155.4968 296.8004,155.5177 Q 296.6441,155.5281 296.3629,155.5697 L 296.1754,154.6322 Q 297.3733,154.3197 297.9462,153.8614 Q 298.5295,153.3926 298.717,152.8926 Q 298.9046,152.3926 298.9046,151.9655 Q 298.9046,151.2467 298.5816,150.6633 Q 298.2691,150.0696 297.4774,150.0696 Q 297.0087,150.0696 296.6649,150.4342 Q 296.3316,150.7883 296.3316,151.33 Q 296.3316,151.5488 296.3941,151.778 Q 295.967,152.0175 295.3107,152.2363 Q 294.6648,152.4446 294.0919,152.4967 L 293.7378,151.8613 Q 293.7378,151.2779 294.2898,150.5904 Q 294.8419,149.8925 295.8107,149.3925 Q 296.7899,148.8924 298.0712,148.8924 Q 299.3421,148.8924 300.1129,149.3195 Q 300.8838,149.7466 301.2275,150.4133 Q 301.5817,151.0696 301.5817,151.778 Q 301.5817,152.5592 300.9671,153.3613 Q 300.3525,154.153 299.3629,154.4864 Q 300.6338,154.6218 301.4046,155.5697 Q 302.1755,156.5177 302.1755,157.7886 Z"
+       id="path8063"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 332.5921,152.9134 Q 332.5921,153.6113 332.165,154.2051 Q 331.7484,154.7885 330.9983,155.1426 Q 330.2483,155.4864 329.2587,155.4864 Q 328.6754,155.4864 327.8732,155.2364 Q 327.0815,154.976 326.4253,154.4343 L 326.7169,153.8197 Q 327.3836,154.2468 327.9357,154.4239 Q 328.4879,154.601 329.0295,154.601 Q 329.717,154.601 330.1858,154.2364 Q 330.6649,153.8718 330.6649,153.0697 Q 330.6649,152.4967 330.4045,152.1634 Q 330.1441,151.83 329.7795,151.6946 Q 329.4149,151.5592 329.1024,151.5592 Q 328.9045,151.5592 328.8108,151.5696 Q 328.717,151.5696 328.4983,151.6009 L 328.3732,151.0071 Q 329.1962,150.8196 329.592,150.5487 Q 329.9983,150.2675 330.1233,149.9758 Q 330.2483,149.6737 330.2483,149.4237 Q 330.2483,148.9966 330.0295,148.6528 Q 329.8212,148.3091 329.2691,148.3091 Q 328.9045,148.3091 328.6545,148.6008 Q 328.4044,148.882 328.5504,149.3091 Q 328.2482,149.455 327.769,149.5904 Q 327.2898,149.7154 326.8836,149.7466 L 326.6336,149.3612 Q 326.6336,149.007 327.019,148.6008 Q 327.4148,148.1841 328.1023,147.882 Q 328.7899,147.5799 329.6858,147.5799 Q 331.0295,147.5799 331.6025,148.132 Q 332.1754,148.6737 332.1754,149.3091 Q 332.1754,149.7779 331.7379,150.2675 Q 331.3108,150.7467 330.6233,150.9342 Q 331.5192,151.0175 332.0504,151.5904 Q 332.5921,152.153 332.5921,152.9134 Z"
+       id="path8066"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 373.3715,157.1219 Q 373.1528,157.4552 372.8507,157.7781 Q 372.5485,158.0907 372.3089,158.2677 H 371.736 V 160.3616 Q 371.736,160.5178 372.0277,160.6637 Q 372.3298,160.7991 373.184,160.997 V 161.7574 H 367.1526 V 160.997 Q 368.5172,160.7678 368.9234,160.6011 Q 369.3401,160.4241 369.3401,160.247 V 158.2677 H 364.4025 L 363.9754,157.8406 L 368.9859,149.6008 Q 369.4755,149.4341 370.1423,149.205 Q 370.8194,148.9654 371.2777,148.7883 L 371.736,149.2258 V 156.8094 H 373.1007 Z M 369.3401,151.5488 L 366.0171,156.8094 H 369.3401 Z"
+       id="path8069"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 398.8369,150.9238 Q 398.6494,150.8925 398.3473,150.7362 Q 398.0452,150.5696 397.9307,150.4758 L 400.1391,146.0069 Q 400.2537,146.0174 400.587,146.0694 Q 400.9203,146.1215 401.3162,146.184 Q 401.7224,146.2465 402.0557,146.309 Q 402.3892,146.3715 402.5038,146.4028 L 402.8267,146.9653 Z"
+       id="path8072"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 443.9174,157.4865 Q 443.9174,158.6948 443.4173,159.747 Q 442.9277,160.7887 441.8861,161.4345 Q 440.8548,162.0699 439.2506,162.0699 Q 438.2818,162.0699 437.1671,161.6533 Q 436.063,161.2366 435.1671,160.4032 L 435.688,159.4657 Q 436.7817,160.2366 437.6046,160.4761 Q 438.4276,160.7157 439.0214,160.7157 Q 440.0631,160.7157 440.7298,159.924 Q 441.3965,159.1219 441.3965,157.9344 Q 441.3965,156.5073 440.6985,155.7572 Q 440.0006,155.0072 438.8651,155.0072 Q 438.0318,155.0072 437.4171,155.2572 Q 436.813,155.5072 436.2713,155.9239 L 435.7817,155.5802 Q 435.8755,155.0176 436.0005,154.1634 Q 436.1359,153.3093 436.2609,152.3821 Q 436.3963,151.4446 436.5005,150.6008 Q 436.6046,149.7571 436.6359,149.205 H 442.1152 Q 442.709,149.205 443.0423,149.1112 Q 443.3757,149.0174 443.3757,149.0174 L 443.7508,149.3925 Q 443.6048,149.6216 443.3236,149.9862 Q 443.0527,150.3404 442.7715,150.6633 Q 442.5007,150.9863 442.334,151.1008 H 437.8339 Q 437.8131,151.5071 437.74,152.0488 Q 437.6775,152.5905 437.5942,153.0905 Q 437.5109,153.5905 437.4484,153.903 Q 437.9068,153.7051 438.4797,153.5905 Q 439.0631,153.4759 439.7193,153.4759 Q 441.1152,153.4759 442.0423,154.0593 Q 442.9798,154.6322 443.4486,155.5489 Q 443.9174,156.4656 443.9174,157.4865 Z"
+       id="path8075"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 477.0455,160.747 Q 476.6393,161.0491 476.0767,161.3616 Q 475.5246,161.6637 474.9933,161.872 Q 474.4621,162.0804 474.1079,162.0804 Q 473.4621,162.0804 473.1599,161.2991 Q 472.8578,160.5178 472.8578,159.5074 Q 472.8578,159.4136 472.8578,158.8615 Q 472.8578,158.3094 472.8578,157.5281 Q 472.8578,156.7469 472.8578,155.9656 Q 472.8578,155.1843 472.8578,154.6322 Q 472.8578,154.0697 472.8578,153.9655 Q 472.8578,153.6322 472.7224,153.1113 Q 472.5974,152.5801 472.462,152.3821 Q 473.0349,152.278 473.7954,152.1113 Q 474.5662,151.9446 475.1496,151.7571 L 475.5246,152.2363 Q 475.4829,152.5071 475.4204,152.8613 Q 475.3683,153.2051 475.3579,153.8509 Q 475.3579,153.9239 475.3579,154.3926 Q 475.3579,154.8614 475.3579,155.5281 Q 475.3579,156.1843 475.3579,156.8614 Q 475.3579,157.5281 475.3579,158.0282 Q 475.3579,158.5282 475.3579,158.6532 Q 475.3579,159.622 475.4517,159.9449 Q 475.5454,160.2574 475.7642,160.2574 Q 476.1705,160.2574 476.7851,159.9657 Z M 473.4933,159.2365 Q 472.4724,160.7574 471.6911,161.4241 Q 470.9203,162.0804 470.1494,162.0804 Q 469.6702,162.0804 469.0765,161.6741 Q 468.4931,161.2574 467.9515,160.5386 Q 467.4098,159.8199 467.0555,158.9136 Q 466.7118,157.9969 466.7118,156.9969 Q 466.7118,156.9135 466.7118,156.5489 Q 466.7118,156.1843 466.7118,155.7364 Q 466.7118,155.2781 466.7118,154.9343 Q 466.7118,154.5801 466.7118,154.528 Q 466.7118,153.9968 466.6597,153.7363 Q 466.618,153.4655 466.3576,153.3509 Q 466.0972,153.2363 465.441,153.1738 V 152.4446 Q 466.368,152.3613 467.1597,152.205 Q 467.9515,152.0384 468.7327,151.7571 Q 468.7431,151.7571 468.9306,151.9655 Q 469.1181,152.1738 469.2119,152.278 Q 469.2119,152.3092 469.2119,152.8613 Q 469.2119,153.4134 469.2119,154.2155 Q 469.2119,155.0072 469.2119,155.8197 Q 469.2119,156.6219 469.2119,157.1844 Q 469.2119,157.7469 469.2119,157.7886 Q 469.2119,158.4032 469.4723,158.9136 Q 469.7327,159.4136 470.1077,159.7053 Q 470.4828,159.997 470.8057,159.997 Q 471.1078,159.997 471.4411,159.8615 Q 471.7849,159.7261 472.2328,159.2782 Q 472.6911,158.8303 473.3371,157.924 Z M 468.0244,156.976 Q 467.9515,157.924 468.0036,158.7886 Q 468.0556,159.6428 468.0452,160.8616 Q 468.0348,162.7679 468.5973,164.0075 Q 469.1702,165.2575 469.7952,165.9138 Q 469.639,165.9659 469.264,166.1117 Q 468.8994,166.2576 468.4619,166.4243 Q 468.0348,166.6013 467.6702,166.7472 Q 467.3161,166.9034 467.191,166.9659 L 466.7118,166.5805 Q 466.7118,166.518 466.7118,165.9138 Q 466.7118,165.32 466.7118,164.3617 Q 466.7118,163.4137 466.7118,162.2679 Q 466.7118,161.1324 466.7118,159.9865 Q 466.7118,158.8407 466.7118,157.8511 Q 466.7118,156.851 466.7118,156.1843 Q 466.7118,155.5072 466.7118,155.351 Q 466.7118,155.351 466.8889,155.5281 Q 467.0764,155.6947 467.3265,155.9552 Q 467.5869,156.2156 467.7848,156.4968 Q 467.9931,156.7677 468.0244,156.976 Z"
+       id="path8078"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 514.9739,157.4656 Q 514.9739,158.1948 514.6926,158.9969 Q 514.4217,159.799 513.8696,160.497 Q 513.3175,161.1949 512.4946,161.6324 Q 511.6821,162.0699 510.5987,162.0699 Q 509.2758,162.0699 508.1923,161.4137 Q 507.1194,160.7574 506.484,159.5803 Q 505.8486,158.3927 505.8486,156.8302 Q 505.8486,154.8614 506.7236,153.1634 Q 507.609,151.455 509.3591,150.2883 Q 511.1091,149.1112 513.6925,148.7466 L 513.9738,149.6737 Q 511.9321,150.1112 510.7341,151.1008 Q 509.5466,152.0905 509.0362,153.4134 Q 508.5361,154.7364 508.5361,156.1635 Q 508.5361,158.6323 509.1924,159.6845 Q 509.8591,160.7366 510.8487,160.7366 Q 511.4528,160.7366 511.7863,160.3511 Q 512.13,159.9657 512.2654,159.3719 Q 512.4009,158.7678 512.4009,158.1323 Q 512.4009,156.8302 512.1196,156.1635 Q 511.8384,155.4968 511.4112,155.2676 Q 510.9841,155.0385 510.5362,155.0385 Q 509.932,155.0385 509.1716,155.5906 Q 508.4215,156.1427 507.8069,157.101 L 507.5986,155.7885 Q 508.4111,154.6843 509.4216,154.1322 Q 510.432,153.5801 511.2028,153.5801 Q 512.9738,153.5801 513.9738,154.6739 Q 514.9739,155.7572 514.9739,157.4656 Z"
+       id="path8081"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 547.349,148.632 Q 547.349,148.632 547.1303,148.8716 Q 546.9114,149.1112 546.6093,149.4237 Q 546.3177,149.7258 546.0781,149.9446 Q 545.8385,150.1633 545.7968,150.1216 Q 545.1302,149.8612 544.3072,149.7362 Q 543.4842,149.6008 542.7551,149.5591 Q 542.0259,149.507 541.6509,149.507 Q 540.9841,149.507 540.3591,149.8091 Q 539.7445,150.1008 539.3487,150.6529 Q 538.9529,151.205 538.9529,151.9863 Q 538.9529,152.7363 539.255,153.4759 Q 539.557,154.2051 540.2029,154.6843 Q 540.8487,155.1635 541.8696,155.1635 Q 542.5363,155.1635 542.828,155.1218 Q 543.1301,155.0801 543.1301,155.0801 L 543.2134,155.9656 Q 543.2134,155.9656 542.8384,156.1635 Q 542.4738,156.351 541.4217,156.351 Q 539.932,156.351 538.755,155.8927 Q 537.5778,155.4343 536.8903,154.5489 Q 536.2132,153.653 536.2132,152.3509 Q 536.2132,151.1633 536.859,150.2571 Q 537.5049,149.3508 538.682,148.8404 Q 539.8591,148.3195 541.4634,148.3195 Q 541.828,148.3195 542.5259,148.3508 Q 543.2342,148.382 544.0571,148.4341 Q 544.8802,148.4758 545.6302,148.5278 Q 546.3802,148.5695 546.8593,148.6008 Q 547.349,148.632 547.349,148.632 Z M 540.8695,164.3617 V 163.6013 Q 542.3176,163.2992 542.3176,162.9554 L 542.3384,149.3508 Q 542.3384,149.2675 542.1613,149.33 Q 541.9946,149.382 541.6509,149.4341 Q 541.3176,149.4862 540.8175,149.3925 V 148.632 H 548.0157 V 149.3925 Q 546.5781,149.6945 546.5781,150.0383 V 162.9554 Q 546.5781,163.0908 546.9218,163.2679 Q 547.2657,163.4554 548.0157,163.6013 V 164.3617 Z M 544.8802,149.5279 L 544.0467,149.33 V 162.9554 Q 544.0467,163.07 544.1927,163.1533 Q 544.3489,163.2471 544.4531,163.2783 Q 544.5781,163.2471 544.7239,163.1533 Q 544.8802,163.07 544.8802,162.9554 Z"
+       id="path8084"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 585.7713,149.6008 Q 585.0524,151.2779 584.3649,152.9863 Q 583.6774,154.6947 583.0732,156.2677 Q 582.4794,157.8302 582.0211,159.1115 Q 581.5627,160.3928 581.2919,161.2157 Q 580.9169,161.4762 580.1982,161.7054 Q 579.4897,161.9345 578.9793,162.0699 L 578.4689,161.6429 Q 579.3335,160.1324 580.0107,158.8511 Q 580.6877,157.5594 581.2711,156.351 Q 581.8648,155.1426 582.4273,153.8718 Q 583.0003,152.6009 583.6462,151.1008 H 578.9897 Q 578.771,151.1008 578.5314,151.1946 Q 578.3022,151.2779 578.0418,151.6321 Q 577.7814,151.9759 577.4897,152.7676 L 576.7814,152.5071 Q 576.8126,152.2675 576.8647,151.8196 Q 576.9272,151.3613 577.0001,150.8508 Q 577.0835,150.33 577.1564,149.8821 Q 577.2397,149.4341 577.3022,149.205 H 585.4274 Z"
+       id="path8087"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 615.0531,154.3392 Q 615.0531,155.3549 614.376,155.9148 Q 613.6989,156.4747 612.7484,156.4747 Q 612.0061,156.4747 611.4592,156.0841 Q 610.9123,155.6804 610.9123,154.782 Q 610.9123,153.7923 611.6024,153.2194 Q 612.3057,152.6334 613.2301,152.6334 Q 613.9203,152.6334 614.4802,153.0371 Q 615.0531,153.4408 615.0531,154.3392 Z"
+       style="font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003"
+       id="path8090" />
+    <path
+       d="M 656.7204,158.0907 Q 656.7204,159.1636 656.0849,160.0699 Q 655.4495,160.9762 654.3558,161.5283 Q 653.2723,162.0699 651.9182,162.0699 Q 650.5014,162.0699 649.5327,161.6116 Q 648.5639,161.1428 648.0639,160.3928 Q 647.5743,159.6428 647.5743,158.7886 Q 647.5743,157.6219 648.491,156.6219 Q 649.4181,155.6218 650.8348,154.976 L 651.9598,155.3614 Q 651.1161,156.0906 650.689,156.8094 Q 650.2618,157.5177 650.2618,158.4761 Q 650.2618,159.5595 650.8765,160.1741 Q 651.4911,160.7887 652.2723,160.7887 Q 653.1265,160.7887 653.5849,160.122 Q 654.0433,159.4449 654.0433,158.5386 Q 654.0433,157.6219 653.6058,157.0594 Q 653.1786,156.4864 652.5015,156.1218 Q 651.8348,155.7572 651.0744,155.4552 Q 650.3139,155.1426 649.6368,154.7676 Q 648.9597,154.3822 648.5327,153.7884 Q 648.1056,153.1947 648.1056,152.2259 Q 648.1056,151.2571 648.6681,150.5071 Q 649.2306,149.7571 650.1785,149.33 Q 651.1265,148.8924 652.2932,148.8924 Q 654.262,148.8924 655.2308,149.6737 Q 656.1995,150.455 656.1995,151.6634 Q 656.1995,152.6113 655.3558,153.3718 Q 654.5224,154.1322 653.3452,154.8197 L 652.2202,154.3718 Q 653.637,153.2259 653.6266,151.9863 Q 653.6162,150.9029 653.1057,150.5071 Q 652.5952,150.1008 651.9182,150.1008 Q 651.2202,150.1008 650.8452,150.6321 Q 650.4806,151.1529 650.4806,151.8613 Q 650.4806,152.5071 650.9286,152.9238 Q 651.3765,153.3405 652.0848,153.653 Q 652.8036,153.9655 653.5953,154.2989 Q 654.3974,154.6218 655.1058,155.0906 Q 655.8141,155.5489 656.262,156.2677 Q 656.7204,156.9864 656.7204,158.0907 Z"
+       id="path8093"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 686.44,164.7393 Q 686.44,165.3774 685.8279,165.9633 Q 685.2159,166.5493 684.1612,166.966 Q 683.1066,167.3957 681.7393,167.5389 L 681.2575,166.6014 Q 682.3903,166.4451 682.8721,166.0545 Q 683.367,165.6768 683.367,165.2471 Q 683.367,164.8174 683.0545,164.6221 Q 682.7549,164.4268 682.182,164.3747 Q 682.182,164.3747 682.2861,164.1534 Q 682.4033,163.945 682.6637,163.2288 Q 682.9372,162.5257 683.393,161.0803 L 684.9946,161.1064 L 684.3175,162.9163 Q 685.3201,163.0986 685.88,163.5544 Q 686.44,164.0101 686.44,164.7393 Z"
+       style="font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003"
+       id="path8096" />
+    <path
+       d="M 727.5691,154.1426 Q 727.5691,156.2468 726.694,157.9656 Q 725.819,159.674 724.0689,160.7887 Q 722.3293,161.8929 719.7042,162.2054 L 719.4438,161.2783 Q 721.6835,160.7262 722.8501,159.8303 Q 724.0272,158.9344 724.4544,157.7365 Q 724.8919,156.5385 724.8919,155.0906 Q 724.8919,153.0488 724.5898,152.0071 Q 724.2876,150.955 723.8293,150.5904 Q 723.371,150.2154 722.8814,150.2154 Q 722.0064,150.2154 721.5168,150.9133 Q 721.0376,151.6009 721.0376,152.8405 Q 721.0376,154.0072 721.3501,154.653 Q 721.6731,155.2989 722.1002,155.5593 Q 722.5376,155.8197 722.8918,155.8197 Q 723.5272,155.8197 724.0689,155.476 Q 724.6107,155.1218 725.0169,154.5697 Q 725.4336,154.0176 725.7044,153.4343 L 725.8398,154.8405 Q 725.2982,155.9135 724.3293,156.6323 Q 723.3606,157.351 722.2147,157.351 Q 720.9855,157.351 720.1417,156.8198 Q 719.3084,156.2781 718.8813,155.3927 Q 718.4541,154.5072 718.4541,153.4759 Q 718.4541,152.6842 718.798,151.8821 Q 719.1417,151.0696 719.7667,150.3925 Q 720.3917,149.7154 721.2459,149.3091 Q 722.1106,148.8924 723.1522,148.8924 Q 724.4336,148.8924 725.4232,149.4341 Q 726.4232,149.9758 726.9961,151.1425 Q 727.5691,152.2988 727.5691,154.1426 Z"
+       id="path8099"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 752.0603,155.2989 V 154.7468 Q 753.1957,154.6322 753.5916,154.476 Q 753.9979,154.3197 753.9979,154.1843 V 149.632 Q 753.9979,149.1425 753.8624,149.0174 Q 753.7791,148.9445 753.3832,148.9445 Q 752.9978,148.9341 752.0395,149.1112 L 751.8311,148.5799 Q 752.1436,148.5278 752.6436,148.3924 Q 753.1436,148.257 753.6957,148.1007 Q 754.2583,147.9341 754.7375,147.7778 Q 755.2166,147.6216 755.4771,147.5174 L 755.8,147.7778 V 154.1843 Q 755.8,154.3093 756.1437,154.476 Q 756.4979,154.6322 757.6022,154.7468 V 155.2989 Z"
+       id="path8102"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 798.6416,155.4864 Q 798.6416,157.2781 798.0165,158.7782 Q 797.4019,160.2678 796.2978,161.1741 Q 795.1935,162.0699 793.756,162.0699 Q 792.3184,162.0699 791.2767,161.1741 Q 790.2351,160.2678 789.6726,158.7782 Q 789.1204,157.2781 789.1204,155.4864 Q 789.1204,153.6947 789.7143,152.1946 Q 790.308,150.6946 791.4017,149.7987 Q 792.4956,148.8924 794.006,148.8924 Q 795.4853,148.8924 796.5165,149.7883 Q 797.5582,150.6737 798.0999,152.1738 Q 798.6416,153.6738 798.6416,155.4864 Z M 795.9228,155.8718 Q 795.9228,153.0176 795.3081,151.6321 Q 794.6935,150.2466 793.756,150.2466 Q 792.8081,150.2466 792.3288,151.3404 Q 791.8497,152.4238 791.8497,155.0385 Q 791.8497,157.8927 792.4018,159.3094 Q 792.9643,160.7157 794.006,160.7157 Q 794.9748,160.7157 795.4436,159.6115 Q 795.9228,158.5073 795.9228,155.8718 Z"
+       id="path8105"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 828.2107,150.8196 Q 828.2107,151.7675 827.7419,152.5176 Q 827.2731,153.2676 826.5648,153.7051 Q 825.8565,154.1322 825.1481,154.1322 Q 824.1897,154.1322 823.5751,153.4863 Q 822.9605,152.8301 822.9605,151.9342 Q 822.9605,150.9758 823.4189,150.2258 Q 823.8772,149.4758 824.5855,149.0487 Q 825.294,148.6112 826.0231,148.6112 Q 826.6169,148.6112 827.1169,148.9237 Q 827.6169,149.2258 827.9086,149.7258 Q 828.2107,150.2258 828.2107,150.8196 Z M 826.6273,151.3925 Q 826.6273,150.8717 826.3669,150.4862 Q 826.1169,150.0904 825.6898,150.0904 Q 825.2419,150.0904 824.8877,150.4342 Q 824.5439,150.7779 824.5439,151.3613 Q 824.5439,151.8613 824.7939,152.2675 Q 825.044,152.6634 825.4815,152.6634 Q 825.9085,152.6634 826.2627,152.33 Q 826.6273,151.9967 826.6273,151.3925 Z"
+       id="path8108"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 867.9898,155.9864 Q 867.9273,156.2156 867.7502,156.6114 Q 867.5835,156.9969 867.5106,157.174 H 861.8437 L 861.5104,156.8406 Q 861.5625,156.6219 861.7291,156.2468 Q 861.8958,155.8614 861.9896,155.6635 H 867.646 Z"
+       id="path8111"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 939.9098,153.9239 Q 939.8473,154.1426 939.6806,154.528 Q 939.514,154.9135 939.441,155.0906 H 931.6596 L 931.3263,154.7572 Q 931.3784,154.5385 931.545,154.1739 Q 931.7117,153.7988 931.8054,153.5905 H 939.5765 Z M 939.9098,157.0489 Q 939.8473,157.2781 939.6806,157.6636 Q 939.514,158.0386 939.441,158.2157 H 931.6596 L 931.3263,157.8823 Q 931.3784,157.6531 931.545,157.2885 Q 931.7117,156.9239 931.8054,156.7156 H 939.5765 Z"
+       id="path8114"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 963.8847,161.7262 Q 963.645,161.8408 963.218,161.9137 Q 962.8013,161.997 962.52,162.0699 L 962.2596,161.7574 L 971.5307,149.2258 Q 971.7287,149.1425 972.1766,149.0383 Q 972.6246,148.9341 972.8433,148.8924 L 973.1038,149.1841 Z M 961.5825,155.1218 V 154.6843 Q 962.5096,154.5905 962.8325,154.4655 Q 963.1555,154.3405 963.1555,154.2364 V 150.5904 Q 963.1555,150.205 963.0513,150.1008 Q 962.9888,150.0383 962.6659,150.0383 Q 962.3534,150.0383 961.5721,150.1737 L 961.4055,149.7466 Q 961.7388,149.6841 962.3325,149.5279 Q 962.9263,149.3612 963.4992,149.1841 Q 964.0826,148.9966 964.3639,148.8924 L 964.6243,149.1112 V 154.2364 Q 964.6243,154.3301 964.9056,154.4655 Q 965.1868,154.5905 966.0826,154.6843 V 155.1218 Z M 973.1454,161.7574 H 968.3848 L 968.2077,161.3824 Q 969.5931,160.0074 970.3328,159.2157 Q 971.0724,158.4136 971.3432,157.9552 Q 971.6245,157.4969 971.6245,157.1323 Q 971.6245,156.7156 971.4162,156.4552 Q 971.2078,156.1843 970.7287,156.1843 Q 970.2495,156.1843 970.0412,156.4864 Q 969.8432,156.7885 969.9162,157.1635 Q 969.7182,157.2573 969.2806,157.3615 Q 968.8431,157.4656 968.5723,157.4761 L 968.3744,157.1427 Q 968.3744,156.7989 968.7494,156.4448 Q 969.1244,156.0802 969.7495,155.8302 Q 970.3745,155.5802 971.1245,155.5802 Q 972.0516,155.5802 972.5932,155.9031 Q 973.1454,156.226 973.1454,156.851 Q 973.1454,157.299 972.8433,157.7781 Q 972.5412,158.2469 971.812,158.9657 Q 971.0828,159.6845 969.8224,160.8616 H 972.1349 Q 972.4057,160.8616 972.5307,160.622 Q 972.6663,160.372 972.7079,160.1324 Q 972.7496,159.8824 972.7496,159.8824 L 973.2392,159.9865 Z"
+       id="path8117"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 1114.737,152.8301 Q 1114.112,152.9759 1113.904,153.1009 Q 1113.706,153.2259 1113.591,153.5384 L 1110.111,162.5283 Q 1109.215,164.8305 1108.028,165.8513 Q 1106.851,166.8826 1105.517,166.8826 Q 1104.986,166.8826 1104.496,166.7576 Q 1104.017,166.643 1103.705,166.4763 Q 1103.392,166.3097 1103.392,166.1742 Q 1103.392,166.0909 1103.569,165.8305 Q 1103.736,165.5701 1103.996,165.2471 Q 1104.246,164.9346 1104.496,164.6638 Q 1104.757,164.4034 1104.923,164.2992 Q 1105.444,164.6429 1105.965,164.7054 Q 1106.496,164.7784 1106.882,164.6429 Q 1107.267,164.5179 1107.705,164.0596 Q 1108.142,163.6117 1108.517,162.7158 L 1108.819,161.997 L 1105.33,153.5384 Q 1105.121,153.0488 1104.173,152.8301 V 152.0696 H 1108.892 V 152.8301 Q 1108.142,152.9238 1107.976,153.0697 Q 1107.809,153.2051 1107.955,153.5384 L 1110.101,158.7678 L 1112.142,153.5384 Q 1112.257,153.2259 1112.121,153.0801 Q 1111.986,152.9342 1111.33,152.8301 V 152.0696 H 1114.737 Z M 1108.934,148.5487 Q 1108.934,149.3091 1108.444,149.8508 Q 1107.965,150.3925 1107.298,150.3925 Q 1106.069,150.3925 1106.069,149.1216 Q 1106.069,148.3612 1106.559,147.8299 Q 1107.048,147.2882 1107.694,147.2882 Q 1108.267,147.2882 1108.601,147.6111 Q 1108.934,147.9237 1108.934,148.5487 Z M 1113.331,148.5487 Q 1113.331,149.3091 1112.851,149.8508 Q 1112.371,150.3925 1111.705,150.3925 Q 1110.465,150.3925 1110.465,149.1216 Q 1110.465,148.3612 1110.955,147.8299 Q 1111.455,147.2882 1112.09,147.2882 Q 1112.673,147.2882 1112.997,147.6111 Q 1113.331,147.9237 1113.331,148.5487 Z"
+       id="path8120"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00003" />
+    <path
+       d="M 100.4066,128.334 Q 100.1253,129.0215 99.62528,129.8027 Q 99.12528,130.5735 98.47948,131.1256 Q 97.83368,131.6673 97.09408,131.6673 Q 96.65658,131.6673 96.1774,131.4173 Q 95.69823,131.1673 95.20865,130.834 Q 94.71907,130.5006 94.2399,130.2506 Q 93.76074,130.0006 93.31282,130.0006 Q 92.85449,130.0006 92.35449,130.4173 Q 91.85449,130.8235 91.41699,131.6881 L 90.70866,131.3235 Q 91.01074,130.6465 91.50032,129.8756 Q 92.00032,129.0944 92.63574,128.5527 Q 93.28157,128.0006 94.02115,128.0006 Q 94.56282,128.0006 95.06282,128.2506 Q 95.56282,128.5006 96.03157,128.834 Q 96.50032,129.1673 96.92738,129.4173 Q 97.36488,129.6673 97.79198,129.6673 Q 98.21908,129.6673 98.73988,129.261 Q 99.27118,128.8548 99.69818,128.0006 Z"
+       id="path8123"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 125.8291,131.1985 Q 125.8291,132.2298 125.4541,133.2298 Q 125.0791,134.2194 124.4645,135.0319 Q 123.8499,135.8339 123.1312,136.3131 Q 122.4124,136.7923 121.7249,136.7923 Q 121.1833,136.7923 120.5166,136.5423 Q 119.8603,136.3027 118.9541,135.6777 V 140.0735 Q 118.9541,140.2402 119.3499,140.4068 Q 119.7458,140.5735 120.7145,140.7193 V 141.4798 H 115.0791 V 140.7193 Q 116.4541,140.386 116.4541,140.0735 V 123.2506 Q 116.4541,122.6465 116.3499,122.386 Q 116.2562,122.1256 115.9541,122.0423 Q 115.6624,121.959 115.0791,121.8965 V 121.1673 Q 116.2666,121.011 116.9853,120.8235 Q 117.7145,120.6361 118.5062,120.334 L 118.9541,120.7715 V 128.1881 Q 120.1208,127.1673 120.9541,126.8235 Q 121.7978,126.4798 122.3916,126.4798 Q 123.3395,126.4798 124.1208,127.0215 Q 124.902,127.5631 125.3603,128.6152 Q 125.8291,129.6569 125.8291,131.1985 Z M 123.4853,132.011 Q 123.4958,130.7298 123.152,129.8965 Q 122.8187,129.0631 122.277,128.6569 Q 121.7458,128.2506 121.152,128.2506 Q 120.777,128.2506 120.3187,128.459 Q 119.8708,128.6673 118.9541,129.4173 V 134.1048 Q 120.027,134.7298 120.6312,134.9069 Q 121.2353,135.0839 121.777,135.0735 Q 122.5999,135.0631 123.0478,134.2194 Q 123.4958,133.3652 123.4853,132.011 Z"
+       id="path8126"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 156.7429,132.1881 Q 156.545,132.3339 156.2325,132.4381 Q 155.92,132.5423 155.6595,132.5944 L 155.3575,132.3756 L 154.5554,122.2298 Q 154.8575,122.0527 155.3366,121.8235 Q 155.8262,121.584 156.295,121.3756 Q 156.7637,121.1569 157.045,121.0631 L 157.5658,121.3965 Z M 157.7741,135.1152 Q 157.7741,135.9589 157.2116,136.4277 Q 156.6491,136.8964 155.8679,136.8964 Q 155.2533,136.8964 154.8054,136.5631 Q 154.3575,136.2298 154.3575,135.4902 Q 154.3575,134.6777 154.9304,134.1985 Q 155.5033,133.7089 156.2741,133.7089 Q 156.847,133.7089 157.3054,134.0527 Q 157.7741,134.386 157.7741,135.1152 Z"
+       id="path8129"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 189.4728,127.8756 Q 189.4728,128.6985 188.8999,129.1881 Q 188.327,129.6673 187.5665,129.6673 Q 186.9832,129.6673 186.5249,129.334 Q 186.0665,128.9902 186.0665,128.2506 Q 186.0665,127.4173 186.6186,126.9485 Q 187.1811,126.4798 187.9728,126.4798 Q 188.577,126.4798 189.0249,126.8131 Q 189.4728,127.1465 189.4728,127.8756 Z M 189.2645,141.1568 Q 188.9624,141.3339 188.4728,141.5631 Q 187.9936,141.8027 187.5249,142.011 Q 187.0561,142.2298 186.7853,142.3235 L 186.254,141.9902 L 187.077,131.1881 Q 187.2749,131.0423 187.5874,130.9485 Q 187.8999,130.8548 188.1603,130.7819 L 188.4624,130.9902 Z"
+       id="path8132"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 256.1253,132.0006 L 255.1253,135.011 Q 255.0316,135.3339 255.3858,135.4798 Q 255.7399,135.6256 256.5941,135.7194 V 136.4798 H 252.042 V 135.7194 Q 252.7503,135.5944 253.1253,135.4589 Q 253.5108,135.3235 253.6149,135.011 L 257.2503,123.9069 Q 257.7399,123.4798 258.3753,123.1985 Q 259.0212,122.9173 259.5628,122.761 L 263.9378,135.011 Q 264.042,135.3027 264.292,135.4694 Q 264.5524,135.636 265.2295,135.7194 V 136.4798 H 260.0524 V 135.7194 Q 260.8545,135.6673 261.1462,135.511 Q 261.4378,135.3548 261.3232,135.011 L 260.2607,132.0006 Z M 259.8232,130.7506 L 258.1045,125.9069 L 256.542,130.7506 Z M 260.6045,121.6256 Q 260.5107,121.8131 260.292,122.0423 Q 260.0732,122.261 259.9066,122.3652 L 254.6878,119.7194 L 254.7712,119.0631 Q 254.8858,118.9798 255.3128,118.7506 Q 255.7503,118.5215 256.1878,118.3027 Q 256.6358,118.0736 256.792,118.0006 Z"
+       id="path8138"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 302.8509,126.5735 Q 302.8092,126.8027 302.6321,127.2298 Q 302.455,127.6465 302.3717,127.8235 H 294.1113 L 293.8509,127.5735 Q 293.903,127.3444 294.08,126.9381 Q 294.2571,126.5215 294.33,126.3131 H 302.5904 Z M 298.5904,134.7089 Q 298.4029,134.8444 297.9967,134.9589 Q 297.5904,135.0631 297.3196,135.1569 L 297.0488,134.9485 L 300.33,123.4485 Q 300.5488,123.2819 300.9342,123.1985 Q 301.33,123.1152 301.58,123.0215 L 301.8613,123.2506 Z M 295.2988,134.7089 Q 295.1113,134.8444 294.7154,134.9589 Q 294.3196,135.0631 294.0488,135.1569 L 293.778,134.9485 L 297.0592,123.4485 Q 297.2779,123.2819 297.6634,123.1985 Q 298.0592,123.1152 298.2884,123.0215 L 298.5904,123.2506 Z M 301.7154,130.459 Q 301.6738,130.6569 301.5071,131.084 Q 301.3509,131.511 301.2675,131.6881 H 292.9759 L 292.7467,131.4277 Q 292.7988,131.2194 292.955,130.8027 Q 293.1217,130.386 293.2155,130.1777 H 301.4863 Z"
+       id="path8141"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 334.0398,124.3444 Q 334.0294,124.6048 333.9878,125.0735 Q 333.9565,125.5423 333.894,126.0631 Q 333.8315,126.584 333.7586,127.0215 Q 333.6961,127.4485 333.6336,127.6465 H 332.8315 Q 332.6857,126.3652 332.1232,125.6256 Q 331.5607,124.8756 330.6232,124.8756 Q 330.2898,124.8756 329.894,125.0215 Q 329.5086,125.1569 329.1857,125.6673 Q 328.8732,126.1777 328.7482,127.2715 Q 328.6232,128.3652 328.8315,130.2819 Q 328.9878,131.7819 328.7065,132.9485 Q 328.4253,134.1048 327.7586,135.0319 Q 328.4669,134.9798 328.9044,134.9798 Q 329.3419,134.9694 329.6648,134.9902 Q 329.9982,135.011 330.3628,135.0319 Q 330.7378,135.0527 331.3107,135.0319 Q 331.9565,135.0214 332.3628,134.8652 Q 332.7794,134.6985 333.0711,134.2714 Q 333.3732,133.8339 333.6648,133.0214 L 334.4253,133.2819 Q 334.3732,133.886 334.269,134.5527 Q 334.1753,135.2089 334.0711,135.7402 Q 333.9773,136.2714 333.9253,136.4798 Q 333.3628,136.7923 332.4878,136.7923 Q 331.6128,136.7923 330.5815,136.6569 Q 329.5503,136.5319 328.5086,136.4173 Q 327.4669,136.2923 326.5607,136.3444 Q 325.6544,136.3964 325.0399,136.7923 L 324.644,136.0423 Q 325.144,135.636 325.4669,135.261 Q 325.7899,134.886 325.9461,134.3339 Q 326.1128,133.7714 326.1232,132.8652 Q 326.144,131.9485 326.0294,130.459 Q 325.8732,128.459 326.4149,126.9173 Q 326.9669,125.3652 328.1128,124.4902 Q 329.269,123.6152 330.9253,123.6152 Q 331.4669,123.6152 332.269,123.7402 Q 333.0711,123.8548 334.0398,124.3444 Z M 331.6336,131.0527 H 324.8732 L 324.5711,130.709 Q 324.6128,130.5527 324.7482,130.261 Q 324.894,129.959 324.9565,129.7923 H 331.7169 L 332.0503,130.1048 Z"
+       id="path8144"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 369.3018,137.8131 Q 369.1143,137.9798 368.8851,138.1048 Q 368.6664,138.2298 368.4059,138.2923 L 368.0518,137.9798 V 122.511 Q 368.333,122.334 368.4893,122.2402 Q 368.6455,122.136 368.9476,122.0631 L 369.3018,122.3652 Z M 368.2289,136.5839 Q 367.333,136.5839 366.2497,136.2506 Q 365.1664,135.9173 364.2184,135.3235 Q 364.1455,135.2714 364.1143,134.9069 Q 364.0934,134.5319 364.1039,134.0214 Q 364.1247,133.5006 364.1664,133.011 Q 364.2184,132.5214 364.3018,132.2298 L 365.0622,132.2714 Q 365.6351,133.511 366.5309,134.3027 Q 367.4268,135.0839 368.8018,135.0839 Q 369.3539,135.0839 369.8643,134.886 Q 370.3851,134.6881 370.708,134.2714 Q 371.0413,133.8444 371.0413,133.1777 Q 371.0413,132.3548 370.5414,131.8548 Q 370.0518,131.3444 369.2705,131.0215 Q 368.4893,130.6881 367.6039,130.3965 Q 366.7289,130.1048 365.9476,129.7194 Q 365.1664,129.3235 364.6664,128.6985 Q 364.1768,128.0735 364.1768,127.0631 Q 364.1768,126.584 364.4059,126.0215 Q 364.6351,125.459 365.1664,124.9694 Q 365.708,124.4694 366.6143,124.1569 Q 367.5205,123.834 368.8851,123.834 Q 369.6664,123.834 370.458,123.9902 Q 371.2601,124.1465 371.8747,124.3965 Q 372.4997,124.6465 372.7809,124.9277 Q 372.8434,125.0006 372.7601,125.3131 Q 372.6872,125.6152 372.5309,126.011 Q 372.3851,126.3965 372.208,126.7298 Q 372.0413,127.0527 371.9059,127.1777 L 371.1872,127.0944 Q 370.7184,126.136 370.0518,125.6152 Q 369.3851,125.084 368.4059,125.084 Q 367.3955,125.084 366.833,125.5319 Q 366.2809,125.9798 366.2809,126.5735 Q 366.2809,127.2402 366.7809,127.6569 Q 367.2809,128.0631 368.0726,128.3652 Q 368.8643,128.6569 369.7497,128.9694 Q 370.6455,129.2819 371.4372,129.7194 Q 372.2288,130.1569 372.7288,130.8548 Q 373.2288,131.5527 373.2288,132.6256 Q 373.2288,133.5527 372.7288,134.4694 Q 372.2288,135.3756 371.1247,135.9798 Q 370.0205,136.5839 368.2289,136.5839 Z"
+       id="path8147"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 398.7788,128.5944 Q 398.4455,128.9277 398.2684,129.3548 Q 398.1017,129.7819 398.1017,130.2194 Q 398.1017,130.6569 398.258,131.0735 Q 398.4246,131.4798 398.758,131.8027 Q 399.1121,132.1569 399.5288,132.3235 Q 399.9455,132.4798 400.383,132.4798 Q 401.3205,132.4798 401.9767,131.8131 Q 402.6434,131.136 402.6434,130.209 Q 402.6434,129.2715 401.9663,128.5944 Q 401.2996,127.9381 400.383,127.9381 Q 399.9455,127.9381 399.5288,128.1048 Q 399.1121,128.261 398.7788,128.5944 Z M 397.8726,127.6881 Q 398.4038,127.1569 399.0496,126.8965 Q 399.7059,126.6256 400.383,126.6256 Q 401.81,126.6256 402.8725,127.6881 Q 403.3934,128.209 403.6642,128.8756 Q 403.935,129.5423 403.935,130.2402 Q 403.935,130.9173 403.6642,131.5735 Q 403.4038,132.2194 402.883,132.7402 Q 402.383,133.261 401.7267,133.5214 Q 401.0705,133.7714 400.383,133.7714 Q 399.6851,133.7714 399.0288,133.511 Q 398.3726,133.2506 397.8413,132.7194 Q 397.3309,132.2089 397.0705,131.5631 Q 396.8205,130.9173 396.8205,130.2402 Q 396.8205,129.5423 397.0809,128.886 Q 397.3413,128.2194 397.8726,127.6881 Z M 398.883,132.5735 L 396.8621,134.5839 L 396.4246,134.5527 Q 396.3205,134.3756 396.2059,134.1569 Q 396.0913,133.9277 396.008,133.7089 L 398.008,131.7089 L 398.4663,131.6777 Z M 397.9246,128.636 L 396.0184,126.7194 L 396.0392,126.261 Q 396.4559,126.0319 396.883,125.8444 L 398.7892,127.7506 L 398.8205,128.2194 Z M 403.8309,134.5735 L 401.9246,132.6569 L 401.9455,132.1985 Q 402.3205,131.9902 402.7892,131.7714 L 404.7163,133.6985 L 404.7267,134.1673 Z M 404.6955,126.7402 L 402.6955,128.7506 L 402.2371,128.7194 Q 402.0288,128.3444 401.81,127.8756 L 403.8309,125.8548 L 404.2892,125.8444 Z"
+       id="path8150"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 446.7395,133.2506 Q 446.7395,134.2194 446.2915,135.0319 Q 445.854,135.8339 445.0832,136.3235 Q 444.3228,136.8027 443.3228,136.8027 Q 442.3228,136.8027 441.5936,136.3235 Q 440.8749,135.8339 440.4791,135.0319 Q 440.0832,134.2194 440.0832,133.2506 Q 440.0832,132.2819 440.4999,131.4798 Q 440.927,130.6673 441.6874,130.1881 Q 442.4582,129.6985 443.4999,129.6985 Q 444.5207,129.6985 445.2395,130.1881 Q 445.9686,130.6673 446.354,131.4694 Q 446.7395,132.2714 446.7395,133.2506 Z M 435.6561,136.4069 Q 435.427,136.5319 434.9061,136.6256 Q 434.3853,136.7298 434.1041,136.8027 L 433.8541,136.4798 L 443.3645,123.9902 Q 443.5832,123.8756 444.104,123.7715 Q 444.6249,123.6569 444.8749,123.6048 L 445.1457,123.9173 Z M 438.9791,127.136 Q 438.9791,128.1048 438.5311,128.9173 Q 438.0936,129.7194 437.3228,130.1985 Q 436.552,130.6777 435.5624,130.6777 Q 434.5624,130.6777 433.8332,130.1985 Q 433.1041,129.7194 432.7082,128.9173 Q 432.3228,128.1048 432.3228,127.136 Q 432.3228,126.1673 432.7395,125.3652 Q 433.1561,124.5527 433.9166,124.0735 Q 434.6874,123.584 435.7291,123.584 Q 436.7603,123.584 437.4791,124.0631 Q 438.2082,124.5423 438.5936,125.3548 Q 438.9791,126.1569 438.9791,127.136 Z M 444.604,133.4589 Q 444.604,131.9381 444.2395,131.209 Q 443.8749,130.4798 443.3228,130.4798 Q 442.802,130.4798 442.5103,131.0631 Q 442.2186,131.6464 442.2186,133.011 Q 442.2186,136.0214 443.4999,136.0214 Q 444.0415,136.0214 444.3228,135.4277 Q 444.604,134.8339 444.604,133.4589 Z M 436.8436,127.3444 Q 436.8436,125.8235 436.4686,125.0944 Q 436.1041,124.3652 435.5624,124.3652 Q 435.0416,124.3652 434.7499,124.9485 Q 434.4582,125.5319 434.4582,126.8965 Q 434.4582,129.8965 435.7291,129.8965 Q 436.2707,129.8965 436.552,129.3131 Q 436.8436,128.7194 436.8436,127.3444 Z"
+       id="path8153"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 468.4837,136.4798 V 135.7194 Q 469.4212,135.5214 469.765,135.3235 Q 470.1087,135.1152 470.1087,134.9694 V 132.4381 H 467.1087 L 466.8795,132.1881 Q 466.9316,132.0319 467.0462,131.6881 Q 467.1712,131.3444 467.2337,131.1881 H 470.1087 V 130.9694 Q 469.3795,129.3652 468.515,127.8548 Q 467.6504,126.3444 466.9212,125.386 Q 466.7441,125.1465 466.4525,125.0215 Q 466.1608,124.886 465.2962,124.886 L 465.2545,124.1256 Q 465.6608,124.0735 466.2129,124.011 Q 466.765,123.9381 467.2754,123.886 Q 467.7962,123.834 468.0775,123.834 Q 468.3691,123.834 468.6608,123.959 Q 468.9525,124.084 469.1295,124.3131 Q 469.9004,125.3444 470.5879,126.5215 Q 471.2858,127.6985 472.0045,129.1985 L 474.015,125.386 Q 474.1712,125.1152 473.9108,124.959 Q 473.6608,124.8027 472.8587,124.6985 V 123.9381 H 477.2129 V 124.6985 Q 476.5045,124.834 476.1608,124.9798 Q 475.817,125.1152 475.6712,125.386 L 472.7129,131.0006 V 131.1881 H 475.4941 L 475.7545,131.4277 L 475.3691,132.4381 H 472.7129 V 134.9694 Q 472.7129,135.1048 473.0462,135.3131 Q 473.39,135.5214 474.3691,135.7194 V 136.4798 Z"
+       id="path8156"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 514.5999,129.8652 Q 514.152,130.2923 513.4957,130.5944 L 513.1103,130.3131 L 510.1624,122.7819 L 507.5583,129.8652 Q 507.3395,130.0735 506.9853,130.2819 Q 506.6416,130.4902 506.4333,130.5944 L 506.1937,130.3131 L 509.5478,121.2506 Q 509.8083,121.011 510.2249,120.7402 Q 510.6416,120.4694 510.9332,120.334 Z"
+       id="path8159"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 547.5475,129.459 Q 547.5475,130.5423 547.1204,131.3652 Q 546.6934,132.1777 546.0163,132.7194 Q 545.3496,133.261 544.5788,133.5319 Q 543.8184,133.8027 543.1309,133.7923 Q 542.6517,133.7923 542.183,133.7194 Q 541.7246,133.636 541.3705,133.4798 L 541.058,132.3964 Q 541.485,132.5839 541.808,132.6464 Q 542.1309,132.6985 542.5059,132.6985 Q 543.0996,132.6985 543.6517,132.4069 Q 544.2038,132.1152 544.5579,131.5006 Q 544.9121,130.8756 544.9121,129.886 Q 544.9121,128.4069 543.985,127.6569 Q 543.058,126.8965 541.5684,126.8965 Q 540.985,126.8965 540.2975,126.9485 Q 539.6205,126.9902 538.9225,127.0631 L 538.808,126.011 Q 539.5996,125.8965 540.4434,125.834 Q 541.2871,125.7715 542.1621,125.7715 Q 544.5788,125.7715 546.0579,126.7298 Q 547.5475,127.6777 547.5475,129.459 Z M 536.6517,136.4798 V 135.7194 Q 538.0996,135.4277 538.0996,135.0839 V 124.761 Q 538.0996,124.636 537.7455,124.4485 Q 537.4017,124.261 536.6517,124.1152 V 123.3548 H 542.4434 V 124.1152 Q 541.3705,124.2923 541.0371,124.459 Q 540.7038,124.6152 540.7038,124.761 V 135.0839 Q 540.7038,135.2089 541.0267,135.3756 Q 541.36,135.5423 542.4434,135.7194 V 136.4798 Z"
+       id="path8162"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 588.2847,128.6881 Q 588.0243,129.011 587.6806,129.4173 Q 587.3472,129.8235 587.0972,130.0006 Q 586.7118,129.8235 586.2535,129.6673 Q 585.8056,129.511 585.4618,129.5006 Q 585.6806,129.7923 585.7431,130.1152 Q 585.8056,130.4381 585.8056,130.8235 Q 585.8056,131.7298 585.2639,132.761 Q 584.7327,133.7923 583.7848,134.7194 Q 582.8473,135.636 581.5868,136.2194 Q 580.3368,136.7923 578.8993,136.7923 Q 576.7118,136.7923 575.4723,135.7819 Q 574.2327,134.761 574.2327,132.8131 Q 574.2327,131.4069 575.4098,129.9798 Q 576.5868,128.5423 579.1285,127.1256 Q 580.2118,126.5215 580.5973,125.7506 Q 580.9931,124.9694 580.9931,124.2819 Q 580.9931,123.5527 580.6493,123.136 Q 580.316,122.7194 579.8368,122.7194 Q 579.2639,122.7194 578.9931,123.3027 Q 578.7327,123.886 578.7327,124.709 Q 578.7223,125.6569 579.1702,126.7402 Q 579.6181,127.8235 580.3473,128.9381 Q 581.0868,130.0423 581.9723,131.084 Q 582.8577,132.1256 583.7639,133.0214 Q 584.6702,133.9069 585.4306,134.5423 Q 585.9618,134.9902 586.5347,135.1048 Q 587.1181,135.2194 587.6493,135.0944 L 587.816,135.8548 Q 587.2222,136.1152 586.5556,136.3339 Q 585.8993,136.5423 585.3889,136.6673 Q 584.8889,136.7923 584.7431,136.7923 Q 584.4098,136.7923 583.6806,136.2923 Q 582.9514,135.7923 582.0035,134.9173 Q 581.0556,134.0423 580.0764,132.9069 Q 579.0973,131.761 578.2535,130.4798 Q 577.4202,129.1881 576.8993,127.8652 Q 576.3889,126.5423 576.3889,125.3027 Q 576.3889,124.1777 576.941,123.2923 Q 577.5035,122.4069 578.4306,121.8965 Q 579.3577,121.3756 580.4723,121.3756 Q 582.0452,121.3756 582.7535,122.1569 Q 583.4618,122.9277 583.4618,123.9381 Q 583.4618,124.6569 582.9931,125.4069 Q 582.5243,126.1569 581.7848,126.834 Q 581.0452,127.511 580.2327,128.0215 Q 578.9098,128.8548 578.191,129.5944 Q 577.4827,130.334 577.2118,131.0631 Q 576.941,131.7819 576.941,132.5944 Q 576.941,133.5631 577.3264,134.1569 Q 577.7118,134.7506 578.3056,135.0214 Q 578.9098,135.2923 579.5243,135.2923 Q 580.4098,135.2923 581.2014,134.9173 Q 581.9931,134.5319 582.5973,133.9277 Q 583.2118,133.3235 583.566,132.6152 Q 583.9202,131.9069 583.9202,131.2506 Q 583.9202,130.3756 583.4306,129.8756 Q 582.941,129.3652 582.3264,129.3652 L 582.0243,129.0006 Q 582.1285,128.8652 582.4306,128.5944 Q 582.7327,128.3131 582.9514,128.2298 H 587.9618 Z"
+       id="path8165"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 613.8952,128.4902 Q 613.6764,128.6569 613.2077,128.8444 Q 612.7493,129.0215 612.4889,129.0944 L 612.0306,128.7923 V 119.6673 Q 612.3327,119.5006 612.7181,119.334 Q 613.1035,119.1569 613.4264,119.084 L 613.8952,119.3861 Z M 613.8952,140.3339 Q 613.6764,140.5006 613.2077,140.6777 Q 612.7493,140.8652 612.4889,140.9485 L 612.0306,140.636 V 131.6256 Q 612.3327,131.4485 612.7181,131.2819 Q 613.1035,131.1152 613.4264,131.011 L 613.8952,131.3444 Z"
+       id="path8168"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 652.618,123.7715 L 654.8784,121.8548 Q 655.0139,121.9485 655.3055,122.1673 Q 655.6076,122.386 655.8784,122.6152 Q 656.1597,122.8444 656.2743,122.959 L 656.1805,123.5423 L 653.1493,124.6465 L 655.9409,125.6465 Q 655.9305,125.8131 655.8784,126.1777 Q 655.8368,126.5423 655.7743,126.9069 Q 655.7222,127.261 655.6701,127.4069 L 655.118,127.6152 L 652.6597,125.5631 L 653.1805,128.459 Q 653.0347,128.5319 652.691,128.6777 Q 652.3576,128.8235 652.0139,128.9485 Q 651.6805,129.0735 651.5243,129.1048 L 651.066,128.7402 L 651.618,125.5631 L 649.368,127.4798 Q 649.2326,127.386 648.9305,127.1673 Q 648.6389,126.9485 648.3576,126.7194 Q 648.0764,126.4798 647.9826,126.3756 L 648.066,125.7923 L 651.1076,124.6881 L 648.3055,123.6881 Q 648.316,123.5215 648.3576,123.1569 Q 648.4097,122.7923 648.4618,122.4381 Q 648.5243,122.0735 648.5764,121.9277 L 649.118,121.7194 L 651.5868,123.7819 L 651.066,120.8756 Q 651.2118,120.7923 651.5451,120.6569 Q 651.8889,120.5111 652.2326,120.3861 Q 652.5764,120.2506 652.7222,120.2194 L 653.1805,120.5944 Z"
+       id="path8171"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 682.6012,127.0657 Q 681.7027,127.0657 680.9345,126.2063 Q 680.1793,125.3469 680.1793,123.7324 Q 680.1793,122.886 680.5829,122.0397 Q 680.9866,121.1803 681.7418,120.6074 Q 682.497,120.0344 683.5647,120.0344 Q 683.9944,120.0344 684.346,120.1907 Q 684.7105,120.3469 685.1402,120.8157 Q 685.1402,121.7402 684.7236,122.0006 Q 684.5673,121.5449 684.2027,121.2714 Q 683.8512,120.998 683.4475,120.998 Q 682.8876,120.998 682.4058,121.4928 Q 681.9371,121.9745 681.9371,123.2897 Q 681.9371,124.4876 682.3798,125.0865 Q 682.8225,125.6855 683.3173,125.6855 Q 683.6168,125.6855 683.9423,125.5162 Q 684.2808,125.3339 684.8928,124.735 Q 684.984,124.774 685.0751,125.0344 Q 685.1793,125.2949 685.2053,125.3469 Q 684.372,126.3496 683.8121,126.7141 Q 683.2652,127.0657 682.6012,127.0657 Z M 685.3746,127.0657 Q 685.01,127.0657 684.8277,126.5839 Q 684.6454,126.0891 684.6454,124.8912 V 120.9329 Q 684.9579,120.8157 685.4267,120.5813 Q 685.8954,120.3469 686.3121,120.0344 L 686.6116,120.3079 Q 686.6116,120.3079 686.5074,120.8417 Q 686.4032,121.3756 686.4032,121.9615 V 124.5917 Q 686.4032,125.5032 686.5335,125.6334 Q 686.5986,125.6985 686.7548,125.6855 Q 686.9241,125.6594 687.2887,125.5032 Q 687.2887,125.4902 687.3798,125.7766 Q 687.484,126.0501 687.484,126.0501 Q 686.872,126.4537 686.234,126.7662 Q 685.596,127.0657 685.3746,127.0657 Z M 680.1923,128.8496 V 127.7037 H 686.9501 V 128.8496 Z"
+       style="font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path8174" />
+    <path
+       d="M 725.2882,139.761 Q 722.6944,138.386 721.4132,135.8444 Q 720.1319,133.3027 720.1319,129.9902 Q 720.1319,127.709 720.7569,125.7506 Q 721.3819,123.7819 722.5382,122.2715 Q 723.6944,120.7506 725.2882,119.8131 L 725.8507,120.5944 Q 724.6111,121.8444 723.7257,124.1048 Q 722.8403,126.3548 722.8403,129.6985 Q 722.8403,132.7402 723.6007,135.1464 Q 724.3715,137.5527 725.8507,138.9798 Z"
+       id="path8177"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 753.9289,123.2715 Q 753.9289,124.0319 753.4393,124.5735 Q 752.9601,125.1152 752.2935,125.1152 Q 751.0643,125.1152 751.0643,123.8444 Q 751.0643,123.084 751.5539,122.5527 Q 752.0539,122.011 752.6893,122.011 Q 753.2726,122.011 753.5955,122.334 Q 753.9289,122.6465 753.9289,123.2715 Z M 758.3247,123.2715 Q 758.3247,124.0319 757.8455,124.5735 Q 757.3664,125.1152 756.6997,125.1152 Q 755.4601,125.1152 755.4601,123.8444 Q 755.4601,123.084 755.9497,122.5527 Q 756.4497,122.011 757.0955,122.011 Q 757.6684,122.011 757.9914,122.334 Q 758.3247,122.6465 758.3247,123.2715 Z"
+       id="path8180"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 796.7167,129.584 Q 796.7167,131.8652 796.0917,133.8339 Q 795.4667,135.7923 794.3105,137.3027 Q 793.1543,138.8235 791.5605,139.7714 L 790.998,138.9902 Q 792.2376,137.7402 793.123,135.4798 Q 794.0084,133.2194 794.0084,129.8756 Q 794.0084,126.8444 793.2376,124.4381 Q 792.4772,122.0215 790.998,120.6048 L 791.5605,119.8236 Q 794.1543,121.1985 795.4355,123.7402 Q 796.7167,126.2715 796.7167,129.584 Z"
+       id="path8183"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 825.5494,136.7923 Q 824.0494,136.7923 822.789,136.2298 Q 821.5286,135.6673 820.6015,134.6673 Q 819.6744,133.6673 819.164,132.3548 Q 818.6536,131.0423 818.6536,129.5423 Q 818.6536,128.0527 819.164,126.7402 Q 819.6744,125.4277 820.6015,124.4381 Q 821.5286,123.4485 822.789,122.886 Q 824.0494,122.3235 825.5494,122.3235 Q 827.0494,122.3235 828.3098,122.886 Q 829.5703,123.4485 830.4973,124.4381 Q 831.4348,125.4277 831.9452,126.7402 Q 832.4661,128.0527 832.4661,129.5423 Q 832.4661,131.0423 831.9452,132.3548 Q 831.4348,133.6673 830.4973,134.6673 Q 829.5703,135.6673 828.3098,136.2298 Q 827.0494,136.7923 825.5494,136.7923 Z M 825.3203,134.0423 Q 824.3515,134.0423 823.4765,133.5319 Q 822.6119,133.0214 822.0703,132.0735 Q 821.5286,131.1256 821.5286,129.8235 Q 821.5286,128.5215 822.1536,127.459 Q 822.789,126.386 823.8723,125.7506 Q 824.9661,125.1152 826.3515,125.1152 Q 827.039,125.1152 827.7369,125.3548 Q 828.4348,125.584 828.7578,125.886 Q 828.7786,125.9798 828.6953,126.2923 Q 828.6223,126.5944 828.4869,126.9694 Q 828.3619,127.3444 828.2265,127.6673 Q 828.1015,127.9798 828.0078,128.0944 L 827.4453,128.011 Q 827.2369,127.3131 826.8619,126.7506 Q 826.4973,126.1881 825.7473,126.1881 Q 824.8828,126.1881 824.2369,126.9694 Q 823.6015,127.7506 823.6015,129.5006 Q 823.6015,130.4694 823.9765,131.1673 Q 824.3619,131.8548 824.9348,132.2298 Q 825.5182,132.6048 826.1328,132.6048 Q 826.6119,132.6048 827.0703,132.4381 Q 827.539,132.2714 828.4244,131.636 L 828.8932,132.1881 Q 828.1536,132.9798 827.5494,133.386 Q 826.9453,133.7819 826.4036,133.9173 Q 825.8619,134.0423 825.3203,134.0423 Z M 825.5494,135.5319 Q 827.2057,135.5319 828.4869,134.7298 Q 829.7682,133.9173 830.4973,132.5631 Q 831.2265,131.1985 831.2265,129.5423 Q 831.2265,127.9069 830.4973,126.5527 Q 829.7682,125.1985 828.4869,124.386 Q 827.2057,123.5735 825.5494,123.5735 Q 823.914,123.5735 822.6328,124.386 Q 821.3515,125.1985 820.6224,126.5527 Q 819.8932,127.9069 819.8932,129.5423 Q 819.8932,131.1985 820.6224,132.5631 Q 821.3515,133.9173 822.6328,134.7298 Q 823.914,135.5319 825.5494,135.5319 Z"
+       id="path8186"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 869.3539,138.1673 Q 869.2914,138.3964 869.1247,138.7819 Q 868.9581,139.1673 868.8747,139.3444 H 860.4268 L 860.0935,139.011 Q 860.1456,138.7923 860.3122,138.4173 Q 860.4789,138.0423 860.5727,137.8339 H 869.0206 Z"
+       id="path8189"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 902.6147,133.5319 Q 902.6147,134.4173 902.1563,135.1569 Q 901.7084,135.8964 900.7918,136.3444 Q 899.8855,136.7923 898.5105,136.7923 Q 897.9376,136.7923 897.2813,136.6569 Q 896.6355,136.5214 896.1459,136.3444 Q 895.6563,136.1569 895.5522,136.0214 Q 895.4688,135.9277 895.4376,135.4902 Q 895.4168,135.0527 895.4376,134.511 Q 895.4584,133.9694 895.5105,133.5319 Q 895.5626,133.0944 895.6355,132.9798 L 896.4688,133.1048 Q 896.698,134.3131 897.3647,134.9173 Q 898.0418,135.511 898.8334,135.511 Q 899.5105,135.511 899.9168,135.2089 Q 900.323,134.9069 900.323,134.2923 Q 900.323,133.636 899.9793,133.1881 Q 899.6355,132.7402 899.0834,132.4069 Q 898.5418,132.0735 897.9272,131.761 Q 897.323,131.4485 896.7813,131.084 Q 896.2397,130.709 895.8959,130.1881 Q 895.5522,129.6569 895.5522,128.886 Q 895.5522,128.1152 895.8959,127.6569 Q 896.2397,127.1985 896.7397,126.9069 Q 897.2397,126.6152 897.7397,126.3652 Q 898.2501,126.1048 898.5938,125.7506 Q 898.9376,125.3965 898.9376,124.7923 Q 898.9376,123.5006 898.2084,122.6881 Q 897.4793,121.8652 896.2501,121.8652 Q 895.6563,121.8652 895.1668,122.1985 Q 894.6876,122.5319 894.3959,123.4381 Q 894.1147,124.334 894.1147,126.0527 V 136.4798 H 890.2397 V 135.7194 Q 890.9376,135.5944 891.2709,135.4173 Q 891.6147,135.2298 891.6147,135.1048 V 126.6256 Q 891.6147,124.9485 892.0209,123.9173 Q 892.4272,122.8756 893.0105,122.2715 Q 893.6043,121.6569 894.1459,121.2923 Q 894.7501,120.886 895.5626,120.6152 Q 896.3751,120.334 897.2501,120.334 Q 898.573,120.334 899.5105,120.9069 Q 900.4584,121.4694 900.9584,122.334 Q 901.4584,123.1985 901.4584,124.084 Q 901.4584,125.1048 901.0938,125.6985 Q 900.7293,126.2923 900.198,126.6256 Q 899.6668,126.959 899.1251,127.1881 Q 898.5938,127.4069 898.2293,127.6881 Q 897.8751,127.959 897.8751,128.459 Q 897.8751,128.9381 898.2084,129.2819 Q 898.5522,129.6152 899.0938,129.8965 Q 899.6355,130.1777 900.2397,130.4798 Q 900.8438,130.7819 901.3855,131.1777 Q 901.9272,131.5631 902.2709,132.136 Q 902.6147,132.7089 902.6147,133.5319 Z"
+       id="path8192"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 939.5329,130.1985 Q 939.4704,130.4277 939.2933,130.8131 Q 939.1266,131.1985 939.0537,131.3652 H 931.9808 L 931.6475,131.0423 Q 931.6996,130.8235 931.8662,130.4485 Q 932.0329,130.0735 932.1266,129.8756 H 939.1891 Z M 936.3662,134.136 Q 936.1579,134.2402 935.7829,134.3652 Q 935.4183,134.4902 935.1891,134.5423 L 934.8558,134.2298 V 127.084 Q 935.0433,127.0215 935.4183,126.886 Q 935.8037,126.7506 936.0329,126.6985 L 936.3662,127.0215 Z"
+       id="path8195"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 967.0435,132.0006 Q 967.0435,132.0006 967.0435,131.8235 Q 967.0435,131.636 967.0435,131.4485 Q 967.0539,131.2506 967.0643,131.2402 L 971.1893,126.8131 L 971.783,127.2819 Q 971.783,127.2819 971.5747,127.7194 Q 971.3664,128.1569 971.0435,128.8131 Q 970.731,129.459 970.4185,130.1048 Q 970.106,130.7506 969.8976,131.1881 Q 969.6893,131.6256 969.6997,131.6152 L 971.7935,135.9902 L 971.1893,136.4589 Z M 962.7935,132.0006 Q 962.7935,132.0006 962.7935,131.8235 Q 962.7935,131.636 962.7935,131.4485 Q 962.8039,131.2506 962.8143,131.2402 L 966.9497,126.8131 L 967.5435,127.2819 Q 967.5435,127.2819 967.3247,127.7194 Q 967.1164,128.1569 966.8039,128.8131 Q 966.4914,129.459 966.1789,130.1048 Q 965.8664,130.7506 965.6581,131.1881 Q 965.4497,131.6256 965.4601,131.6152 L 967.5539,135.9902 L 966.9497,136.4589 Z"
+       id="path8198"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 889.9108,95.13644 Q 889.7546,95.23019 889.5801,95.32133 Q 889.4082,95.41248 889.2572,95.46977 Q 889.1061,95.52967 889.0202,95.52967 Q 888.929,95.52967 888.8691,95.44633 Q 888.8092,95.36561 888.8092,95.22498 Q 888.8092,95.17029 888.8301,95.02706 Q 888.8509,94.88384 888.8822,94.69634 Q 888.916,94.50884 888.9473,94.32134 Q 888.9785,94.13123 888.9993,93.98019 Q 889.0228,93.82654 889.0228,93.75623 Q 889.0228,93.60259 888.9941,93.54269 Q 888.9681,93.48019 888.8848,93.48019 Q 888.8144,93.48019 888.6504,93.57394 Q 888.4863,93.66769 888.3353,93.91248 Q 888.2572,94.03488 888.2129,94.21196 Q 888.1712,94.38644 888.1269,94.63904 Q 888.0853,94.87081 888.0723,95.00363 Q 888.0618,95.13384 888.0671,95.25883 Q 888.0306,95.27446 887.9473,95.31092 Q 887.8665,95.34738 887.7702,95.39165 Q 887.6738,95.43592 887.5905,95.47238 Q 887.5098,95.51144 887.4785,95.52967 L 887.3743,95.42811 Q 887.4264,95.17029 887.4759,94.88904 Q 887.5254,94.60519 887.5644,94.34477 Q 887.6035,94.08436 887.6269,93.88644 Q 887.6504,93.68592 887.6504,93.59477 Q 887.6504,93.47498 887.6243,93.44894 Q 887.5983,93.42029 887.5514,93.42029 Q 887.515,93.42029 887.4238,93.44634 Q 887.3353,93.47238 887.2936,93.488 L 887.2441,93.30832 Q 887.3535,93.26144 887.4941,93.20675 Q 887.6374,93.14946 887.7754,93.09998 Q 887.916,93.0479 888.0228,93.01665 Q 888.1296,92.9854 888.1686,92.9854 Q 888.2415,92.9854 888.265,93.04009 Q 888.291,93.09477 888.291,93.27967 Q 888.291,93.40467 888.2728,93.54009 Q 888.5566,93.25884 888.8327,93.12342 Q 889.1087,92.9854 889.3431,92.9854 Q 889.5072,92.9854 889.5957,93.06613 Q 889.6868,93.14686 889.6868,93.39946 Q 889.6868,93.53488 889.653,93.74321 Q 889.6191,93.94894 889.5749,94.1755 Q 889.5332,94.39946 889.4993,94.59477 Q 889.4655,94.78748 889.4655,94.89425 Q 889.4655,94.98279 889.4889,95.01665 Q 889.5124,95.0479 889.5592,95.0479 Q 889.6191,95.0479 889.6816,95.02967 Q 889.7441,95.00884 889.8431,94.96196 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.33333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path8305" />
+    <path
+       d="M 892.2415,93.96717 Q 892.2415,94.31352 892.0697,94.66769 Q 891.8978,95.01925 891.6061,95.25883 Q 891.4707,95.37081 891.2832,95.44894 Q 891.0983,95.52967 890.9421,95.52967 Q 890.6712,95.52967 890.4759,95.39946 Q 890.2806,95.26665 890.1764,95.04009 Q 890.0723,94.81092 890.0723,94.52706 Q 890.0723,94.15467 890.2207,93.82915 Q 890.3717,93.50363 890.7207,93.2354 Q 890.8561,93.13123 891.041,93.05832 Q 891.2259,92.9854 891.4004,92.9854 Q 891.8092,92.9854 892.0254,93.26144 Q 892.2415,93.53488 892.2415,93.96717 Z M 891.6348,94.17029 Q 891.6348,93.77446 891.5098,93.56092 Q 891.3874,93.34738 891.2207,93.34738 Q 891.0202,93.34738 890.9004,93.50102 Q 890.7832,93.65467 890.7311,93.88123 Q 890.6816,94.10519 890.6816,94.32654 Q 890.6816,94.55831 890.7441,94.75363 Q 890.8092,94.94634 890.9082,95.06092 Q 891.0098,95.1755 891.1191,95.1755 Q 891.2624,95.1755 891.3613,95.08175 Q 891.4603,94.9854 891.5202,94.83436 Q 891.5801,94.68071 891.6061,94.50623 Q 891.6348,94.33175 891.6348,94.17029 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.33333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path8307" />
+    <path
+       d="M 895.0905,95.13644 Q 894.9342,95.23019 894.7598,95.32133 Q 894.5879,95.41248 894.4368,95.46977 Q 894.2858,95.52967 894.1999,95.52967 Q 894.1087,95.52967 894.0488,95.44633 Q 893.9889,95.36561 893.9889,95.22498 Q 893.9889,95.17029 894.0098,95.02706 Q 894.0306,94.88384 894.0618,94.69634 Q 894.0957,94.50884 894.1269,94.32134 Q 894.1582,94.13123 894.179,93.98019 Q 894.2025,93.82654 894.2025,93.75623 Q 894.2025,93.60259 894.1738,93.54269 Q 894.1478,93.48019 894.0644,93.48019 Q 893.9941,93.48019 893.8301,93.57394 Q 893.666,93.66769 893.515,93.91248 Q 893.4368,94.03488 893.3926,94.21196 Q 893.3509,94.38644 893.3066,94.63904 Q 893.265,94.87081 893.2519,95.00363 Q 893.2415,95.13384 893.2467,95.25883 Q 893.2103,95.27446 893.1269,95.31092 Q 893.0462,95.34738 892.9499,95.39165 Q 892.8535,95.43592 892.7702,95.47238 Q 892.6894,95.51144 892.6582,95.52967 L 892.554,95.42811 Q 892.6061,95.17029 892.6556,94.88904 Q 892.7051,94.60519 892.7441,94.34477 Q 892.7832,94.08436 892.8066,93.88644 Q 892.8301,93.68592 892.8301,93.59477 Q 892.8301,93.47498 892.804,93.44894 Q 892.778,93.42029 892.7311,93.42029 Q 892.6947,93.42029 892.6035,93.44634 Q 892.515,93.47238 892.4733,93.488 L 892.4238,93.30832 Q 892.5332,93.26144 892.6738,93.20675 Q 892.817,93.14946 892.9551,93.09998 Q 893.0957,93.0479 893.2025,93.01665 Q 893.3092,92.9854 893.3483,92.9854 Q 893.4212,92.9854 893.4447,93.04009 Q 893.4707,93.09477 893.4707,93.27967 Q 893.4707,93.40467 893.4525,93.54009 Q 893.7363,93.25884 894.0124,93.12342 Q 894.2884,92.9854 894.5228,92.9854 Q 894.6868,92.9854 894.7754,93.06613 Q 894.8665,93.14686 894.8665,93.39946 Q 894.8665,93.53488 894.8327,93.74321 Q 894.7988,93.94894 894.7545,94.1755 Q 894.7129,94.39946 894.679,94.59477 Q 894.6452,94.78748 894.6452,94.89425 Q 894.6452,94.98279 894.6686,95.01665 Q 894.692,95.0479 894.7389,95.0479 Q 894.7988,95.0479 894.8613,95.02967 Q 894.9238,95.00884 895.0228,94.96196 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.33333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path8309" />
+    <path
+       d="M 900.0563,93.3394 Q 900.0035,93.4683 899.8922,93.6734 Q 899.7809,93.8785 899.7281,93.9781 H 896.6637 L 896.5113,93.7906 Q 896.5582,93.6675 896.6696,93.4683 Q 896.7809,93.2691 896.8512,93.1578 H 899.8981 Z"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path8311" />
+    <path
+       d="M 903.6907,93.83436 Q 903.6907,94.1104 903.5735,94.39425 Q 903.4589,94.67811 903.2662,94.93331 Q 903.0865,95.16769 902.8131,95.34998 Q 902.5397,95.52967 902.2116,95.52967 Q 902.123,95.52967 901.998,95.46977 Q 901.8756,95.40988 901.7558,95.30571 Q 901.636,95.20154 901.5553,95.07134 Q 901.4772,94.94113 901.4772,94.7979 Q 901.4772,94.70675 901.5032,94.50363 Q 901.5293,94.2979 901.5709,94.02706 Q 901.6126,93.75363 901.6569,93.45936 Q 901.7037,93.16248 901.7454,92.88644 Q 901.7871,92.6104 901.8131,92.39686 Q 901.8392,92.18071 901.8392,92.07394 Q 901.8392,91.95415 901.7923,91.92811 Q 901.748,91.89946 901.7011,91.89946 Q 901.6621,91.89946 901.5892,91.9255 Q 901.5162,91.94894 901.4616,91.96977 L 901.4173,91.79009 Q 901.5735,91.71457 901.7714,91.64165 Q 901.9694,91.56613 902.1334,91.51665 Q 902.3001,91.46457 902.3626,91.46457 Q 902.4511,91.46457 902.4798,91.51144 Q 902.511,91.55832 902.511,91.67811 Q 902.511,91.8005 902.4824,92.03488 Q 902.4537,92.26665 902.4069,92.56092 Q 902.3626,92.85519 902.3105,93.17029 Q 902.261,93.4854 902.2142,93.77967 Q 902.1699,94.07134 902.1412,94.2979 Q 902.1152,94.52446 902.1152,94.63904 Q 902.1152,94.73019 902.1803,94.82394 Q 902.2454,94.91769 902.3366,94.98019 Q 902.4277,95.04269 902.5032,95.04269 Q 902.6308,95.04269 902.7246,94.97759 Q 902.8209,94.90988 902.8912,94.80571 Q 902.9954,94.65206 903.0371,94.43592 Q 903.0813,94.21717 903.0813,94.04269 Q 903.0813,93.77446 903.0032,93.613 Q 902.9277,93.44894 902.8027,93.44894 Q 902.7246,93.44894 902.5214,93.63384 Q 902.3209,93.81613 902.0892,94.24581 L 902.0475,93.85259 Q 902.261,93.49321 902.4563,93.30571 Q 902.6543,93.11821 902.8157,93.05311 Q 902.9798,92.9854 903.097,92.9854 Q 903.3444,92.9854 903.5162,93.20415 Q 903.6907,93.4229 903.6907,93.83436 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.33333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path8313" />
+    <path
+       d="M 906.1595,93.20936 Q 906.1256,93.25102 906.0735,93.33957 Q 906.0214,93.42811 905.9642,93.52446 Q 905.9069,93.62082 905.8574,93.68852 Q 905.8105,93.75623 905.7845,93.75623 Q 905.7194,93.75623 905.6621,93.70675 Q 905.6048,93.65727 905.5501,93.60779 Q 905.498,93.55571 905.4485,93.55571 Q 905.3574,93.55571 905.2428,93.67029 Q 905.1282,93.78227 905.0214,93.98019 Q 904.9147,94.1755 904.8418,94.4255 Q 904.7845,94.62081 904.7506,94.83696 Q 904.7168,95.05311 904.7246,95.25883 Q 904.6699,95.28227 904.5449,95.33956 Q 904.4199,95.39425 904.3001,95.44894 Q 904.1803,95.50623 904.136,95.52967 L 904.0319,95.42811 Q 904.1074,95.05831 904.1699,94.69894 Q 904.2324,94.33696 904.2688,94.0479 Q 904.3053,93.75623 904.3053,93.59998 Q 904.3053,93.48019 904.274,93.45415 Q 904.2428,93.4255 904.1985,93.4255 Q 904.1621,93.4255 904.0761,93.45154 Q 903.9902,93.47498 903.9511,93.488 L 903.9043,93.31352 Q 904.0527,93.24582 904.2428,93.17029 Q 904.4355,93.09477 904.5996,93.04009 Q 904.7636,92.9854 904.8261,92.9854 Q 904.899,92.9854 904.9225,93.04009 Q 904.9485,93.09217 904.9485,93.24582 Q 904.9485,93.3005 904.9329,93.43071 Q 904.9173,93.55832 904.9017,93.65727 Q 905.0709,93.38384 905.2063,93.238 Q 905.3444,93.09217 905.4642,93.04009 Q 905.5839,92.9854 905.6959,92.9854 Q 905.7871,92.9854 905.9147,93.07394 Q 906.0449,93.16248 906.1595,93.20936 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.33333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path8315" />
+    <path
+       d="M 908.6673,93.18071 Q 908.6673,93.25884 908.4459,93.44634 Q 908.2272,93.63384 907.8365,93.87081 L 907.2975,94.20154 L 906.9355,94.1104 L 907.4668,93.71717 Q 907.6751,93.56352 907.7845,93.46717 Q 907.8964,93.37082 907.8964,93.32134 Q 907.8964,93.25623 907.6438,93.26665 L 907.623,93.08696 Q 907.8339,93.05571 908.0397,93.02967 Q 908.248,93.00102 908.4121,93.00102 Q 908.5657,93.00102 908.6152,93.0479 Q 908.6673,93.09477 908.6673,93.18071 Z M 907.3548,91.7328 Q 907.3548,91.89946 907.3157,92.19894 Q 907.2767,92.49582 907.2168,92.863 Q 907.1595,93.23019 907.0944,93.613 Q 907.0319,93.99321 906.9798,94.33436 Q 906.9303,94.6755 906.9069,94.92029 Q 906.886,95.16508 906.9121,95.25363 Q 906.8756,95.27186 906.7897,95.31092 Q 906.7063,95.34998 906.6074,95.39425 Q 906.5084,95.43852 906.4251,95.47498 Q 906.3418,95.51144 906.3105,95.52967 L 906.1985,95.42811 Q 906.2115,95.32915 906.2506,95.08175 Q 906.2923,94.83436 906.347,94.50102 Q 906.4043,94.16769 906.4615,93.80311 Q 906.5214,93.43592 906.5709,93.09217 Q 906.623,92.74842 906.6543,92.48019 Q 906.6881,92.21196 906.6881,92.08175 Q 906.6881,91.95155 906.6543,91.9255 Q 906.623,91.89946 906.5631,91.89946 Q 906.524,91.89946 906.4355,91.92811 Q 906.347,91.95415 906.3001,91.96977 L 906.2532,91.79009 Q 906.3626,91.74061 906.5058,91.68592 Q 906.649,91.62863 906.7897,91.57915 Q 906.9329,91.52707 907.0423,91.49582 Q 907.1543,91.46457 907.2011,91.46457 Q 907.274,91.46457 907.3131,91.50623 Q 907.3548,91.5479 907.3548,91.7328 Z M 908.623,95.12863 Q 908.5084,95.22498 908.373,95.31613 Q 908.2376,95.40727 908.1152,95.46456 Q 907.9928,95.52446 907.9173,95.52446 Q 907.8053,95.52446 907.6985,95.40206 Q 907.5918,95.27706 907.4902,95.08696 Q 907.3886,94.89686 907.2949,94.69634 Q 907.2011,94.49321 907.11,94.33175 Q 907.0214,94.17029 906.9355,94.1104 L 907.3964,93.96977 Q 907.4876,94.02446 907.5735,94.14946 Q 907.6621,94.27446 907.7454,94.42811 Q 907.8287,94.57915 907.9069,94.72238 Q 907.985,94.863 908.0579,94.95675 Q 908.1334,95.0479 908.2037,95.0479 Q 908.2714,95.0479 908.3626,95.02967 Q 908.4537,95.00884 908.5397,94.96196 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.33333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path8317" />
+    <path
+       d="M 1259.439,149.7046 L 1261.7,147.7879 Q 1261.835,147.8816 1262.127,148.1004 Q 1262.429,148.3191 1262.7,148.5483 Q 1262.981,148.7775 1263.095,148.8921 L 1263.002,149.4755 L 1259.97,150.5797 L 1262.762,151.5797 Q 1262.752,151.7464 1262.7,152.111 Q 1262.658,152.4756 1262.595,152.8402 Q 1262.543,153.1944 1262.491,153.3402 L 1261.939,153.5486 L 1259.481,151.4964 L 1260.002,154.3924 Q 1259.856,154.4653 1259.512,154.6111 Q 1259.179,154.757 1258.835,154.882 Q 1258.501,155.007 1258.345,155.0382 L 1257.887,154.6736 L 1258.439,151.4964 L 1256.189,153.4132 Q 1256.053,153.3194 1255.751,153.1006 Q 1255.46,152.8819 1255.178,152.6527 Q 1254.897,152.4131 1254.803,152.3089 L 1254.887,151.7256 L 1257.928,150.6213 L 1255.126,149.6213 Q 1255.137,149.4546 1255.178,149.09 Q 1255.23,148.7254 1255.283,148.3712 Q 1255.345,148.0066 1255.397,147.8608 L 1255.939,147.6524 L 1258.408,149.7151 L 1257.887,146.8087 Q 1258.033,146.7253 1258.366,146.5899 Q 1258.71,146.4441 1259.054,146.319 Q 1259.397,146.1836 1259.543,146.1524 L 1260.002,146.5274 Z"
+       style="font-weight:bold;font-size:21.3344px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005"
+       id="path8569" />
+    <path
+       d="M 1319.866,156.6425 Q 1319.803,156.8717 1319.626,157.2675 Q 1319.459,157.653 1319.386,157.83 H 1313.719 L 1313.386,157.4967 Q 1313.438,157.2779 1313.605,156.9029 Q 1313.772,156.5175 1313.865,156.3195 H 1319.522 Z"
+       style="font-weight:bold;font-size:21.3344px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005"
+       id="path8572" />
+    <path
+       d="M 1148.264,189.6736 Q 1147.545,191.3507 1146.858,193.059 Q 1146.17,194.7673 1145.566,196.3402 Q 1144.972,197.9027 1144.514,199.184 Q 1144.056,200.4652 1143.785,201.2881 Q 1143.41,201.5486 1142.691,201.7777 Q 1141.983,202.0069 1141.472,202.1423 L 1140.962,201.7152 Q 1141.827,200.2048 1142.504,198.9236 Q 1143.181,197.6319 1143.764,196.4236 Q 1144.358,195.2152 1144.92,193.9444 Q 1145.493,192.6736 1146.139,191.1736 H 1141.483 Q 1141.264,191.1736 1141.024,191.2673 Q 1140.795,191.3507 1140.535,191.7048 Q 1140.274,192.0486 1139.983,192.8402 L 1139.274,192.5798 Q 1139.306,192.3402 1139.358,191.8923 Q 1139.42,191.434 1139.493,190.9236 Q 1139.577,190.4027 1139.649,189.9548 Q 1139.733,189.5069 1139.795,189.2777 H 1147.92 Z"
+       id="path8575"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1262.448,194.2152 Q 1262.448,196.3194 1261.573,198.0381 Q 1260.698,199.7465 1258.948,200.8611 Q 1257.208,201.9652 1254.583,202.2777 L 1254.323,201.3506 Q 1256.563,200.7986 1257.729,199.9027 Q 1258.906,199.0069 1259.333,197.809 Q 1259.771,196.6111 1259.771,195.1631 Q 1259.771,193.1215 1259.469,192.0798 Q 1259.167,191.0277 1258.708,190.6632 Q 1258.25,190.2882 1257.76,190.2882 Q 1256.885,190.2882 1256.396,190.9861 Q 1255.917,191.6736 1255.917,192.9132 Q 1255.917,194.0798 1256.229,194.7256 Q 1256.552,195.3715 1256.979,195.6319 Q 1257.417,195.8923 1257.771,195.8923 Q 1258.406,195.8923 1258.948,195.5486 Q 1259.49,195.1944 1259.896,194.6423 Q 1260.313,194.0902 1260.583,193.5069 L 1260.719,194.9131 Q 1260.177,195.9861 1259.208,196.7048 Q 1258.24,197.4236 1257.094,197.4236 Q 1255.865,197.4236 1255.021,196.8923 Q 1254.188,196.3506 1253.76,195.4652 Q 1253.333,194.5798 1253.333,193.5486 Q 1253.333,192.7569 1253.677,191.9548 Q 1254.021,191.1423 1254.646,190.4652 Q 1255.271,189.7882 1256.125,189.3819 Q 1256.99,188.9652 1258.031,188.9652 Q 1259.313,188.9652 1260.302,189.5069 Q 1261.302,190.0486 1261.875,191.2152 Q 1262.448,192.3715 1262.448,194.2152 Z"
+       id="path8578"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1148.67,268.1192 Q 1148.451,268.4525 1148.149,268.7754 Q 1147.847,269.0879 1147.607,269.265 H 1147.034 V 271.3588 Q 1147.034,271.515 1147.326,271.6609 Q 1147.628,271.7963 1148.482,271.9942 V 272.7546 H 1142.451 V 271.9942 Q 1143.816,271.765 1144.222,271.5984 Q 1144.639,271.4213 1144.639,271.2442 V 269.265 H 1139.701 L 1139.274,268.8379 L 1144.284,260.5984 Q 1144.774,260.4317 1145.441,260.2025 Q 1146.118,259.963 1146.576,259.7859 L 1147.034,260.2234 V 267.8067 H 1148.399 Z M 1144.639,262.5463 L 1141.316,267.8067 H 1144.639 Z"
+       id="path8581"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1262.459,268.4629 Q 1262.459,269.1921 1262.177,269.9942 Q 1261.906,270.7963 1261.354,271.4942 Q 1260.802,272.1921 1259.979,272.6296 Q 1259.167,273.0671 1258.084,273.0671 Q 1256.761,273.0671 1255.677,272.4109 Q 1254.604,271.7546 1253.969,270.5775 Q 1253.334,269.39 1253.334,267.8275 Q 1253.334,265.8588 1254.209,264.1609 Q 1255.094,262.4525 1256.844,261.2859 Q 1258.594,260.1088 1261.177,259.7442 L 1261.459,260.6713 Q 1259.417,261.1088 1258.219,262.0984 Q 1257.031,263.088 1256.521,264.4109 Q 1256.021,265.7338 1256.021,267.1609 Q 1256.021,269.6296 1256.677,270.6817 Q 1257.344,271.7338 1258.334,271.7338 Q 1258.938,271.7338 1259.271,271.3484 Q 1259.615,270.9629 1259.75,270.3692 Q 1259.886,269.765 1259.886,269.1296 Q 1259.886,267.8275 1259.604,267.1609 Q 1259.323,266.4942 1258.896,266.265 Q 1258.469,266.0359 1258.021,266.0359 Q 1257.417,266.0359 1256.656,266.588 Q 1255.906,267.14 1255.292,268.0984 L 1255.084,266.7859 Q 1255.896,265.6817 1256.906,265.1296 Q 1257.917,264.5775 1258.688,264.5775 Q 1260.459,264.5775 1261.459,265.6713 Q 1262.459,266.7546 1262.459,268.4629 Z"
+       id="path8584"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1141.411,298.8442 L 1145.64,300.5422 L 1145.276,301.4902 L 1139.275,298.8963 V 297.5108 L 1145.276,294.917 L 1145.64,295.8649 L 1141.411,297.5629 H 1157.141 V 298.8442 Z"
+       style="font-weight:bold;font-size:21.3344px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005"
+       id="path8587" />
+    <path
+       d="M 1265.205,301.4902 L 1264.841,300.5422 L 1269.07,298.8442 H 1253.34 V 297.5629 H 1269.07 L 1264.841,295.8649 L 1265.205,294.917 L 1271.206,297.5108 V 298.8963 Z"
+       style="font-weight:bold;font-size:21.3344px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005"
+       id="path8590" />
+    <path
+       d="M 1139.598,343.5716 V 342.707 Q 1141.233,342.5091 1141.816,342.2487 Q 1142.41,341.9883 1142.41,341.7695 V 334.0924 Q 1142.41,333.6758 1142.379,333.4466 Q 1142.348,333.207 1142.223,333.0716 Q 1142.098,332.9362 1141.525,332.9362 Q 1140.952,332.9258 1139.577,333.2174 L 1139.275,332.3737 Q 1139.723,332.2799 1140.431,332.0612 Q 1141.15,331.832 1141.931,331.5612 Q 1142.712,331.2904 1143.389,331.0299 Q 1144.066,330.7695 1144.452,330.6029 L 1144.91,331.0404 V 341.7695 Q 1144.91,341.9674 1145.421,342.2383 Q 1145.941,342.5091 1147.514,342.707 V 343.5716 Z"
+       id="path8593"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1262.073,339.6029 Q 1262.073,340.7695 1261.479,341.7487 Q 1260.886,342.7174 1259.813,343.3008 Q 1258.75,343.8841 1257.323,343.8841 Q 1256.5,343.8841 1255.386,343.4778 Q 1254.271,343.0716 1253.334,342.1758 L 1253.761,341.1653 Q 1254.709,341.8633 1255.479,342.1549 Q 1256.25,342.4466 1257.032,342.4466 Q 1258.011,342.4466 1258.698,341.8216 Q 1259.396,341.1966 1259.396,339.8633 Q 1259.396,338.9049 1259.011,338.3529 Q 1258.636,337.7904 1258.104,337.5508 Q 1257.584,337.3112 1257.125,337.3112 Q 1256.854,337.3112 1256.698,337.332 Q 1256.542,337.3424 1256.261,337.3841 L 1256.073,336.4466 Q 1257.271,336.1341 1257.844,335.6758 Q 1258.427,335.207 1258.615,334.707 Q 1258.802,334.207 1258.802,333.7799 Q 1258.802,333.0612 1258.479,332.4779 Q 1258.167,331.8841 1257.375,331.8841 Q 1256.907,331.8841 1256.563,332.2487 Q 1256.229,332.6029 1256.229,333.1445 Q 1256.229,333.3633 1256.292,333.5924 Q 1255.865,333.832 1255.209,334.0508 Q 1254.563,334.2591 1253.99,334.3112 L 1253.636,333.6758 Q 1253.636,333.0924 1254.188,332.4049 Q 1254.74,331.707 1255.709,331.207 Q 1256.688,330.707 1257.969,330.707 Q 1259.24,330.707 1260.011,331.1341 Q 1260.782,331.5612 1261.125,332.2279 Q 1261.479,332.8841 1261.479,333.5924 Q 1261.479,334.3737 1260.865,335.1758 Q 1260.25,335.9674 1259.261,336.3008 Q 1260.532,336.4362 1261.302,337.3841 Q 1262.073,338.332 1262.073,339.6029 Z"
+       id="path8596"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1200.267,165.2887 Q 1200.121,165.3825 1199.777,165.5075 Q 1199.444,165.6325 1199.09,165.7367 Q 1198.746,165.8513 1198.569,165.9034 L 1198.111,165.5596 L 1205.413,146.3295 Q 1205.694,146.1524 1206.236,145.9857 Q 1206.778,145.819 1207.069,145.7461 L 1207.538,146.0482 Z"
+       style="font-weight:bold;font-size:21.3344px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005"
+       id="path8599" />
+    <path
+       d="M 1207.397,198.1631 Q 1207.397,199.2361 1206.761,200.1423 Q 1206.126,201.0486 1205.032,201.6006 Q 1203.949,202.1423 1202.595,202.1423 Q 1201.178,202.1423 1200.209,201.684 Q 1199.24,201.2152 1198.74,200.4652 Q 1198.251,199.7152 1198.251,198.8611 Q 1198.251,197.6944 1199.168,196.6944 Q 1200.095,195.6944 1201.511,195.0486 L 1202.636,195.434 Q 1201.793,196.1631 1201.365,196.8819 Q 1200.938,197.5902 1200.938,198.5486 Q 1200.938,199.6319 1201.553,200.2465 Q 1202.168,200.8611 1202.949,200.8611 Q 1203.803,200.8611 1204.261,200.1944 Q 1204.72,199.5173 1204.72,198.6111 Q 1204.72,197.6944 1204.282,197.1319 Q 1203.855,196.559 1203.178,196.1944 Q 1202.511,195.8298 1201.751,195.5277 Q 1200.99,195.2152 1200.313,194.8402 Q 1199.636,194.4548 1199.209,193.8611 Q 1198.782,193.2673 1198.782,192.2986 Q 1198.782,191.3298 1199.345,190.5798 Q 1199.907,189.8298 1200.855,189.4027 Q 1201.803,188.9652 1202.97,188.9652 Q 1204.938,188.9652 1205.907,189.7465 Q 1206.876,190.5277 1206.876,191.7361 Q 1206.876,192.684 1206.032,193.4444 Q 1205.199,194.2048 1204.022,194.8923 L 1202.897,194.4444 Q 1204.313,193.2986 1204.303,192.059 Q 1204.293,190.9757 1203.782,190.5798 Q 1203.272,190.1736 1202.595,190.1736 Q 1201.897,190.1736 1201.522,190.7048 Q 1201.157,191.2257 1201.157,191.934 Q 1201.157,192.5798 1201.605,192.9965 Q 1202.053,193.4132 1202.761,193.7256 Q 1203.48,194.0381 1204.272,194.3715 Q 1205.074,194.6944 1205.782,195.1631 Q 1206.49,195.6215 1206.938,196.3402 Q 1207.397,197.059 1207.397,198.1631 Z"
+       id="path8602"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1205.163,224.9724 L 1203.455,220.7433 V 236.6806 H 1202.194 V 220.7433 L 1200.496,224.9724 L 1199.538,224.5974 L 1202.121,218.6079 H 1203.528 L 1206.111,224.5974 Z"
+       style="font-weight:bold;font-size:21.3331px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:0.999991"
+       id="path8605" />
+    <path
+       d="M 1207.199,268.4838 Q 1207.199,269.6921 1206.699,270.7442 Q 1206.21,271.7859 1205.168,272.4317 Q 1204.137,273.0671 1202.533,273.0671 Q 1201.564,273.0671 1200.449,272.6504 Q 1199.345,272.2338 1198.449,271.4004 L 1198.97,270.4629 Q 1200.064,271.2338 1200.887,271.4734 Q 1201.71,271.7129 1202.303,271.7129 Q 1203.345,271.7129 1204.012,270.9213 Q 1204.678,270.1192 1204.678,268.9317 Q 1204.678,267.5046 1203.981,266.7546 Q 1203.283,266.0046 1202.147,266.0046 Q 1201.314,266.0046 1200.699,266.2546 Q 1200.095,266.5046 1199.553,266.9213 L 1199.064,266.5775 Q 1199.158,266.015 1199.283,265.1609 Q 1199.418,264.3067 1199.543,263.3796 Q 1199.678,262.4421 1199.783,261.5984 Q 1199.887,260.7546 1199.918,260.2025 H 1205.397 Q 1205.991,260.2025 1206.324,260.1088 Q 1206.658,260.015 1206.658,260.015 L 1207.033,260.39 Q 1206.887,260.6192 1206.606,260.9838 Q 1206.335,261.338 1206.053,261.6609 Q 1205.783,261.9838 1205.616,262.0984 H 1201.116 Q 1201.095,262.5046 1201.022,263.0463 Q 1200.96,263.588 1200.876,264.088 Q 1200.793,264.588 1200.731,264.9005 Q 1201.189,264.7025 1201.762,264.588 Q 1202.345,264.4734 1203.001,264.4734 Q 1204.397,264.4734 1205.324,265.0567 Q 1206.262,265.6296 1206.731,266.5463 Q 1207.199,267.4629 1207.199,268.4838 Z"
+       id="path8608"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1207.059,343.5716 H 1198.736 L 1198.434,342.8008 Q 1200.267,340.6549 1201.434,339.207 Q 1202.611,337.7591 1203.267,336.8008 Q 1203.923,335.832 1204.184,335.1758 Q 1204.454,334.5091 1204.454,333.9466 Q 1204.454,333.0612 1204.069,332.4674 Q 1203.694,331.8737 1202.829,331.8737 Q 1202.142,331.8737 1201.767,332.3216 Q 1201.402,332.7695 1201.34,333.3737 Q 1201.298,333.6862 1201.35,333.9987 Q 1201.121,334.1237 1200.704,334.2695 Q 1200.288,334.4154 1199.84,334.5299 Q 1199.392,334.6341 1199.079,334.6654 L 1198.715,333.957 Q 1198.715,333.4258 1199.1,332.8529 Q 1199.486,332.2799 1200.152,331.8008 Q 1200.819,331.3112 1201.684,331.0091 Q 1202.559,330.707 1203.538,330.707 Q 1205.142,330.707 1206.111,331.3737 Q 1207.079,332.0404 1207.079,333.3424 Q 1207.079,334.0404 1206.777,334.7695 Q 1206.475,335.4883 1205.788,336.4154 Q 1205.1,337.332 1203.965,338.6341 Q 1202.829,339.9258 1201.163,341.7591 H 1205.319 Q 1205.663,341.7591 1205.881,341.4258 Q 1206.111,341.0924 1206.236,340.6133 Q 1206.361,340.1237 1206.381,339.6758 L 1207.215,339.8737 Z"
+       id="path8611"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1203.528,378.4015 H 1202.121 L 1199.538,372.4016 L 1200.496,372.037 L 1202.194,376.2661 V 360.3288 H 1203.455 V 376.2661 L 1205.163,372.037 L 1206.111,372.4016 Z"
+       style="font-weight:bold;font-size:21.3331px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:0.999991"
+       id="path8614" />
+    <path
+       d="M 1321.276,297.8754 Q 1321.213,298.1046 1321.036,298.4901 Q 1320.87,298.8755 1320.797,299.0422 H 1313.723 L 1313.39,298.7192 Q 1313.442,298.5005 1313.609,298.1255 Q 1313.776,297.7504 1313.869,297.5525 H 1320.932 Z M 1318.109,301.8131 Q 1317.901,301.9173 1317.526,302.0423 Q 1317.161,302.1673 1316.932,302.2194 L 1316.599,301.9069 V 294.7607 Q 1316.786,294.6982 1317.161,294.5628 Q 1317.547,294.4274 1317.776,294.3753 L 1318.109,294.6982 Z"
+       style="font-weight:bold;font-size:21.3344px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005"
+       id="path8617" />
+    <path
+       d="M 1174.063,202.4444 L 1162.938,191.309 L 1164.719,195.5069 L 1163.802,195.9131 L 1161.396,189.8611 L 1162.375,188.8819 L 1168.438,191.2777 L 1168.031,192.1944 L 1163.844,190.4132 L 1174.969,201.5381 Z"
+       id="path8620"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1286.644,195.9131 L 1285.727,195.5069 L 1287.508,191.309 L 1276.383,202.4444 L 1275.477,201.5381 L 1286.602,190.4132 L 1282.415,192.1944 L 1282.008,191.2777 L 1288.071,188.8819 L 1289.05,189.8611 Z"
+       id="path8623"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1288.071,344.1862 L 1282.008,341.7903 L 1282.415,340.8633 L 1286.602,342.6445 L 1275.477,331.5195 L 1276.383,330.6237 L 1287.508,341.7487 L 1285.727,337.5612 L 1286.644,337.1445 L 1289.05,343.1966 Z"
+       id="path8626"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1163.844,342.6445 L 1168.031,340.8633 L 1168.438,341.7903 L 1162.375,344.1862 L 1161.396,343.1966 L 1163.802,337.1445 L 1164.719,337.5612 L 1162.938,341.7487 L 1174.063,330.6237 L 1174.969,331.5195 Z"
+       id="path8629"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1148.795,411.0032 Q 1148.795,412.7948 1148.17,414.2948 Q 1147.556,415.7844 1146.452,416.6907 Q 1145.347,417.5865 1143.91,417.5865 Q 1142.472,417.5865 1141.431,416.6907 Q 1140.389,415.7844 1139.827,414.2948 Q 1139.274,412.7948 1139.274,411.0032 Q 1139.274,409.2115 1139.868,407.7115 Q 1140.462,406.2115 1141.556,405.3157 Q 1142.649,404.4094 1144.16,404.4094 Q 1145.639,404.4094 1146.67,405.3053 Q 1147.712,406.1907 1148.254,407.6907 Q 1148.795,409.1907 1148.795,411.0032 Z M 1146.077,411.3886 Q 1146.077,408.5344 1145.462,407.149 Q 1144.847,405.7636 1143.91,405.7636 Q 1142.962,405.7636 1142.483,406.8573 Q 1142.004,407.9407 1142.004,410.5552 Q 1142.004,413.4094 1142.556,414.8261 Q 1143.118,416.2323 1144.16,416.2323 Q 1145.129,416.2323 1145.597,415.1282 Q 1146.077,414.024 1146.077,411.3886 Z"
+       id="path8632"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1260.109,415.9094 Q 1260.109,416.7532 1259.547,417.2219 Q 1258.984,417.6907 1258.203,417.6907 Q 1257.588,417.6907 1257.14,417.3573 Q 1256.693,417.024 1256.693,416.2844 Q 1256.693,415.4719 1257.265,414.9927 Q 1257.849,414.5032 1258.609,414.5032 Q 1259.182,414.5032 1259.64,414.8469 Q 1260.109,415.1802 1260.109,415.9094 Z"
+       id="path8635"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1288.65,416.5448 Q 1288.65,417.2844 1288.244,418.1698 Q 1287.838,419.0552 1287.14,419.8677 Q 1286.452,420.6906 1285.619,421.2323 L 1284.91,420.7115 Q 1285.494,420.0344 1285.827,419.2948 Q 1286.16,418.5657 1286.16,417.6594 Q 1286.16,417.2011 1285.785,416.8157 Q 1285.41,416.4198 1284.733,416.4719 L 1284.567,415.6698 Q 1284.66,415.5448 1285.035,415.3677 Q 1285.421,415.1802 1285.921,415.0032 Q 1286.431,414.8157 1286.9,414.6907 Q 1287.379,414.5657 1287.65,414.5761 Q 1288.15,414.8052 1288.4,415.2636 Q 1288.65,415.7219 1288.65,416.5448 Z M 1288.431,408.3573 Q 1288.431,409.2011 1287.869,409.6698 Q 1287.306,410.1386 1286.525,410.1386 Q 1285.91,410.1386 1285.463,409.8052 Q 1285.015,409.4719 1285.015,408.7323 Q 1285.015,407.9198 1285.588,407.4407 Q 1286.171,406.9511 1286.931,406.9511 Q 1287.504,406.9511 1287.963,407.2948 Q 1288.431,407.6282 1288.431,408.3573 Z"
+       id="path8638"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1139.275,449.31 V 448.6921 Q 1140.435,448.4551 1140.435,448.1758 V 439.788 Q 1140.435,439.6865 1140.155,439.5341 Q 1139.885,439.3818 1139.275,439.2633 V 438.6454 H 1143.719 V 439.2633 Q 1142.551,439.5087 1142.551,439.788 V 448.1758 Q 1142.551,448.2774 1142.83,448.4297 Q 1143.109,448.5736 1143.719,448.6921 V 449.31 Z"
+       style="font-weight:bold;font-size:17.3342px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005"
+       id="path8641" />
+    <path
+       d="M 1150.024,449.31 V 448.6921 Q 1150.634,448.5313 1150.888,448.4128 Q 1151.142,448.2859 1151.142,448.1758 V 444.3332 Q 1151.142,443.4022 1150.947,443.0636 Q 1150.752,442.725 1150.253,442.725 Q 1149.847,442.725 1149.313,442.9705 Q 1148.789,443.2075 1147.968,443.9015 V 448.1758 Q 1147.968,448.4551 1149.093,448.6921 V 449.31 H 1144.819 V 448.6921 Q 1145.936,448.3959 1145.936,448.1758 V 443.4783 Q 1145.936,443.0382 1145.886,442.8351 Q 1145.835,442.6235 1145.598,442.5388 Q 1145.369,442.4542 1144.819,442.3865 V 441.794 Q 1145.623,441.7094 1146.241,441.5655 Q 1146.867,441.4216 1147.485,441.1846 L 1147.841,441.5401 L 1147.934,442.7589 Q 1148.916,441.921 1149.779,441.557 Q 1150.642,441.1846 1151.302,441.1846 Q 1152.03,441.1846 1152.597,441.6755 Q 1153.173,442.1664 1153.173,443.3514 V 448.1758 Q 1153.173,448.2859 1153.402,448.4044 Q 1153.63,448.5228 1154.299,448.6921 V 449.31 Z"
+       style="font-weight:bold;font-size:17.3342px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005"
+       id="path8643" />
+    <path
+       d="M 1161.104,446.9147 Q 1161.104,447.8119 1160.723,448.3451 Q 1160.35,448.8783 1159.792,449.1407 Q 1159.233,449.4031 1158.675,449.4793 Q 1158.116,449.5639 1157.744,449.5639 Q 1157.202,449.5639 1156.508,449.4116 Q 1155.814,449.2677 1155.247,448.946 Q 1155.196,448.9122 1155.162,448.6498 Q 1155.137,448.379 1155.137,447.9896 Q 1155.145,447.5918 1155.179,447.1855 Q 1155.221,446.7793 1155.306,446.4661 L 1155.992,446.5592 Q 1156.169,447.4649 1156.736,447.9981 Q 1157.312,448.5228 1158.04,448.5228 Q 1159.242,448.5228 1159.242,447.5749 Q 1159.242,446.9232 1158.649,446.5084 Q 1158.065,446.0852 1157.202,445.6366 Q 1156.736,445.3912 1156.279,445.0865 Q 1155.831,444.7818 1155.526,444.384 Q 1155.23,443.9862 1155.23,443.4445 Q 1155.23,442.742 1155.661,442.2426 Q 1156.102,441.7347 1156.796,441.4639 Q 1157.49,441.1846 1158.251,441.1846 Q 1158.979,441.1846 1159.69,441.3623 Q 1160.41,441.5401 1160.799,441.8363 Q 1160.85,441.8786 1160.816,442.1156 Q 1160.791,442.3526 1160.706,442.6658 Q 1160.63,442.9705 1160.52,443.2583 Q 1160.41,443.5376 1160.308,443.673 L 1159.724,443.6053 Q 1159.292,442.0733 1158.158,442.0733 Q 1157.65,442.0733 1157.371,442.3103 Q 1157.092,442.5473 1157.092,442.8943 Q 1157.092,443.4022 1157.557,443.7407 Q 1158.031,444.0708 1159.03,444.5786 Q 1159.521,444.8326 1159.995,445.1373 Q 1160.477,445.4335 1160.791,445.8567 Q 1161.104,446.2799 1161.104,446.9147 Z"
+       style="font-weight:bold;font-size:17.3342px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005"
+       id="path8645" />
+    <path
+       d="M 1253.45,449.31 V 448.6921 Q 1254.61,448.4551 1254.61,448.1758 V 439.5087 Q 1254.279,439.5595 1253.983,439.6018 Q 1253.687,439.6441 1253.45,439.678 L 1253.34,438.8993 Q 1253.899,438.7554 1254.703,438.6454 Q 1255.515,438.5269 1256.379,438.4592 Q 1257.25,438.3915 1257.978,438.3915 Q 1260.568,438.3915 1261.99,439.7626 Q 1263.421,441.1338 1263.421,443.5884 Q 1263.421,445.1711 1262.955,446.2714 Q 1262.49,447.3633 1261.736,448.0404 Q 1260.983,448.7091 1260.086,449.0138 Q 1259.197,449.31 1258.325,449.31 H 1257.64 Q 1256.649,449.31 1255.795,449.31 Q 1254.948,449.31 1253.78,449.31 Z M 1258.012,448.4044 Q 1258.503,448.4044 1259.045,448.1504 Q 1259.595,447.8965 1260.069,447.3548 Q 1260.551,446.8131 1260.848,445.9667 Q 1261.152,445.1119 1261.152,443.9185 Q 1261.152,441.667 1260.179,440.4821 Q 1259.214,439.2887 1257.369,439.2887 Q 1257.216,439.2887 1257.056,439.2971 Q 1256.895,439.3056 1256.726,439.3141 V 447.8796 Q 1256.726,448.2181 1257.115,448.3112 Q 1257.504,448.4044 1258.012,448.4044 Z"
+       style="font-weight:bold;font-size:17.3342px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005"
+       id="path8648" />
+    <path
+       d="M 1271.961,444.6548 Q 1271.808,444.8326 1271.427,445.0442 Q 1271.047,445.2473 1270.776,445.3489 H 1265.664 L 1265.68,444.4009 H 1269.616 Q 1269.811,444.4009 1269.87,444.3417 Q 1269.938,444.2739 1269.938,444.0962 Q 1269.938,443.7576 1269.802,443.3175 Q 1269.675,442.8689 1269.345,442.5388 Q 1269.024,442.2003 1268.448,442.2003 Q 1267.526,442.2003 1267.145,443.0128 Q 1266.772,443.8169 1266.772,445.1627 Q 1266.772,446.4492 1267.314,447.2956 Q 1267.864,448.142 1268.897,448.142 Q 1269.252,448.142 1269.591,448.0827 Q 1269.929,448.015 1270.369,447.7949 Q 1270.81,447.5749 1271.47,447.1178 Q 1271.58,447.1771 1271.724,447.3887 Q 1271.876,447.5918 1271.91,447.6595 Q 1271.123,448.4551 1270.539,448.8699 Q 1269.955,449.2761 1269.405,449.42 Q 1268.863,449.5639 1268.186,449.5639 Q 1267.221,449.5639 1266.425,449.0645 Q 1265.63,448.5652 1265.147,447.668 Q 1264.673,446.7623 1264.673,445.5689 Q 1264.673,443.2583 1266.417,441.9802 Q 1266.865,441.6501 1267.483,441.4216 Q 1268.11,441.1846 1268.753,441.1846 Q 1269.862,441.1846 1270.564,441.6755 Q 1271.275,442.1664 1271.614,442.962 Q 1271.961,443.7492 1271.961,444.6548 Z"
+       style="font-weight:bold;font-size:17.3342px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005"
+       id="path8650" />
+    <path
+       d="M 1272.959,449.31 V 448.6921 Q 1273.687,448.5652 1273.924,448.4382 Q 1274.161,448.3112 1274.161,448.1758 V 438.5946 Q 1274.161,438.0952 1274.077,437.8752 Q 1273.992,437.6551 1273.755,437.5874 Q 1273.518,437.5112 1273.044,437.4604 V 436.868 Q 1273.89,436.7495 1274.525,436.6056 Q 1275.16,436.4617 1275.829,436.1909 L 1276.193,436.5379 V 448.1758 Q 1276.193,448.3028 1276.447,448.4382 Q 1276.709,448.5736 1277.403,448.6921 V 449.31 Z"
+       style="font-weight:bold;font-size:17.3342px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005"
+       id="path8652" />
+    <path
+       d="M 1288.659,448.5808 Q 1288.659,449.3204 1288.253,450.2059 Q 1287.847,451.0913 1287.149,451.9039 Q 1286.461,452.7268 1285.628,453.2685 L 1284.92,452.7477 Q 1285.503,452.0706 1285.836,451.3309 Q 1286.17,450.6017 1286.17,449.6954 Q 1286.17,449.2371 1285.795,448.8516 Q 1285.42,448.4558 1284.742,448.5079 L 1284.576,447.7058 Q 1284.67,447.5807 1285.045,447.4037 Q 1285.43,447.2161 1285.93,447.0391 Q 1286.44,446.8515 1286.909,446.7265 Q 1287.388,446.6015 1287.659,446.6119 Q 1288.159,446.8411 1288.409,447.2995 Q 1288.659,447.7578 1288.659,448.5808 Z"
+       style="font-weight:bold;font-size:21.3344px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005"
+       id="path8655" />
+    <path
+       d="M 1317.46,440.5152 Q 1317.446,440.7587 1317.396,441.1598 Q 1317.353,441.5609 1317.288,441.9404 Q 1317.224,442.32 1317.166,442.5062 H 1316.629 Q 1316.565,441.1455 1316.042,441.1455 H 1313.263 L 1313.471,440.286 H 1317.174 Z M 1316.722,444.2967 Q 1316.608,444.4972 1316.414,444.798 Q 1316.221,445.0917 1316.064,445.1991 Q 1315.841,444.9914 1315.541,444.8983 Q 1315.247,444.8052 1314.645,444.8052 H 1313.163 L 1313.321,444.046 H 1316.486 Z M 1317.926,447.1328 Q 1317.89,447.541 1317.832,447.9994 Q 1317.782,448.4506 1317.725,448.8087 Q 1317.675,449.1668 1317.632,449.31 H 1310.864 V 448.7872 Q 1311.845,448.5866 1311.845,448.3503 V 441.2529 Q 1311.845,441.167 1311.609,441.038 Q 1311.38,440.9091 1310.864,440.8089 V 440.286 H 1314.674 V 440.8089 Q 1314.194,440.859 1313.915,440.9306 Q 1313.636,440.9951 1313.636,441.0953 V 447.9922 Q 1313.636,448.1283 1313.736,448.2357 Q 1313.843,448.336 1314.151,448.3933 Q 1314.466,448.4506 1315.097,448.4506 H 1315.806 Q 1316.465,448.4506 1316.78,448.1211 Q 1317.095,447.7845 1317.403,446.9466 Z"
+       style="font-weight:bold;font-size:14.6675px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005"
+       id="path8658" />
+    <path
+       d="M 1323.011,449.31 V 448.7872 Q 1323.526,448.6511 1323.741,448.5508 Q 1323.956,448.4434 1323.956,448.3503 V 445.0988 Q 1323.956,444.311 1323.791,444.0245 Q 1323.626,443.7381 1323.204,443.7381 Q 1322.86,443.7381 1322.409,443.9458 Q 1321.965,444.1463 1321.27,444.7336 V 448.3503 Q 1321.27,448.5866 1322.223,448.7872 V 449.31 H 1318.606 V 448.7872 Q 1319.551,448.5365 1319.551,448.3503 V 444.3755 Q 1319.551,444.0031 1319.508,443.8312 Q 1319.465,443.6521 1319.265,443.5805 Q 1319.071,443.5089 1318.606,443.4516 V 442.9503 Q 1319.286,442.8786 1319.809,442.7569 Q 1320.339,442.6351 1320.862,442.4346 L 1321.163,442.7354 L 1321.242,443.7667 Q 1322.072,443.0577 1322.803,442.7497 Q 1323.533,442.4346 1324.092,442.4346 Q 1324.708,442.4346 1325.188,442.85 Q 1325.675,443.2654 1325.675,444.268 V 448.3503 Q 1325.675,448.4434 1325.868,448.5437 Q 1326.061,448.6439 1326.627,448.7872 V 449.31 Z"
+       style="font-weight:bold;font-size:14.6675px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005"
+       id="path8660" />
+    <path
+       d="M 1332.056,448.1999 Q 1331.111,448.8874 1330.445,449.2097 Q 1329.778,449.5249 1329.406,449.5249 Q 1328.79,449.5249 1328.339,449.045 Q 1327.895,448.5652 1327.895,447.5625 V 443.5447 H 1327.028 L 1326.821,443.2869 L 1327.379,442.6495 H 1327.895 V 441.1526 L 1329.342,440.0855 L 1329.614,440.3219 V 442.6495 H 1331.798 L 1332.056,442.9073 Q 1331.92,443.1508 1331.698,443.4229 Q 1331.476,443.6879 1331.333,443.7954 Q 1331.161,443.7094 1330.817,443.6306 Q 1330.473,443.5447 1330.094,443.5447 H 1329.614 V 446.8964 Q 1329.614,447.6341 1329.778,447.9278 Q 1329.95,448.2142 1330.223,448.2142 Q 1330.473,448.2142 1330.803,448.1068 Q 1331.139,447.9994 1331.741,447.6771 Z"
+       style="font-weight:bold;font-size:14.6675px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005"
+       id="path8662" />
+    <path
+       d="M 1338.845,445.371 Q 1338.716,445.5214 1338.394,445.7004 Q 1338.072,445.8723 1337.843,445.9582 H 1333.517 L 1333.531,445.1561 H 1336.862 Q 1337.026,445.1561 1337.076,445.106 Q 1337.134,445.0487 1337.134,444.8983 Q 1337.134,444.6118 1337.019,444.2394 Q 1336.912,443.8598 1336.632,443.5805 Q 1336.36,443.294 1335.873,443.294 Q 1335.093,443.294 1334.77,443.9816 Q 1334.455,444.6619 1334.455,445.8007 Q 1334.455,446.8893 1334.914,447.6055 Q 1335.379,448.3217 1336.253,448.3217 Q 1336.554,448.3217 1336.84,448.2715 Q 1337.127,448.2142 1337.499,448.028 Q 1337.871,447.8418 1338.43,447.4551 Q 1338.523,447.5052 1338.645,447.6843 Q 1338.774,447.8561 1338.802,447.9134 Q 1338.136,448.5866 1337.642,448.9376 Q 1337.148,449.2814 1336.683,449.4031 Q 1336.224,449.5249 1335.651,449.5249 Q 1334.835,449.5249 1334.162,449.1023 Q 1333.488,448.6798 1333.08,447.9206 Q 1332.679,447.1543 1332.679,446.1445 Q 1332.679,444.1893 1334.154,443.1078 Q 1334.534,442.8285 1335.057,442.6351 Q 1335.587,442.4346 1336.131,442.4346 Q 1337.069,442.4346 1337.664,442.85 Q 1338.265,443.2654 1338.552,443.9386 Q 1338.845,444.6047 1338.845,445.371 Z"
+       style="font-weight:bold;font-size:14.6675px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005"
+       id="path8664" />
+    <path
+       d="M 1345.578,442.7497 Q 1345.642,442.7927 1345.613,443.0935 Q 1345.585,443.3943 1345.499,443.8097 Q 1345.413,444.2179 1345.305,444.5975 Q 1345.198,444.9699 1345.112,445.1633 H 1344.589 Q 1344.539,444.5832 1344.339,444.1749 Q 1344.138,443.7596 1343.794,443.7596 Q 1343.608,443.7596 1343.372,443.867 Q 1343.135,443.9672 1342.87,444.2824 Q 1342.605,444.5975 1342.319,445.2206 V 448.3503 Q 1342.319,448.4577 1342.613,448.5723 Q 1342.913,448.6869 1343.587,448.7872 V 449.31 H 1339.655 V 448.7872 Q 1340.6,448.5723 1340.6,448.3503 V 444.5545 Q 1340.6,444.0818 1340.55,443.8956 Q 1340.5,443.7094 1340.435,443.645 Q 1340.342,443.5519 1340.192,443.516 Q 1340.049,443.4731 1339.655,443.4516 V 442.9503 Q 1340.178,442.8786 1340.528,442.8142 Q 1340.887,442.7426 1341.194,442.6566 Q 1341.51,442.5635 1341.911,442.4346 L 1342.211,442.7354 L 1342.305,443.7739 Q 1342.691,443.2224 1343.257,442.8285 Q 1343.83,442.4346 1344.446,442.4346 Q 1345.033,442.4346 1345.578,442.7497 Z"
+       style="font-weight:bold;font-size:14.6675px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00005"
+       id="path8666" />
+    <path
+       d="M 161.1093,265.5573 Q 160.8229,265.5573 160.4453,265.6745 L 160.4974,270.2448 Q 160.4974,270.414 161.2656,270.5312 V 271 H 158.4661 V 270.5312 Q 159.2343,270.401 159.2343,270.2448 L 159.1823,266.7031 L 156.9427,271 H 156.4088 L 154.1953,266.7031 L 154.1562,270.2448 Q 154.1562,270.414 154.8724,270.5312 V 271 H 152.6328 V 270.5312 Q 153.3619,270.414 153.3619,270.2448 L 153.414,265.7135 Q 153.2187,265.6224 153.0234,265.5963 Q 152.8411,265.5573 152.6848,265.5573 V 265.0885 H 154.5599 Q 154.664,265.0885 154.7421,265.1666 Q 154.8203,265.2448 154.9505,265.4922 L 156.9036,269.2812 L 158.8958,265.4922 Q 159.026,265.2187 159.0911,265.1536 Q 159.1692,265.0885 159.2864,265.0885 H 161.1093 Z M 147.9583,271 V 270.5312 Q 148.4531,270.4401 148.6093,270.3489 Q 148.7786,270.2578 148.7786,270.1927 V 265.7786 H 147.4505 Q 147.2812,265.7786 147.138,266 Q 147.0078,266.2213 146.7734,266.7552 L 146.3697,266.638 Q 146.3828,266.3906 146.4479,265.8568 Q 146.526,265.3229 146.5911,265.0885 H 152.3333 L 152.5416,265.2448 Q 152.5286,265.4791 152.4635,265.9739 Q 152.3984,266.4557 152.3333,266.7291 H 151.9296 Q 151.8125,266.2995 151.7473,266.039 Q 151.6953,265.7786 151.4609,265.7786 H 150.1718 V 270.1927 Q 150.1718,270.2448 150.3281,270.3489 Q 150.4973,270.4401 150.9921,270.5312 V 271 Z"
+       style="font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px"
+       id="path8720" />
+    <path
+       d="M 1094.623,202.2911 Q 1094.623,202.5489 1094.5,202.8594 Q 1094.383,203.17 1094.008,203.5274 Q 1093.633,203.879 1092.877,204.2715 Q 1092.121,204.6641 1090.844,205.0743 L 1090.803,204.4649 Q 1091.605,204.1426 1092.074,203.8907 Q 1092.549,203.6329 1092.783,203.4219 Q 1093.017,203.211 1093.088,203.0176 Q 1093.158,202.8184 1093.158,202.5958 Q 1093.158,202.3262 1093.035,202.1915 Q 1092.918,202.0508 1092.754,202.0508 Q 1092.66,202.0508 1092.467,202.1505 Q 1092.273,202.2501 1092.127,202.4258 Q 1091.81,202.795 1091.617,203.2755 Q 1091.43,203.7559 1091.43,204.4005 Q 1091.43,205.168 1091.693,205.6251 Q 1091.963,206.0762 1092.308,206.0762 Q 1092.555,206.0762 1093.029,205.8477 Q 1093.51,205.6192 1094.219,205.0508 Q 1094.283,205.086 1094.377,205.2559 Q 1094.471,205.4258 1094.488,205.4669 Q 1093.527,206.3047 1092.9,206.6446 Q 1092.273,206.9844 1091.752,206.9844 Q 1091.43,206.9844 1091.031,206.7852 Q 1090.639,206.5919 1090.351,206.1524 Q 1090.07,205.7071 1090.07,204.9688 Q 1090.07,204.0489 1090.498,203.293 Q 1090.926,202.5313 1091.664,201.9161 Q 1091.928,201.6993 1092.396,201.4825 Q 1092.871,201.2598 1093.334,201.2598 Q 1093.996,201.2598 1094.307,201.588 Q 1094.623,201.9102 1094.623,202.2911 Z"
+       id="path8713"
+       style="font-style:italic;font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 1101.045,206.0997 Q 1100.693,206.3106 1100.301,206.5157 Q 1099.914,206.7208 1099.574,206.8497 Q 1099.234,206.9844 1099.041,206.9844 Q 1098.836,206.9844 1098.701,206.7969 Q 1098.566,206.6153 1098.566,206.2989 Q 1098.566,206.1758 1098.613,205.8536 Q 1098.66,205.5313 1098.73,205.1094 Q 1098.807,204.6876 1098.877,204.2657 Q 1098.947,203.838 1098.994,203.4981 Q 1099.047,203.1524 1099.047,202.9942 Q 1099.047,202.6485 1098.982,202.5137 Q 1098.924,202.3731 1098.736,202.3731 Q 1098.578,202.3731 1098.209,202.584 Q 1097.84,202.795 1097.5,203.3458 Q 1097.324,203.6212 1097.224,204.0196 Q 1097.131,204.4122 1097.031,204.9805 Q 1096.937,205.502 1096.908,205.8008 Q 1096.885,206.0938 1096.896,206.3751 Q 1096.814,206.4102 1096.627,206.4922 Q 1096.445,206.5743 1096.228,206.6739 Q 1096.012,206.7735 1095.824,206.8555 Q 1095.642,206.9434 1095.572,206.9844 L 1095.338,206.7559 Q 1095.455,206.1758 1095.566,205.543 Q 1095.678,204.9044 1095.766,204.3184 Q 1095.853,203.7325 1095.906,203.2872 Q 1095.959,202.836 1095.959,202.6309 Q 1095.959,202.3614 1095.9,202.3028 Q 1095.842,202.2383 1095.736,202.2383 Q 1095.654,202.2383 1095.449,202.2969 Q 1095.25,202.3555 1095.156,202.3907 L 1095.045,201.9864 Q 1095.291,201.8809 1095.607,201.7579 Q 1095.93,201.629 1096.24,201.5176 Q 1096.557,201.4005 1096.797,201.3301 Q 1097.037,201.2598 1097.125,201.2598 Q 1097.289,201.2598 1097.342,201.3829 Q 1097.4,201.5059 1097.4,201.9219 Q 1097.4,202.2032 1097.359,202.5079 Q 1097.998,201.8751 1098.619,201.5704 Q 1099.24,201.2598 1099.767,201.2598 Q 1100.137,201.2598 1100.336,201.4415 Q 1100.541,201.6231 1100.541,202.1915 Q 1100.541,202.4962 1100.465,202.9649 Q 1100.389,203.4278 1100.289,203.9376 Q 1100.195,204.4415 1100.119,204.8809 Q 1100.043,205.3145 1100.043,205.5547 Q 1100.043,205.754 1100.096,205.8301 Q 1100.148,205.9005 1100.254,205.9005 Q 1100.389,205.9005 1100.529,205.8594 Q 1100.67,205.8126 1100.892,205.7071 Z"
+       id="path8715"
+       style="font-style:italic;font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 178.9461,338.9201 Q 178.9877,338.9618 178.8419,339.2639 Q 178.6961,339.5659 178.4565,339.9722 Q 178.2273,340.368 177.9877,340.7118 Q 177.7586,341.0451 177.6231,341.1597 L 176.9981,341.0034 Q 176.7169,340.3472 176.1648,339.8264 Q 175.6231,339.2951 174.769,339.2951 Q 174.3523,339.2951 173.9669,339.4201 Q 173.5815,339.5347 173.1648,339.8576 Q 172.5086,340.368 172.0606,341.1284 Q 171.6231,341.8888 171.3627,342.7534 Q 171.1127,343.618 170.9981,344.4513 Q 170.8836,345.2847 170.8836,345.9409 Q 170.8836,347.4513 171.3627,348.3263 Q 171.8523,349.1909 172.5502,349.5555 Q 173.2481,349.9201 173.8627,349.9201 Q 174.394,349.9201 175.2169,349.6388 Q 176.0502,349.3472 177.3315,348.4097 Q 177.4148,348.493 177.5502,348.743 Q 177.6961,348.9826 177.7065,349.118 Q 176.2898,350.5243 174.9981,351.0659 Q 173.7065,351.5972 172.7377,351.5972 Q 171.5294,351.5972 170.5398,351.0034 Q 169.5502,350.4097 168.9565,349.2743 Q 168.3731,348.1388 168.3731,346.5347 Q 168.3731,345.2222 168.7377,343.8784 Q 169.1023,342.5243 169.8627,341.3055 Q 170.6231,340.0868 171.8002,339.1597 Q 172.5502,338.5659 173.5919,338.2222 Q 174.6336,337.8784 175.6127,337.8784 Q 176.6336,337.8784 177.5606,338.1909 Q 178.4981,338.493 178.9461,338.9201 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path8730" />
+    <path
+       d="M 203.8106,350.1701 Q 203.1752,350.5451 202.4877,350.9097 Q 201.8002,351.2743 201.1961,351.5034 Q 200.6023,351.743 200.2273,351.743 Q 199.9252,351.743 199.6752,351.4097 Q 199.4252,351.0868 199.4252,350.5243 Q 199.4252,350.3055 199.5086,349.7534 Q 199.6023,349.2013 199.7273,348.4722 Q 199.8627,347.743 199.9981,346.9722 Q 200.1336,346.2013 200.2169,345.5347 Q 200.3106,344.868 200.3106,344.4513 Q 200.3106,343.5659 199.9044,343.5659 Q 199.6856,343.5659 199.1336,343.8784 Q 198.5919,344.1805 197.9981,345.0659 Q 197.6336,345.6076 197.4252,346.3368 Q 197.2169,347.0555 197.0398,348.243 Q 196.9044,349.1909 196.8627,349.7743 Q 196.8315,350.3576 196.8523,350.6597 Q 196.7065,350.743 196.3731,350.8888 Q 196.0398,351.0347 195.644,351.2118 Q 195.2586,351.3784 194.9252,351.5243 Q 194.5919,351.6701 194.4565,351.743 L 194.0398,351.3368 Q 194.3523,349.9201 194.6023,348.5451 Q 194.8523,347.1597 194.9981,346.0868 Q 195.1544,345.0034 195.1544,344.493 Q 195.1544,343.5659 194.6961,343.5659 Q 194.5398,343.5659 193.9877,343.868 Q 193.4356,344.1701 192.8315,345.0451 Q 192.4565,345.5868 192.2273,346.3368 Q 192.0086,347.0868 191.8315,348.243 Q 191.6752,349.1909 191.6231,349.7743 Q 191.5711,350.3576 191.5919,350.6597 Q 191.4565,350.743 191.1231,350.8888 Q 190.7898,351.0347 190.4044,351.2118 Q 190.019,351.3784 189.6961,351.5243 Q 189.3731,351.6701 189.2377,351.743 L 188.8211,351.3368 Q 189.1023,349.868 189.3523,348.4201 Q 189.6023,346.9618 189.7586,345.7951 Q 189.9148,344.618 189.9148,344.0243 Q 189.9148,343.5451 189.8002,343.4305 Q 189.6856,343.3055 189.5086,343.3055 Q 189.3419,343.3055 189.0086,343.4097 Q 188.6752,343.5034 188.4773,343.5763 L 188.3106,342.8576 Q 188.9044,342.5972 189.6544,342.3055 Q 190.4148,342.0034 191.0606,341.7847 Q 191.7065,341.5659 191.9565,341.5659 Q 192.2794,341.5659 192.394,341.7951 Q 192.5086,342.0243 192.5086,342.7638 Q 192.5086,342.9305 192.4773,343.2222 Q 192.4565,343.5138 192.4252,343.7847 Q 193.6544,342.493 194.5711,342.0347 Q 195.4981,341.5659 196.3523,341.5659 Q 197.1336,341.5659 197.4461,342.0972 Q 197.769,342.6284 197.769,343.3159 Q 197.769,343.3888 197.7586,343.4722 Q 197.7586,343.5555 197.7481,343.6805 Q 198.9565,342.4618 199.7898,342.0138 Q 200.6336,341.5659 201.4148,341.5659 Q 202.0294,341.5659 202.4565,341.9826 Q 202.8836,342.3888 202.8836,343.3993 Q 202.8836,343.993 202.7481,344.8055 Q 202.6231,345.618 202.4565,346.4722 Q 202.2898,347.3159 202.1648,348.0451 Q 202.0398,348.7743 202.0398,349.2013 Q 202.0398,349.5555 202.144,349.6805 Q 202.2481,349.7951 202.4252,349.7951 Q 202.7273,349.7951 202.9773,349.7222 Q 203.2377,349.6493 203.6752,349.4722 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path8734" />
+    <path
+       d="M 210.9148,345.5972 Q 210.8211,345.8263 210.6231,346.1909 Q 210.4252,346.5555 210.3315,346.7326 H 204.8836 L 204.6127,346.3993 Q 204.6961,346.1805 204.894,345.8263 Q 205.0919,345.4722 205.2169,345.2743 H 210.6336 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path8736" />
+    <path
+       d="M 181.2898,362.2185 Q 181.2898,363.4373 180.8731,364.7602 Q 180.4669,366.0831 179.894,367.0206 Q 179.5815,367.5414 179.144,368.0414 Q 178.7169,368.531 178.1961,368.8539 Q 177.6856,369.1768 177.1231,369.1768 Q 176.5502,369.1768 175.8002,368.5727 Q 175.0502,367.9685 174.394,366.9893 L 174.7169,365.6039 Q 174.9252,365.9789 175.3211,366.3227 Q 175.7273,366.656 176.1856,366.8747 Q 176.644,367.0935 177.0086,367.0935 Q 177.4461,367.0935 177.7898,366.8331 Q 178.144,366.5727 178.3419,366.156 Q 178.6023,365.6039 178.7169,364.8331 Q 178.8315,364.0622 178.8315,363.281 Q 178.8315,362.1768 178.5086,361.5102 Q 178.1856,360.8331 177.8002,360.8331 Q 177.5502,360.8331 177.0711,361.156 Q 176.6023,361.4789 176.0606,362.1039 Q 175.5294,362.7289 175.0815,363.6143 L 175.0086,361.8018 Q 175.9252,360.6248 176.6336,360.0206 Q 177.3419,359.4164 177.9148,359.2081 Q 178.4981,358.9998 179.0086,358.9998 Q 179.9356,358.9998 180.6127,359.8331 Q 181.2898,360.656 181.2898,362.2185 Z M 175.6961,359.6873 Q 175.6961,360.1352 175.5398,361.1456 Q 175.394,362.156 175.0815,363.9789 Q 174.7794,365.8018 174.3106,368.6872 Q 173.9669,370.8331 173.8836,371.781 Q 173.8002,372.7289 173.9044,373.0102 Q 173.7481,373.0518 173.4044,373.1768 Q 173.0711,373.3018 172.6752,373.4581 Q 172.2794,373.6247 171.9461,373.7602 Q 171.6231,373.8956 171.4877,373.9581 L 171.0711,373.5727 Q 171.1231,373.1768 171.2898,372.2602 Q 171.4461,371.3435 171.6648,370.1247 Q 171.894,368.906 172.1336,367.5831 Q 172.3731,366.2602 172.5711,365.031 Q 172.7794,363.7914 172.9044,362.8435 Q 173.0398,361.8956 173.0398,361.4581 Q 173.0398,360.9789 172.8836,360.8748 Q 172.7273,360.7602 172.5502,360.7602 Q 172.4148,360.7602 172.0815,360.8539 Q 171.7481,360.9477 171.5815,361.0102 L 171.394,360.3123 Q 172.0086,360.0206 172.7898,359.7185 Q 173.5711,359.4164 174.2273,359.2081 Q 174.8836,358.9998 175.1336,358.9998 Q 175.394,358.9998 175.5398,359.1456 Q 175.6961,359.281 175.6961,359.6873 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path8738" />
+    <path
+       d="M 187.644,345.493 Q 187.644,346.8784 186.9565,348.2951 Q 186.269,349.7013 185.1023,350.6597 Q 184.5606,351.1076 183.8106,351.4201 Q 183.0711,351.743 182.4461,351.743 Q 181.3627,351.743 180.5815,351.2222 Q 179.8002,350.6909 179.3836,349.7847 Q 178.9669,348.868 178.9669,347.7326 Q 178.9669,346.243 179.5606,344.9409 Q 180.1648,343.6388 181.5606,342.5659 Q 182.1023,342.1493 182.8419,341.8576 Q 183.5815,341.5659 184.2794,341.5659 Q 185.9148,341.5659 186.7794,342.6701 Q 187.644,343.7638 187.644,345.493 Z M 185.2169,346.3055 Q 185.2169,344.7222 184.7169,343.868 Q 184.2273,343.0138 183.5606,343.0138 Q 182.7586,343.0138 182.2794,343.6284 Q 181.8106,344.243 181.6023,345.1493 Q 181.4044,346.0451 181.4044,346.9305 Q 181.4044,347.8576 181.6544,348.6388 Q 181.9148,349.4097 182.3106,349.868 Q 182.7169,350.3263 183.1544,350.3263 Q 183.7273,350.3263 184.1231,349.9513 Q 184.519,349.5659 184.7586,348.9618 Q 184.9981,348.3472 185.1023,347.6493 Q 185.2169,346.9513 185.2169,346.3055 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path8732" />
+    <path
+       d="M 191.0398,362.9268 Q 191.0398,364.3122 190.3523,365.7289 Q 189.6648,367.1352 188.4981,368.0935 Q 187.9565,368.5414 187.2065,368.8539 Q 186.4669,369.1768 185.8419,369.1768 Q 184.7586,369.1768 183.9773,368.656 Q 183.1961,368.1247 182.7794,367.2185 Q 182.3627,366.3018 182.3627,365.1664 Q 182.3627,363.6768 182.9565,362.3748 Q 183.5606,361.0727 184.9565,359.9998 Q 185.4981,359.5831 186.2377,359.2914 Q 186.9773,358.9998 187.6752,358.9998 Q 189.3106,358.9998 190.1752,360.1039 Q 191.0398,361.1977 191.0398,362.9268 Z M 188.6127,363.7393 Q 188.6127,362.156 188.1127,361.3018 Q 187.6231,360.4477 186.9565,360.4477 Q 186.1544,360.4477 185.6752,361.0623 Q 185.2065,361.6768 184.9981,362.5831 Q 184.8002,363.4789 184.8002,364.3643 Q 184.8002,365.2914 185.0502,366.0727 Q 185.3106,366.8435 185.7065,367.3018 Q 186.1127,367.7602 186.5502,367.7602 Q 187.1231,367.7602 187.519,367.3852 Q 187.9148,366.9997 188.1544,366.3956 Q 188.394,365.781 188.4981,365.0831 Q 188.6127,364.3852 188.6127,363.7393 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path8740" />
+    <path
+       d="M 199.644,359.9581 Q 199.4044,360.2706 199.0919,360.656 Q 198.7794,361.031 198.4981,361.3018 Q 198.2273,361.5727 198.0919,361.5727 Q 197.9252,361.5727 197.7169,361.3643 Q 197.519,361.156 197.2586,360.8852 Q 197.0086,360.6039 196.6961,360.3956 Q 196.394,360.1873 196.019,360.1873 Q 195.4461,360.1873 195.1336,360.4893 Q 194.8315,360.7914 194.8315,361.281 Q 194.8315,361.7706 195.2586,362.1352 Q 195.6856,362.4998 196.5294,362.9268 Q 197.0919,363.2185 197.6231,363.5935 Q 198.1544,363.9581 198.4877,364.4789 Q 198.8315,364.9997 198.8315,365.7393 Q 198.8315,366.4581 198.394,367.0831 Q 197.9669,367.7081 197.2794,368.1768 Q 196.6023,368.6456 195.8211,368.906 Q 195.0502,369.1768 194.3731,369.1768 Q 193.4877,369.1768 192.7794,368.8956 Q 192.0711,368.6247 191.6544,368.2497 Q 191.2377,367.8643 191.2377,367.5727 Q 191.2377,367.4268 191.3836,367.1143 Q 191.5294,366.8018 191.7377,366.4685 Q 191.9461,366.1247 192.144,365.8852 Q 192.3523,365.6456 192.4565,365.6456 Q 192.5919,365.6456 192.769,365.9789 Q 192.9461,366.3122 193.2273,366.7602 Q 193.5086,367.1977 193.9461,367.531 Q 194.394,367.8643 195.0502,367.8643 Q 195.7273,367.8643 196.1231,367.4893 Q 196.5294,367.1039 196.5294,366.4997 Q 196.5294,365.7914 195.8731,365.281 Q 195.2273,364.7602 194.4461,364.3643 Q 193.3419,363.8122 192.9461,363.2185 Q 192.5606,362.6143 192.5606,361.9477 Q 192.5606,361.2914 192.9356,360.7498 Q 193.3106,360.2081 193.9148,359.8227 Q 194.5294,359.4268 195.2273,359.2185 Q 195.9252,358.9998 196.5711,358.9998 Q 197.3106,358.9998 197.8419,359.2081 Q 198.3731,359.4164 198.7898,359.6456 Q 199.2169,359.8748 199.644,359.9581 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path8742" />
+    <path
+       d="M 208.2169,360.8331 Q 208.2169,361.2914 207.9981,361.8435 Q 207.7898,362.3956 207.1231,363.031 Q 206.4565,363.656 205.1127,364.3539 Q 203.769,365.0518 201.4981,365.781 L 201.4252,364.6977 Q 202.8523,364.1247 203.6856,363.6768 Q 204.5294,363.2185 204.9461,362.8435 Q 205.3627,362.4685 205.4877,362.1248 Q 205.6127,361.7706 205.6127,361.3748 Q 205.6127,360.8956 205.394,360.656 Q 205.1856,360.406 204.894,360.406 Q 204.7273,360.406 204.3836,360.5831 Q 204.0398,360.7602 203.7794,361.0727 Q 203.2169,361.7289 202.8731,362.5831 Q 202.5398,363.4373 202.5398,364.5831 Q 202.5398,365.9477 203.0086,366.7602 Q 203.4877,367.5622 204.1023,367.5622 Q 204.5398,367.5622 205.3836,367.156 Q 206.2377,366.7497 207.4981,365.7393 Q 207.6127,365.8018 207.7794,366.1039 Q 207.9461,366.406 207.9773,366.4789 Q 206.269,367.9685 205.1544,368.5727 Q 204.0398,369.1768 203.1127,369.1768 Q 202.5398,369.1768 201.8315,368.8227 Q 201.1336,368.4789 200.6231,367.6977 Q 200.1231,366.906 200.1231,365.5935 Q 200.1231,363.9581 200.8836,362.6143 Q 201.644,361.2602 202.9565,360.1664 Q 203.4252,359.781 204.2586,359.3956 Q 205.1023,358.9998 205.9252,358.9998 Q 207.1023,358.9998 207.6544,359.5831 Q 208.2169,360.156 208.2169,360.8331 Z"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px"
+       id="path8744" />
+    <path
+       d="M 954.0142,367.8445 V 352.6956 H 948.6614 L 958.4574,342.8996 L 968.2534,352.6956 H 962.9006 V 367.8445 Z M 955.0638,366.7949 H 961.851 V 351.646 H 965.6994 L 958.4574,344.404 L 951.2153,351.646 H 955.0638 Z"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:34.9858px;line-height:1.25;font-family:'Noto Sans Symbols2';-inkscape-font-specification:'Noto Sans Symbols2';word-spacing:0px;stroke-width:1.31197"
+       id="path8857" />
+    <path
+       d="M 97.95123,367.8445 V 352.6956 H 92.59843 L 102.3944,342.8996 L 112.1904,352.6956 H 106.8376 V 367.8445 Z M 99.00083,366.7949 H 105.788 V 351.646 H 109.6364 L 102.3944,344.404 L 95.15233,351.646 H 99.00083 Z"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:34.9858px;line-height:1.25;font-family:'Noto Sans Symbols2';-inkscape-font-specification:'Noto Sans Symbols2';word-spacing:0px;display:inline;stroke-width:1.31197"
+       id="path8857-1" />
+    <path
+       d="M 171.6805,440.549 Q 169.6005,440.549 168.1605,439.109 Q 168.0325,438.981 167.8725,438.821 Q 167.7445,438.629 167.7445,438.437 Q 167.7445,438.181 167.9045,438.181 Q 168.0965,438.181 168.1605,438.117 Q 168.3525,437.957 168.3525,437.765 Q 168.3525,437.541 168.3845,437.317 Q 168.4485,436.901 168.8005,436.389 Q 169.1845,435.877 169.6645,435.877 Q 169.6645,435.877 169.6965,435.909 Q 169.7285,435.909 169.7285,435.941 Q 169.7285,436.069 169.5045,436.293 Q 169.2805,436.517 169.0245,436.837 Q 168.8005,437.125 168.8005,437.541 Q 168.8005,438.117 169.2485,438.501 Q 169.7285,438.885 170.4005,439.109 Q 171.1045,439.333 171.7765,439.429 Q 172.4805,439.525 172.8965,439.525 Q 174.8805,439.525 176.4165,438.565 Q 177.9845,437.573 179.1685,436.037 Q 180.3525,434.469 181.2165,432.709 Q 182.0805,430.917 182.6885,429.349 Q 180.9285,429.349 179.1685,429.157 Q 177.4085,428.933 175.6165,428.933 Q 175.4885,428.933 175.2645,428.997 Q 175.0725,429.029 175.0725,429.253 Q 175.0725,429.541 175.1685,429.861 Q 175.2965,430.149 175.2965,430.469 Q 175.2965,430.885 175.2325,431.333 Q 175.1685,431.781 174.8805,432.165 Q 174.5605,432.581 174.3365,432.805 Q 174.1125,432.997 173.8245,433.541 Q 173.7285,433.765 173.5685,433.989 Q 173.4085,434.181 173.1205,434.181 H 173.0245 Q 173.2165,433.989 173.4725,433.477 Q 173.7285,432.933 173.7285,432.677 Q 173.7285,432.229 173.5045,431.493 Q 173.2805,430.757 173.2805,430.405 Q 173.2805,430.085 173.7605,429.605 Q 174.2725,429.125 174.9445,428.645 Q 175.6485,428.165 176.2885,427.845 Q 176.9285,427.525 177.2485,427.525 Q 177.6965,427.525 178.1445,427.589 Q 178.5925,427.653 179.0405,427.717 Q 180.0645,427.845 181.0885,428.005 Q 182.1125,428.133 183.1045,428.197 Q 183.8405,426.149 184.4485,424.069 Q 185.0885,421.957 185.7605,419.909 Q 183.2005,418.789 180.3845,417.861 Q 177.5685,416.901 174.7525,416.901 Q 172.3845,416.901 170.5605,417.829 Q 168.7685,418.725 167.7445,420.485 Q 166.7205,422.213 166.7205,424.709 Q 166.7205,425.093 166.7525,425.477 Q 166.7845,425.861 166.9125,426.213 Q 166.9765,426.437 167.0725,426.629 Q 167.2005,426.789 167.2325,427.013 Q 166.6565,426.821 166.4325,426.341 Q 166.2405,425.861 166.0805,425.445 Q 165.9525,425.029 165.5045,425.029 Q 165.4405,425.029 165.1525,425.157 Q 164.8965,425.285 164.8325,425.349 Q 165.3445,422.341 167.0405,420.165 Q 168.7365,417.989 171.2645,416.805 Q 173.8245,415.621 176.8325,415.621 Q 179.3925,415.621 181.6645,416.453 Q 183.9685,417.285 186.2725,418.341 Q 186.6565,417.253 187.7765,416.773 Q 188.9285,416.293 189.9845,416.293 Q 190.0485,416.293 190.1765,416.325 Q 190.3045,416.357 190.3045,416.485 Q 190.3045,416.613 190.0805,416.677 Q 189.8885,416.709 189.8245,416.709 Q 189.4405,416.709 189.0565,417.189 Q 188.6725,417.637 188.3525,418.213 Q 188.0645,418.789 187.9045,419.077 Q 188.9285,419.525 190.2085,420.037 Q 191.4885,420.549 192.8005,420.901 Q 194.1125,421.221 195.2325,421.221 Q 195.6485,421.221 196.1925,421.125 Q 196.7685,421.029 197.2165,420.773 Q 197.6645,420.485 197.6645,419.941 Q 197.6645,419.781 197.5365,419.493 Q 197.4085,419.173 197.3445,419.045 Q 197.4085,418.725 197.6645,418.725 Q 198.0165,418.725 198.1445,419.077 Q 198.2725,419.429 198.2725,419.685 Q 198.2725,419.717 198.1125,420.005 Q 197.9845,420.293 197.9205,420.357 Q 197.2805,421.445 196.2245,421.989 Q 195.2005,422.533 193.9525,422.565 H 193.8885 Q 192.9605,422.565 191.7125,422.245 Q 190.4965,421.893 189.2805,421.445 Q 188.0965,420.965 187.2325,420.581 Q 186.4325,422.469 185.7925,424.453 Q 185.1845,426.405 184.4805,428.325 Q 185.1205,428.357 185.7285,428.421 Q 186.3685,428.453 186.9765,428.453 Q 187.9045,428.453 188.8005,428.261 Q 189.7285,428.069 190.3365,427.333 Q 190.3365,427.333 190.3365,427.333 Q 190.3685,427.301 190.4005,427.301 V 427.365 Q 190.4005,428.037 189.8565,428.453 Q 189.3445,428.837 188.5765,429.061 Q 187.8405,429.253 187.0725,429.349 Q 186.3365,429.413 185.8565,429.413 Q 185.4405,429.413 184.9925,429.413 Q 184.5765,429.381 184.1285,429.381 Q 183.2005,431.909 181.6645,434.117 Q 180.5765,435.685 179.0085,437.189 Q 177.4725,438.661 175.5845,439.589 Q 173.7285,440.549 171.6805,440.549 Z"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Beau Rivage';-inkscape-font-specification:'Beau Rivage';word-spacing:0px"
+       id="path8919" />
+    <path
+       d="M 186.5925,439.397 Q 186.5605,439.397 186.5605,439.365 Q 186.5605,439.237 186.6885,439.109 Q 186.7845,438.981 186.8165,438.917 Q 187.0405,438.565 187.3605,437.733 Q 187.6485,436.869 187.9365,435.813 Q 188.2565,434.725 188.5125,433.637 Q 188.8005,432.517 189.0245,431.589 Q 189.2485,430.661 189.3445,430.181 Q 189.4085,429.925 189.4725,429.509 Q 189.5365,429.093 189.6645,428.677 Q 189.7925,428.261 189.9525,428.133 Q 190.2725,427.877 190.8165,427.685 Q 191.3925,427.493 192.0005,427.397 Q 192.6085,427.269 192.9925,427.269 Q 193.0565,427.269 193.1525,427.333 Q 193.2485,427.397 193.2805,427.461 V 427.557 Q 193.2805,427.653 193.2165,427.653 Q 193.1525,427.621 193.0885,427.621 Q 192.3845,427.621 191.8405,428.421 Q 191.2965,429.189 190.9125,430.341 Q 190.5285,431.461 190.2725,432.517 Q 190.0165,433.573 189.8885,434.117 Q 190.9125,432.357 192.2245,430.757 Q 193.5685,429.125 195.3605,428.133 Q 195.5845,428.005 195.8725,427.877 Q 196.1605,427.717 196.3845,427.717 Q 196.8005,427.717 196.8965,428.101 Q 196.9925,428.453 196.9925,428.773 Q 196.9925,429.189 196.7045,429.989 Q 196.4165,430.789 196.0325,431.589 Q 195.6805,432.357 195.4885,432.805 Q 195.2965,433.317 195.0405,434.117 Q 194.7845,434.917 194.5925,435.717 Q 194.4005,436.517 194.4005,437.061 Q 194.4005,437.285 194.4645,437.573 Q 194.5285,437.861 194.8165,437.861 Q 194.9765,437.861 195.0725,437.797 Q 195.2005,437.733 195.3285,437.669 Q 196.0645,437.253 196.7365,436.549 Q 197.4405,435.813 198.0165,434.981 Q 198.5925,434.117 198.9765,433.413 Q 199.0085,433.445 199.0085,433.541 Q 199.0085,433.733 198.7845,434.117 Q 198.5605,434.469 198.2725,434.885 Q 197.9845,435.301 197.7285,435.621 Q 197.5045,435.941 197.5045,436.005 Q 197.4725,436.229 197.4085,436.389 Q 197.3445,436.517 197.2485,436.741 Q 196.8645,437.125 196.1285,437.701 Q 195.4245,438.245 194.6565,438.693 Q 193.9205,439.109 193.3445,439.109 Q 192.8325,439.109 192.6405,438.725 Q 192.4805,438.309 192.4805,437.861 Q 192.4805,436.997 192.8325,435.813 Q 193.1845,434.597 193.6645,433.413 Q 194.1445,432.197 194.4645,431.365 Q 194.5605,431.109 194.7525,430.565 Q 194.9765,430.021 194.9765,429.797 Q 194.9765,429.637 194.9125,429.445 Q 194.8805,429.253 194.6245,429.253 Q 194.3045,429.253 193.7925,429.669 Q 193.3125,430.085 193.0565,430.341 Q 191.6805,431.877 190.6885,433.765 Q 189.6965,435.621 189.0245,437.605 Q 188.9285,437.861 188.8965,437.989 Q 188.8965,438.085 188.6405,438.245 Q 188.5445,438.309 188.0325,438.597 Q 187.5525,438.885 187.1045,439.141 Q 186.6245,439.397 186.5925,439.397 Z"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Beau Rivage';-inkscape-font-specification:'Beau Rivage';word-spacing:0px"
+       id="path8921" />
+    <path
+       d="M 103.3088,423.4862 Q 103.3608,423.5383 103.1785,423.9159 Q 102.9963,424.2935 102.6968,424.8013 Q 102.4103,425.2961 102.1108,425.7258 Q 101.8244,426.1424 101.6551,426.2857 L 100.8739,426.0903 Q 100.5223,425.27 99.83218,424.619 Q 99.1551,423.9549 98.08739,423.9549 Q 97.56656,423.9549 97.08479,424.1112 Q 96.60301,424.2544 96.08218,424.6581 Q 95.26187,425.2961 94.70197,426.2466 Q 94.15509,427.1971 93.82957,428.2778 Q 93.51707,429.3586 93.37384,430.4002 Q 93.23061,431.4419 93.23061,432.2622 Q 93.23061,434.1503 93.82957,435.244 Q 94.44155,436.3247 95.31395,436.7805 Q 96.18635,437.2362 96.95458,437.2362 Q 97.61864,437.2362 98.64729,436.8846 Q 99.68896,436.52 101.2905,435.3482 Q 101.3947,435.4523 101.564,435.7648 Q 101.7462,436.0643 101.7593,436.2336 Q 99.98843,437.9914 98.37385,438.6685 Q 96.75926,439.3326 95.54832,439.3326 Q 94.03791,439.3326 92.80093,438.5904 Q 91.56394,437.8482 90.82176,436.4289 Q 90.09259,435.0096 90.09259,433.0044 Q 90.09259,431.3638 90.54832,429.6841 Q 91.00405,427.9914 91.95457,426.468 Q 92.90509,424.9445 94.37645,423.7857 Q 95.31395,423.0435 96.61603,422.6138 Q 97.91812,422.1841 99.14208,422.1841 Q 100.4181,422.1841 101.577,422.5747 Q 102.7489,422.9523 103.3088,423.4862 Z"
+       id="path8924"
+       style="font-style:italic;font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 112.2671,427.6528 Q 112.0848,427.9002 111.7202,428.2648 Q 111.3556,428.6294 110.9911,428.9419 Q 110.6265,429.2544 110.4702,429.3456 Q 110.314,428.981 109.8582,428.8768 Q 109.4025,428.7596 108.5692,428.7596 H 103.7124 L 103.4129,428.2518 L 104.9754,427.1971 H 111.9025 Z M 111.4728,436.9628 Q 110.0405,438.0956 108.6603,438.8117 Q 107.2801,439.5148 106.564,439.5148 Q 105.7697,439.5148 105.0535,438.7857 Q 104.3504,438.0435 104.3504,436.8977 Q 104.3504,436.4029 104.3765,435.895 Q 104.4155,435.3742 104.5327,434.6581 L 105.7957,426.7414 Q 105.952,425.7258 106.1473,425.4002 Q 106.3426,425.0747 106.6942,424.8924 L 109.1812,423.6685 L 109.5457,423.994 Q 109.4416,424.0851 109.2463,424.6841 Q 109.064,425.27 108.8817,426.4419 L 107.7749,433.4601 Q 107.6968,433.968 107.6577,434.5279 Q 107.6187,435.0878 107.6187,435.3482 Q 107.6187,436.1555 107.853,436.494 Q 108.1004,436.8325 108.465,436.8325 Q 109.2723,436.8325 111.1213,435.9992 Z"
+       id="path8926"
+       style="font-style:italic;font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 123.478,427.9133 Q 123.3088,428.1216 123.0484,428.5643 Q 122.7879,429.007 122.5015,429.4888 Q 122.215,429.9706 121.9676,430.3091 Q 121.7333,430.6476 121.603,430.6476 Q 121.2775,430.6476 120.9911,430.4002 Q 120.7046,430.1529 120.4312,429.9055 Q 120.1708,429.645 119.9234,429.645 Q 119.4676,429.645 118.8947,430.218 Q 118.3218,430.7779 117.7879,431.7674 Q 117.2541,432.744 116.8895,433.994 Q 116.603,434.9706 116.4338,436.0513 Q 116.2645,437.132 116.3036,438.1607 Q 116.0301,438.2779 115.4051,438.5643 Q 114.7801,438.8378 114.1812,439.1112 Q 113.5822,439.3977 113.3608,439.5148 L 112.84,439.007 Q 113.2176,437.1581 113.5301,435.3612 Q 113.8426,433.5513 114.0249,432.106 Q 114.2072,430.6476 114.2072,429.8664 Q 114.2072,429.2674 114.051,429.1372 Q 113.8947,428.994 113.6733,428.994 Q 113.4911,428.994 113.0614,429.1242 Q 112.6317,429.2414 112.4364,429.3065 L 112.202,428.4341 Q 112.9442,428.0956 113.8947,427.718 Q 114.8582,427.3403 115.6786,427.0669 Q 116.4989,426.7935 116.8114,426.7935 Q 117.176,426.7935 117.2931,427.0669 Q 117.4234,427.3273 117.4234,428.0956 Q 117.4234,428.369 117.3452,429.02 Q 117.2671,429.6581 117.189,430.1529 Q 118.0353,428.7857 118.7124,428.0565 Q 119.4025,427.3273 120.0015,427.0669 Q 120.6004,426.7935 121.1603,426.7935 Q 121.6161,426.7935 122.2541,427.2362 Q 122.9051,427.6789 123.478,427.9133 Z"
+       id="path8928"
+       style="font-style:italic;font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 129.4807,437.5487 Q 128.2046,438.356 126.9286,438.9419 Q 125.6655,439.5148 124.8452,439.5148 Q 124.4937,439.5148 124.1942,439.1112 Q 123.9077,438.7206 123.9077,437.9654 Q 123.9077,437.5357 124.064,436.3898 Q 124.2202,435.244 124.4546,433.6685 Q 124.702,432.093 124.9754,430.3612 Q 125.2619,428.6294 125.4963,427.0018 Q 125.7437,425.3742 125.8999,424.1112 Q 126.0562,422.8482 126.0562,422.2362 Q 126.0562,421.6372 125.8478,421.507 Q 125.6395,421.3638 125.3921,421.3638 Q 125.2359,421.3638 124.8322,421.481 Q 124.4416,421.5982 124.1291,421.7153 L 123.8947,420.8169 Q 124.6239,420.4914 125.6004,420.1138 Q 126.59,419.7362 127.4364,419.4627 Q 128.2827,419.1893 128.6083,419.1893 Q 128.9728,419.1893 129.1812,419.4237 Q 129.4025,419.658 129.4025,420.257 Q 129.4025,420.9341 129.2463,422.2101 Q 129.09,423.4732 128.8426,425.0877 Q 128.5952,426.7023 128.3218,428.4211 Q 128.0484,430.1398 127.801,431.7284 Q 127.5536,433.3169 127.3973,434.5409 Q 127.2411,435.7518 127.2411,436.3378 Q 127.2411,436.7805 127.3583,436.9497 Q 127.4885,437.106 127.6968,437.106 Q 127.9963,437.106 128.3478,437.0148 Q 128.6994,436.9107 129.2723,436.6763 Z"
+       id="path8930"
+       style="font-style:italic;font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 241.8644,431.8195 H 245.7056 L 244.5337,425.6737 Z M 246.0051,433.395 H 241.1743 L 239.5207,437.145 Q 239.3384,437.5357 239.716,437.731 Q 240.1066,437.9133 241.0832,438.0305 L 240.966,438.981 H 235.6926 L 235.8228,438.0305 Q 236.6561,437.8742 237.1118,437.7049 Q 237.5806,437.5357 237.7498,437.145 L 243.8436,423.2909 Q 244.4816,422.77 245.3019,422.4054 Q 246.1223,422.0278 246.7733,421.8325 L 249.729,437.145 Q 249.7941,437.5096 250.0546,437.718 Q 250.315,437.9263 251.0962,438.0305 L 250.979,438.981 H 244.9764 L 245.1066,438.0305 Q 246.0441,437.9654 246.4087,437.77 Q 246.7863,437.5747 246.7082,437.145 Z"
+       id="path8933"
+       style="font-style:italic;font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 258.6223,437.5487 Q 257.3462,438.356 256.0702,438.9419 Q 254.8072,439.5148 253.9868,439.5148 Q 253.6353,439.5148 253.3358,439.1112 Q 253.0493,438.7206 253.0493,437.9654 Q 253.0493,437.5357 253.2056,436.3898 Q 253.3618,435.244 253.5962,433.6685 Q 253.8436,432.093 254.1171,430.3612 Q 254.4035,428.6294 254.6379,427.0018 Q 254.8853,425.3742 255.0415,424.1112 Q 255.1978,422.8482 255.1978,422.2362 Q 255.1978,421.6372 254.9895,421.507 Q 254.7811,421.3638 254.5337,421.3638 Q 254.3775,421.3638 253.9738,421.481 Q 253.5832,421.5982 253.2707,421.7153 L 253.0363,420.8169 Q 253.7655,420.4914 254.7421,420.1138 Q 255.7316,419.7362 256.578,419.4627 Q 257.4244,419.1893 257.7499,419.1893 Q 258.1145,419.1893 258.3228,419.4237 Q 258.5441,419.658 258.5441,420.257 Q 258.5441,420.9341 258.3879,422.2101 Q 258.2316,423.4732 257.9843,425.0877 Q 257.7369,426.7023 257.4634,428.4211 Q 257.19,430.1398 256.9426,431.7284 Q 256.6952,433.3169 256.5389,434.5409 Q 256.3827,435.7518 256.3827,436.3378 Q 256.3827,436.7805 256.4999,436.9497 Q 256.6301,437.106 256.8384,437.106 Q 257.1379,437.106 257.4895,437.0148 Q 257.841,436.9107 258.4139,436.6763 Z"
+       id="path8935"
+       style="font-style:italic;font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 268.44,427.6528 Q 268.2577,427.9002 267.8931,428.2648 Q 267.5285,428.6294 267.1639,428.9419 Q 266.7994,429.2544 266.6431,429.3456 Q 266.4869,428.981 266.0311,428.8768 Q 265.5754,428.7596 264.7421,428.7596 H 259.8853 L 259.5858,428.2518 L 261.1483,427.1971 H 268.0754 Z M 267.6457,436.9628 Q 266.2134,438.0956 264.8332,438.8117 Q 263.453,439.5148 262.7369,439.5148 Q 261.9426,439.5148 261.2264,438.7857 Q 260.5233,438.0435 260.5233,436.8977 Q 260.5233,436.4029 260.5494,435.895 Q 260.5884,435.3742 260.7056,434.6581 L 261.9686,426.7414 Q 262.1249,425.7258 262.3202,425.4002 Q 262.5155,425.0747 262.8671,424.8924 L 265.3541,423.6685 L 265.7186,423.994 Q 265.6145,424.0851 265.4192,424.6841 Q 265.2369,425.27 265.0546,426.4419 L 263.9478,433.4601 Q 263.8697,433.968 263.8306,434.5279 Q 263.7915,435.0878 263.7915,435.3482 Q 263.7915,436.1555 264.0259,436.494 Q 264.2733,436.8325 264.6379,436.8325 Q 265.4452,436.8325 267.2942,435.9992 Z"
+       id="path8937"
+       style="font-style:italic;font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 306.5526,432.0539 L 316.7219,421.8455 L 326.9042,432.0539 L 316.7219,442.2622 Z"
+       id="path8940"
+       style="font-style:italic;font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 344.5344,435.0226 Q 344.3652,435.7648 344.1568,436.5982 Q 343.9615,437.4185 343.7662,438.0695 Q 343.5839,438.7206 343.4928,438.981 H 332.2297 L 332.3469,438.0305 Q 334.0657,437.6659 334.1178,437.2362 L 335.8886,424.3325 Q 335.9146,424.1763 335.55,423.9419 Q 335.1855,423.7075 334.3391,423.5252 L 334.4693,422.5747 H 340.8105 L 340.6803,423.5252 Q 338.9745,423.9028 338.8964,424.3325 L 337.2297,436.481 Q 337.1777,436.9497 337.5943,437.1841 Q 338.024,437.4185 339.3521,437.4185 H 340.7063 Q 341.4355,437.4185 341.9172,437.1581 Q 342.412,436.8977 342.8027,436.2987 Q 343.2063,435.6997 343.7011,434.6841 Z"
+       id="path8942"
+       style="font-style:italic;font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 356.1621,425.9471 Q 356.1621,427.3664 355.3027,428.369 Q 354.4433,429.3586 353.1803,429.8924 Q 354.5084,430.0487 355.1725,431.0773 Q 355.8496,432.106 355.8496,433.4081 Q 355.8496,435.0357 355.0032,436.4029 Q 354.1568,437.757 352.7245,438.5773 Q 351.3053,439.3846 349.5475,439.3846 Q 348.636,439.3846 347.412,438.8247 Q 346.1881,438.2648 345.2896,437.2362 L 345.9928,435.9732 Q 346.9563,436.8586 347.8287,437.2102 Q 348.7011,437.5487 349.5995,437.5487 Q 350.9277,437.5487 351.8131,436.494 Q 352.6985,435.4393 352.6985,433.7596 Q 352.6985,432.4055 352.0475,431.7805 Q 351.3964,431.1555 350.4589,431.1555 Q 350.1594,431.1555 349.9641,431.1815 Q 349.7818,431.1945 349.4954,431.2466 L 349.4173,430.0747 Q 351.136,429.645 352.0995,428.6815 Q 353.0761,427.718 353.0761,426.1424 Q 353.0761,425.3221 352.7506,424.8664 Q 352.4381,424.4107 351.761,424.4107 Q 350.9928,424.4107 350.6021,424.9836 Q 350.2115,425.5565 350.2115,426.507 Q 349.6907,426.8065 348.8443,427.093 Q 348.011,427.3794 347.4251,427.4055 L 347.1126,426.6112 Q 347.1907,426.0643 347.6464,425.4263 Q 348.1021,424.7883 348.8313,424.2153 Q 349.5605,423.6294 350.498,423.2648 Q 351.4355,422.9002 352.4902,422.9002 Q 353.8834,422.9002 354.6777,423.3429 Q 355.485,423.7726 355.8235,424.4627 Q 356.1621,425.1528 356.1621,425.9471 Z"
+       id="path8944"
+       style="font-style:italic;font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 737.9256,431.8195 H 741.7668 L 740.5949,425.6737 Z M 742.0663,433.395 H 737.2355 L 735.5819,437.145 Q 735.3996,437.5357 735.7772,437.731 Q 736.1678,437.9133 737.1444,438.0305 L 737.0272,438.981 H 731.7537 L 731.884,438.0305 Q 732.7173,437.8742 733.173,437.7049 Q 733.6418,437.5357 733.811,437.145 L 739.9048,423.2909 Q 740.5428,422.77 741.3631,422.4054 Q 742.1834,422.0278 742.8345,421.8325 L 745.7902,437.145 Q 745.8553,437.5096 746.1157,437.718 Q 746.3762,437.9263 747.1574,438.0305 L 747.0402,438.981 H 741.0376 L 741.1678,438.0305 Q 742.1053,437.9654 742.4699,437.77 Q 742.8475,437.5747 742.7694,437.145 Z"
+       id="path8959"
+       style="font-style:italic;font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 754.6835,437.5487 Q 753.4074,438.356 752.1314,438.9419 Q 750.8684,439.5148 750.048,439.5148 Q 749.6965,439.5148 749.397,439.1112 Q 749.1105,438.7206 749.1105,437.9654 Q 749.1105,437.5357 749.2668,436.3898 Q 749.423,435.244 749.6574,433.6685 Q 749.9048,432.093 750.1782,430.3612 Q 750.4647,428.6294 750.6991,427.0018 Q 750.9465,425.3742 751.1027,424.1112 Q 751.259,422.8482 751.259,422.2362 Q 751.259,421.6372 751.0506,421.507 Q 750.8423,421.3638 750.5949,421.3638 Q 750.4387,421.3638 750.035,421.481 Q 749.6444,421.5982 749.3319,421.7153 L 749.0975,420.8169 Q 749.8267,420.4914 750.8032,420.1138 Q 751.7928,419.7362 752.6392,419.4627 Q 753.4855,419.1893 753.8111,419.1893 Q 754.1756,419.1893 754.384,419.4237 Q 754.6053,419.658 754.6053,420.257 Q 754.6053,420.9341 754.4491,422.2101 Q 754.2928,423.4732 754.0454,425.0877 Q 753.798,426.7023 753.5246,428.4211 Q 753.2512,430.1398 753.0038,431.7284 Q 752.7564,433.3169 752.6001,434.5409 Q 752.4439,435.7518 752.4439,436.3378 Q 752.4439,436.7805 752.5611,436.9497 Q 752.6913,437.106 752.8996,437.106 Q 753.1991,437.106 753.5506,437.0148 Q 753.9022,436.9107 754.4751,436.6763 Z"
+       id="path8961"
+       style="font-style:italic;font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 764.5012,427.6528 Q 764.3189,427.9002 763.9543,428.2648 Q 763.5897,428.6294 763.2251,428.9419 Q 762.8606,429.2544 762.7043,429.3456 Q 762.5481,428.981 762.0923,428.8768 Q 761.6366,428.7596 760.8033,428.7596 H 755.9465 L 755.647,428.2518 L 757.2095,427.1971 H 764.1366 Z M 763.7069,436.9628 Q 762.2746,438.0956 760.8944,438.8117 Q 759.5142,439.5148 758.798,439.5148 Q 758.0038,439.5148 757.2876,438.7857 Q 756.5845,438.0435 756.5845,436.8977 Q 756.5845,436.4029 756.6105,435.895 Q 756.6496,435.3742 756.7668,434.6581 L 758.0298,426.7414 Q 758.1861,425.7258 758.3814,425.4002 Q 758.5767,425.0747 758.9283,424.8924 L 761.4152,423.6685 L 761.7798,423.994 Q 761.6757,424.0851 761.4803,424.6841 Q 761.2981,425.27 761.1158,426.4419 L 760.009,433.4601 Q 759.9309,433.968 759.8918,434.5279 Q 759.8527,435.0878 759.8527,435.3482 Q 759.8527,436.1555 760.0871,436.494 Q 760.3345,436.8325 760.6991,436.8325 Q 761.5064,436.8325 763.3553,435.9992 Z"
+       id="path8963"
+       style="font-style:italic;font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 815.8513,423.4862 Q 815.9034,423.5383 815.7211,423.9159 Q 815.5388,424.2935 815.2393,424.8013 Q 814.9529,425.2961 814.6534,425.7258 Q 814.3669,426.1424 814.1977,426.2857 L 813.4164,426.0903 Q 813.0649,425.27 812.3747,424.619 Q 811.6977,423.9549 810.63,423.9549 Q 810.1091,423.9549 809.6273,424.1112 Q 809.1456,424.2544 808.6247,424.6581 Q 807.8044,425.2961 807.2445,426.2466 Q 806.6977,427.1971 806.3721,428.2778 Q 806.0596,429.3586 805.9164,430.4002 Q 805.7732,431.4419 805.7732,432.2622 Q 805.7732,434.1503 806.3721,435.244 Q 806.9841,436.3247 807.8565,436.7805 Q 808.7289,437.2362 809.4971,437.2362 Q 810.1612,437.2362 811.1899,436.8846 Q 812.2315,436.52 813.8331,435.3482 Q 813.9373,435.4523 814.1065,435.7648 Q 814.2888,436.0643 814.3018,436.2336 Q 812.531,437.9914 810.9164,438.6685 Q 809.3018,439.3326 808.0909,439.3326 Q 806.5805,439.3326 805.3435,438.5904 Q 804.1065,437.8482 803.3643,436.4289 Q 802.6352,435.0096 802.6352,433.0044 Q 802.6352,431.3638 803.0909,429.6841 Q 803.5466,427.9914 804.4971,426.468 Q 805.4477,424.9445 806.919,423.7857 Q 807.8565,423.0435 809.1586,422.6138 Q 810.4607,422.1841 811.6846,422.1841 Q 812.9607,422.1841 814.1195,422.5747 Q 815.2914,422.9523 815.8513,423.4862 Z"
+       id="path8966"
+       style="font-style:italic;font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 824.8097,427.6528 Q 824.6274,427.9002 824.2628,428.2648 Q 823.8982,428.6294 823.5336,428.9419 Q 823.169,429.2544 823.0128,429.3456 Q 822.8565,428.981 822.4008,428.8768 Q 821.9451,428.7596 821.1117,428.7596 H 816.255 L 815.9555,428.2518 L 817.518,427.1971 H 824.4451 Z M 824.0154,436.9628 Q 822.5831,438.0956 821.2029,438.8117 Q 819.8227,439.5148 819.1065,439.5148 Q 818.3123,439.5148 817.5961,438.7857 Q 816.893,438.0435 816.893,436.8977 Q 816.893,436.4029 816.919,435.895 Q 816.9581,435.3742 817.0753,434.6581 L 818.3383,426.7414 Q 818.4945,425.7258 818.6899,425.4002 Q 818.8852,425.0747 819.2367,424.8924 L 821.7237,423.6685 L 822.0883,423.994 Q 821.9841,424.0851 821.7888,424.6841 Q 821.6065,425.27 821.4242,426.4419 L 820.3175,433.4601 Q 820.2393,433.968 820.2003,434.5279 Q 820.1612,435.0878 820.1612,435.3482 Q 820.1612,436.1555 820.3956,436.494 Q 820.643,436.8325 821.0076,436.8325 Q 821.8149,436.8325 823.6638,435.9992 Z"
+       id="path8968"
+       style="font-style:italic;font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 836.0206,427.9133 Q 835.8513,428.1216 835.5909,428.5643 Q 835.3305,429.007 835.044,429.4888 Q 834.7576,429.9706 834.5102,430.3091 Q 834.2758,430.6476 834.1456,430.6476 Q 833.8201,430.6476 833.5336,430.4002 Q 833.2472,430.1529 832.9737,429.9055 Q 832.7133,429.645 832.4659,429.645 Q 832.0102,429.645 831.4373,430.218 Q 830.8644,430.7779 830.3305,431.7674 Q 829.7966,432.744 829.4321,433.994 Q 829.1456,434.9706 828.9763,436.0513 Q 828.8071,437.132 828.8461,438.1607 Q 828.5727,438.2779 827.9477,438.5643 Q 827.3227,438.8378 826.7237,439.1112 Q 826.1248,439.3977 825.9034,439.5148 L 825.3826,439.007 Q 825.7602,437.1581 826.0727,435.3612 Q 826.3852,433.5513 826.5675,432.106 Q 826.7498,430.6476 826.7498,429.8664 Q 826.7498,429.2674 826.5935,429.1372 Q 826.4373,428.994 826.2159,428.994 Q 826.0336,428.994 825.6039,429.1242 Q 825.1742,429.2414 824.9789,429.3065 L 824.7446,428.4341 Q 825.4867,428.0956 826.4373,427.718 Q 827.4008,427.3403 828.2211,427.0669 Q 829.0414,426.7935 829.3539,426.7935 Q 829.7185,426.7935 829.8357,427.0669 Q 829.9659,427.3273 829.9659,428.0956 Q 829.9659,428.369 829.8878,429.02 Q 829.8097,429.6581 829.7315,430.1529 Q 830.5779,428.7857 831.255,428.0565 Q 831.9451,427.3273 832.544,427.0669 Q 833.143,426.7935 833.7029,426.7935 Q 834.1586,426.7935 834.7967,427.2362 Q 835.4477,427.6789 836.0206,427.9133 Z"
+       id="path8970"
+       style="font-style:italic;font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 842.0232,437.5487 Q 840.7472,438.356 839.4711,438.9419 Q 838.2081,439.5148 837.3878,439.5148 Q 837.0362,439.5148 836.7368,439.1112 Q 836.4503,438.7206 836.4503,437.9654 Q 836.4503,437.5357 836.6065,436.3898 Q 836.7628,435.244 836.9972,433.6685 Q 837.2446,432.093 837.518,430.3612 Q 837.8045,428.6294 838.0388,427.0018 Q 838.2862,425.3742 838.4425,424.1112 Q 838.5987,422.8482 838.5987,422.2362 Q 838.5987,421.6372 838.3904,421.507 Q 838.1821,421.3638 837.9347,421.3638 Q 837.7784,421.3638 837.3748,421.481 Q 836.9842,421.5982 836.6717,421.7153 L 836.4373,420.8169 Q 837.1664,420.4914 838.143,420.1138 Q 839.1326,419.7362 839.9789,419.4627 Q 840.8253,419.1893 841.1508,419.1893 Q 841.5154,419.1893 841.7237,419.4237 Q 841.9451,419.658 841.9451,420.257 Q 841.9451,420.9341 841.7888,422.2101 Q 841.6326,423.4732 841.3852,425.0877 Q 841.1378,426.7023 840.8644,428.4211 Q 840.5909,430.1398 840.3435,431.7284 Q 840.0961,433.3169 839.9399,434.5409 Q 839.7836,435.7518 839.7836,436.3378 Q 839.7836,436.7805 839.9008,436.9497 Q 840.031,437.106 840.2394,437.106 Q 840.5388,437.106 840.8904,437.0148 Q 841.242,436.9107 841.8149,436.6763 Z"
+       id="path8972"
+       style="font-style:italic;font-weight:bold;font-size:26.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 385.3082,430.9628 Q 385.0986,431.2361 384.8251,431.5735 Q 384.5517,431.9015 384.3056,432.1385 Q 384.0686,432.3754 383.9501,432.3754 Q 383.8043,432.3754 383.622,432.1931 Q 383.4488,432.011 383.2209,431.774 Q 383.0022,431.5278 382.7288,431.3455 Q 382.4644,431.1632 382.1363,431.1632 Q 381.635,431.1632 381.3616,431.4275 Q 381.0972,431.6918 381.0972,432.1202 Q 381.0972,432.5486 381.4709,432.8677 Q 381.8446,433.1866 382.5829,433.5604 Q 383.0751,433.8156 383.54,434.1437 Q 384.0048,434.4628 384.2965,434.9184 Q 384.5973,435.3741 384.5973,436.0213 Q 384.5973,436.6503 384.2144,437.1972 Q 383.8407,437.7439 383.2392,438.1542 Q 382.6467,438.5643 381.9631,438.7921 Q 381.2887,439.0292 380.6962,439.0292 Q 379.9215,439.0292 379.3017,438.783 Q 378.6819,438.5461 378.3173,438.218 Q 377.9527,437.8808 377.9527,437.6254 Q 377.9527,437.4979 378.0803,437.2244 Q 378.2079,436.951 378.3902,436.6594 Q 378.5725,436.3586 378.7457,436.149 Q 378.928,435.9393 379.0191,435.9393 Q 379.1376,435.9393 379.2926,436.2309 Q 379.4475,436.5226 379.6936,436.9146 Q 379.9397,437.2973 380.3225,437.589 Q 380.7144,437.8808 381.2887,437.8808 Q 381.8811,437.8808 382.2275,437.5525 Q 382.5829,437.2153 382.5829,436.6866 Q 382.5829,436.0668 382.0087,435.6202 Q 381.4436,435.1646 380.76,434.8181 Q 379.7939,434.3351 379.4475,433.8156 Q 379.1103,433.2869 379.1103,432.7036 Q 379.1103,432.1293 379.4384,431.6555 Q 379.7665,431.1814 380.2952,430.8442 Q 380.8329,430.4979 381.4436,430.3156 Q 382.0543,430.1241 382.6194,430.1241 Q 383.2665,430.1241 383.7314,430.3064 Q 384.1962,430.4887 384.5608,430.6893 Q 384.9345,430.8899 385.3082,430.9628 Z"
+       id="path9073"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 394.04,432.9406 Q 394.04,434.007 393.6754,435.1646 Q 393.3199,436.3222 392.8186,437.1424 Q 392.5452,437.5982 392.1624,438.0357 Q 391.7887,438.464 391.3329,438.7466 Q 390.8863,439.0292 390.3941,439.0292 Q 389.8928,439.0292 389.2366,438.5004 Q 388.5803,437.9719 388.0061,437.115 L 388.2887,435.9028 Q 388.471,436.2309 388.8173,436.5317 Q 389.1728,436.8235 389.5738,437.0149 Q 389.9749,437.2062 390.2939,437.2062 Q 390.6767,437.2062 390.9775,436.9784 Q 391.2874,436.7504 391.4605,436.386 Q 391.6884,435.9028 391.7887,435.2284 Q 391.8889,434.5538 391.8889,433.8702 Q 391.8889,432.9042 391.6064,432.3208 Q 391.3238,431.7284 390.9866,431.7284 Q 390.7678,431.7284 390.3486,432.011 Q 389.9384,432.2934 389.4644,432.8403 Q 388.9996,433.3872 388.6077,434.1619 L 388.5439,432.576 Q 389.346,431.5461 389.9658,431.0174 Q 390.5855,430.4887 391.0868,430.3064 Q 391.5973,430.1241 392.0439,430.1241 Q 392.8551,430.1241 393.4475,430.8534 Q 394.04,431.5735 394.04,432.9406 Z M 389.1454,430.7257 Q 389.1454,431.1177 389.0087,432.0018 Q 388.8811,432.886 388.6077,434.4809 Q 388.3434,436.076 387.9332,438.6007 Q 387.6324,440.4784 387.5595,441.3077 Q 387.4866,442.1372 387.5777,442.3833 Q 387.441,442.4198 387.1402,442.5292 Q 386.8486,442.6385 386.5022,442.7753 Q 386.1558,442.9211 385.8642,443.0396 Q 385.5816,443.158 385.4631,443.2128 L 385.0986,442.8756 Q 385.1441,442.5292 385.29,441.7271 Q 385.4267,440.925 385.6181,439.8586 Q 385.8186,438.7921 386.0282,437.6347 Q 386.2379,436.4771 386.4111,435.4015 Q 386.5933,434.3168 386.7027,433.4875 Q 386.8212,432.658 386.8212,432.2753 Q 386.8212,431.8559 386.6845,431.7649 Q 386.5478,431.6646 386.3928,431.6646 Q 386.2743,431.6646 385.9827,431.7466 Q 385.691,431.8286 385.5452,431.8833 L 385.3811,431.2726 Q 385.9189,431.0174 386.6025,430.7531 Q 387.2861,430.4887 387.8603,430.3064 Q 388.4345,430.1241 388.6532,430.1241 Q 388.8811,430.1241 389.0087,430.2518 Q 389.1454,430.3702 389.1454,430.7257 Z"
+       id="path9075"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 403.5647,437.6893 Q 402.79,438.2361 402.0973,438.6372 Q 401.4046,439.0292 401.0856,439.0292 Q 400.8668,439.0292 400.566,438.7921 Q 400.2744,438.5643 400.0556,437.9719 Q 399.8369,437.3795 399.8369,436.2948 Q 399.8369,436.0851 399.8915,435.6202 Q 399.9554,435.1555 400.0374,434.5629 Q 400.1285,433.9705 400.2288,433.3781 Q 400.3291,432.7857 400.4111,432.3208 Q 400.4931,431.8469 400.5296,431.6372 Q 400.5843,431.3546 401.0126,431.0812 Q 401.441,430.8077 401.9879,430.5616 Q 402.5348,430.3156 402.9449,430.1241 L 403.2275,430.7167 Q 402.9267,430.9719 402.7991,431.1814 Q 402.6715,431.382 402.5439,432.0018 Q 402.2613,433.3052 402.1064,434.408 Q 401.9606,435.5018 401.9606,435.9028 Q 401.9606,436.5317 402.0882,436.942 Q 402.2249,437.343 402.4436,437.343 Q 402.6259,437.343 402.8356,437.2973 Q 403.0543,437.2427 403.4189,437.0878 Z M 402.6715,431.1723 Q 402.4163,431.3546 402.1793,431.7556 Q 401.9423,432.1567 401.7418,432.4939 Q 401.5413,432.8312 401.3772,432.8312 Q 401.2587,432.8312 401.04,432.6216 Q 400.8212,432.4119 400.5387,432.1293 Q 400.2561,431.8469 399.9371,431.6372 Q 399.6272,431.4184 399.3264,431.4184 Q 398.7522,431.4184 398.3238,431.8012 Q 397.8955,432.1841 397.6129,432.7765 Q 397.3303,433.3598 397.1845,434.0161 Q 397.0478,434.6632 397.0478,435.201 Q 397.0478,436.2219 397.3212,436.7323 Q 397.5947,437.2336 397.9319,437.2336 Q 398.2327,437.2336 398.8069,436.6503 Q 399.3902,436.0577 400.1103,434.964 L 399.9462,436.7232 Q 399.5634,437.2792 399.0804,437.8077 Q 398.6064,438.3365 398.0869,438.6827 Q 397.5764,439.0292 397.0569,439.0292 Q 396.6194,439.0292 396.1363,438.7101 Q 395.6533,438.4003 395.316,437.7076 Q 394.9788,437.0149 394.9788,435.8754 Q 394.9788,434.4354 395.6897,433.1503 Q 396.4007,431.865 397.6858,430.9809 Q 398.178,430.6437 398.8707,430.3885 Q 399.5634,430.1241 400.3291,430.1241 Q 400.803,430.1241 401.2587,430.3793 Q 401.7236,430.6254 402.0882,430.8899 Q 402.4619,431.1451 402.6715,431.1723 Z"
+       id="path9077"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 411.8772,431.1542 Q 411.622,431.4094 411.2483,431.7466 Q 410.8746,432.0747 410.5192,432.3208 Q 410.1637,432.5577 409.9723,432.5577 Q 409.7809,432.5577 409.5713,432.2753 Q 409.3616,431.9927 409.0973,431.7101 Q 408.833,431.4184 408.4775,431.4184 Q 407.8121,431.4184 407.3564,431.9927 Q 406.9007,432.5577 406.6546,433.4146 Q 406.4176,434.2622 406.4176,435.1189 Q 406.4176,436.2948 406.7822,436.9601 Q 407.1559,437.6163 407.7301,437.6163 Q 408.2132,437.6163 408.9059,437.261 Q 409.6077,436.8963 410.583,436.0942 Q 410.6559,436.1854 410.82,436.4314 Q 410.9931,436.6684 411.0296,436.7413 Q 409.5986,438.0357 408.6233,438.5369 Q 407.6572,439.0292 406.8369,439.0292 Q 406.3173,439.0292 405.7158,438.7375 Q 405.1233,438.4458 404.6949,437.7257 Q 404.2666,436.9966 404.2666,435.7205 Q 404.2666,434.49 404.8043,433.2504 Q 405.3512,432.011 406.691,431.1177 Q 407.2015,430.7805 408.0035,430.4524 Q 408.8056,430.1241 409.5713,430.1241 Q 410.109,430.1241 410.5009,430.343 Q 410.8929,430.5525 411.221,430.8077 Q 411.5491,431.0538 411.8772,431.1542 Z"
+       id="path9079"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 419.096,431.7284 Q 419.096,432.1293 418.9046,432.6125 Q 418.7223,433.0955 418.139,433.6515 Q 417.5556,434.1985 416.3799,434.8091 Q 415.2041,435.4198 413.2171,436.0577 L 413.1533,435.1098 Q 414.402,434.6086 415.1312,434.2167 Q 415.8694,433.8156 416.234,433.4875 Q 416.5986,433.1594 416.708,432.8586 Q 416.8174,432.5486 416.8174,432.2024 Q 416.8174,431.783 416.626,431.5735 Q 416.4437,431.3546 416.1885,431.3546 Q 416.0426,431.3546 415.7418,431.5095 Q 415.4411,431.6646 415.2132,431.9379 Q 414.721,432.5122 414.4202,433.2597 Q 414.1286,434.007 414.1286,435.0097 Q 414.1286,436.2036 414.5387,436.9146 Q 414.958,437.6163 415.4957,437.6163 Q 415.8786,437.6163 416.6168,437.261 Q 417.3642,436.9055 418.4671,436.0213 Q 418.5674,436.076 418.7132,436.3403 Q 418.859,436.6046 418.8864,436.6684 Q 417.3916,437.9719 416.4163,438.5004 Q 415.4411,439.0292 414.6299,439.0292 Q 414.1286,439.0292 413.5088,438.7192 Q 412.8981,438.4184 412.4515,437.7348 Q 412.014,437.0421 412.014,435.8937 Q 412.014,434.4628 412.6793,433.2869 Q 413.3447,432.1021 414.4931,431.1451 Q 414.9033,430.8077 415.6325,430.4705 Q 416.3707,430.1241 417.0908,430.1241 Q 418.1207,430.1241 418.6038,430.6345 Q 419.096,431.136 419.096,431.7284 Z"
+       id="path9081"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 457.2073,448.5614 Q 456.6604,448.8895 456.0498,449.2085 Q 455.4482,449.5275 454.9195,449.7281 Q 454.3909,449.9377 454.0901,449.9377 Q 453.7711,449.9377 453.5615,449.646 Q 453.3518,449.3635 453.3518,448.8713 Q 453.3518,448.6799 453.4248,448.1786 Q 453.4977,447.6773 453.607,447.021 Q 453.7255,446.3648 453.8349,445.7085 Q 453.9443,445.0432 454.0172,444.5145 Q 454.0992,443.9767 454.0992,443.7307 Q 454.0992,443.1929 453.999,442.9833 Q 453.9078,442.7645 453.6162,442.7645 Q 453.3701,442.7645 452.7958,443.0926 Q 452.2216,443.4208 451.693,444.2775 Q 451.4195,444.7059 451.2646,445.3257 Q 451.1188,445.9364 450.9638,446.8205 Q 450.818,447.6317 450.7724,448.0965 Q 450.7359,448.5523 450.7542,448.9898 Q 450.6266,449.0445 450.3349,449.1721 Q 450.0524,449.2997 449.7151,449.4546 Q 449.3779,449.6096 449.0862,449.7372 Q 448.8037,449.8739 448.6943,449.9377 L 448.3297,449.5822 Q 448.512,448.6799 448.6852,447.6955 Q 448.8583,446.702 448.9951,445.7906 Q 449.1318,444.8791 449.2138,444.1864 Q 449.2958,443.4846 449.2958,443.1655 Q 449.2958,442.7463 449.2047,442.6551 Q 449.1135,442.5549 448.9495,442.5549 Q 448.8219,442.5549 448.5029,442.646 Q 448.193,442.7372 448.0471,442.7918 L 447.874,442.1629 Q 448.2568,441.9989 448.749,441.8075 Q 449.2503,441.6069 449.7333,441.4338 Q 450.2255,441.2515 450.5992,441.1421 Q 450.9729,441.0327 451.1096,441.0327 Q 451.3649,441.0327 451.4469,441.2241 Q 451.538,441.4155 451.538,442.0627 Q 451.538,442.5002 451.4742,442.9741 Q 452.4677,441.9898 453.4339,441.5158 Q 454.4,441.0327 455.2203,441.0327 Q 455.7945,441.0327 456.1044,441.3153 Q 456.4235,441.5978 456.4235,442.482 Q 456.4235,442.9559 456.305,443.6851 Q 456.1865,444.4051 456.0315,445.1981 Q 455.8857,445.982 455.7672,446.6656 Q 455.6487,447.34 455.6487,447.7137 Q 455.6487,448.0236 455.7307,448.1421 Q 455.8128,448.2515 455.9768,448.2515 Q 456.1865,448.2515 456.4052,448.1877 Q 456.624,448.1148 456.9703,447.9507 Z"
+       id="path9084"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 465.3649,444.4689 Q 465.3649,445.6812 464.7633,446.9208 Q 464.1618,448.1512 463.1409,448.9898 Q 462.667,449.3817 462.0107,449.6551 Q 461.3636,449.9377 460.8167,449.9377 Q 459.8688,449.9377 459.1852,449.482 Q 458.5016,449.0171 458.137,448.2241 Q 457.7724,447.4221 457.7724,446.4286 Q 457.7724,445.1252 458.292,443.9859 Q 458.8206,442.8465 460.042,441.9077 Q 460.5159,441.5431 461.163,441.2879 Q 461.8102,441.0327 462.4209,441.0327 Q 463.8519,441.0327 464.6084,441.9989 Q 465.3649,442.9559 465.3649,444.4689 Z M 463.2412,445.1799 Q 463.2412,443.7945 462.8037,443.0471 Q 462.3753,442.2997 461.792,442.2997 Q 461.0901,442.2997 460.6709,442.8374 Q 460.2607,443.3752 460.0784,444.1682 Q 459.9052,444.952 459.9052,445.7267 Q 459.9052,446.5379 460.124,447.2215 Q 460.3519,447.896 460.6982,448.2971 Q 461.0537,448.6981 461.4365,448.6981 Q 461.9378,448.6981 462.2841,448.37 Q 462.6305,448.0327 462.8401,447.5041 Q 463.0498,446.9663 463.1409,446.3557 Q 463.2412,445.745 463.2412,445.1799 Z M 465.8753,438.0249 Q 465.8297,438.1616 465.7112,438.3895 Q 465.5927,438.6174 465.4651,438.8361 Q 465.3467,439.0549 465.2828,439.1551 H 459.5953 L 459.3766,438.8635 Q 459.4495,438.6812 459.65,438.2984 Q 459.8505,437.9155 459.9599,437.7332 H 465.6292 Z"
+       id="path9086"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 475.3363,448.5614 Q 474.7894,448.8895 474.1787,449.2085 Q 473.5771,449.5275 473.0485,449.7281 Q 472.5198,449.9377 472.2191,449.9377 Q 471.9,449.9377 471.6904,449.646 Q 471.4808,449.3635 471.4808,448.8713 Q 471.4808,448.6799 471.5537,448.1786 Q 471.6266,447.6773 471.736,447.021 Q 471.8545,446.3648 471.9639,445.7085 Q 472.0732,445.0432 472.1461,444.5145 Q 472.2282,443.9767 472.2282,443.7307 Q 472.2282,443.1929 472.1279,442.9833 Q 472.0368,442.7645 471.7451,442.7645 Q 471.499,442.7645 470.9248,443.0926 Q 470.3506,443.4208 469.8219,444.2775 Q 469.5485,444.7059 469.3935,445.3257 Q 469.2477,445.9364 469.0928,446.8205 Q 468.9469,447.6317 468.9013,448.0965 Q 468.8649,448.5523 468.8831,448.9898 Q 468.7555,449.0445 468.4638,449.1721 Q 468.1813,449.2997 467.8441,449.4546 Q 467.5068,449.6096 467.2151,449.7372 Q 466.9326,449.8739 466.8232,449.9377 L 466.4586,449.5822 Q 466.6409,448.6799 466.8141,447.6955 Q 466.9873,446.702 467.124,445.7906 Q 467.2607,444.8791 467.3427,444.1864 Q 467.4248,443.4846 467.4248,443.1655 Q 467.4248,442.7463 467.3336,442.6551 Q 467.2425,442.5549 467.0784,442.5549 Q 466.9508,442.5549 466.6318,442.646 Q 466.3219,442.7372 466.1761,442.7918 L 466.0029,442.1629 Q 466.3857,441.9989 466.8779,441.8075 Q 467.3792,441.6069 467.8623,441.4338 Q 468.3545,441.2515 468.7282,441.1421 Q 469.1019,441.0327 469.2386,441.0327 Q 469.4938,441.0327 469.5758,441.2241 Q 469.667,441.4155 469.667,442.0627 Q 469.667,442.5002 469.6032,442.9741 Q 470.5967,441.9898 471.5628,441.5158 Q 472.529,441.0327 473.3493,441.0327 Q 473.9235,441.0327 474.2334,441.3153 Q 474.5524,441.5978 474.5524,442.482 Q 474.5524,442.9559 474.4339,443.6851 Q 474.3154,444.4051 474.1605,445.1981 Q 474.0146,445.982 473.8961,446.6656 Q 473.7777,447.34 473.7777,447.7137 Q 473.7777,448.0236 473.8597,448.1421 Q 473.9417,448.2515 474.1058,448.2515 Q 474.3154,448.2515 474.5342,448.1877 Q 474.7529,448.1148 475.0993,447.9507 Z"
+       id="path9088"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 481.3245,444.5601 Q 481.2425,444.7606 481.0693,445.0796 Q 480.8962,445.3986 480.8141,445.5536 H 476.0472 L 475.8102,445.2619 Q 475.8831,445.0705 476.0563,444.7606 Q 476.2295,444.4507 476.3389,444.2775 H 481.0785 Z"
+       id="path9090"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 490.5303,444.0041 Q 490.5303,444.9702 490.1201,445.9637 Q 489.7191,446.9572 489.0446,447.8505 Q 488.4157,448.6708 487.4587,449.3088 Q 486.5016,449.9377 485.3532,449.9377 Q 485.0433,449.9377 484.6058,449.7281 Q 484.1774,449.5184 483.7581,449.1538 Q 483.3389,448.7893 483.0563,448.3335 Q 482.7829,447.8778 482.7829,447.3765 Q 482.7829,447.0575 482.874,446.3465 Q 482.9652,445.6265 483.111,444.6786 Q 483.2568,443.7215 483.4118,442.6916 Q 483.5759,441.6525 483.7217,440.6864 Q 483.8675,439.7202 483.9587,438.9728 Q 484.0498,438.2163 484.0498,437.8426 Q 484.0498,437.4233 483.8857,437.3322 Q 483.7308,437.2319 483.5667,437.2319 Q 483.43,437.2319 483.1748,437.3231 Q 482.9196,437.4051 482.7282,437.478 L 482.5732,436.8491 Q 483.1201,436.5848 483.8128,436.3296 Q 484.5055,436.0653 485.0798,435.8921 Q 485.6631,435.7098 485.8818,435.7098 Q 486.1917,435.7098 486.292,435.8739 Q 486.4014,436.0379 486.4014,436.4572 Q 486.4014,436.8856 486.3011,437.7059 Q 486.2009,438.5171 486.0368,439.5471 Q 485.8818,440.577 485.6996,441.6799 Q 485.5264,442.7827 485.3623,443.8127 Q 485.2074,444.8335 485.1071,445.6265 Q 485.016,446.4195 485.016,446.8205 Q 485.016,447.1395 485.2438,447.4676 Q 485.4717,447.7958 485.7907,448.0145 Q 486.1097,448.2333 486.374,448.2333 Q 486.8206,448.2333 487.1488,448.0054 Q 487.486,447.7684 487.7321,447.4038 Q 488.0967,446.8661 488.2425,446.1096 Q 488.3975,445.3439 488.3975,444.7333 Q 488.3975,443.7945 488.124,443.2293 Q 487.8597,442.6551 487.4222,442.6551 Q 487.1488,442.6551 486.4378,443.3023 Q 485.736,443.9403 484.9248,445.4442 L 484.779,444.0679 Q 485.5264,442.8101 486.21,442.1538 Q 486.9027,441.4976 487.4678,441.2697 Q 488.042,441.0327 488.4522,441.0327 Q 489.318,441.0327 489.9196,441.7984 Q 490.5303,442.564 490.5303,444.0041 Z"
+       id="path9092"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 499.1709,441.8166 Q 499.0524,441.9624 498.8701,442.2723 Q 498.6879,442.5822 498.4873,442.9195 Q 498.2868,443.2567 498.1136,443.4937 Q 497.9496,443.7307 497.8584,443.7307 Q 497.6306,443.7307 497.43,443.5575 Q 497.2295,443.3843 497.0381,443.2111 Q 496.8558,443.0288 496.6826,443.0288 Q 496.3636,443.0288 495.9626,443.4299 Q 495.5615,443.8218 495.1879,444.5145 Q 494.8142,445.1981 494.5589,446.0731 Q 494.3584,446.7567 494.2399,447.5132 Q 494.1214,448.2697 494.1488,448.9898 Q 493.9574,449.0718 493.5199,449.2723 Q 493.0824,449.4637 492.6631,449.6551 Q 492.2438,449.8557 492.0889,449.9377 L 491.7243,449.5822 Q 491.9886,448.288 492.2074,447.0301 Q 492.4261,445.7632 492.5537,444.7515 Q 492.6813,443.7307 492.6813,443.1838 Q 492.6813,442.7645 492.572,442.6734 Q 492.4626,442.5731 492.3076,442.5731 Q 492.18,442.5731 491.8793,442.6642 Q 491.5785,442.7463 491.4417,442.7918 L 491.2777,442.1812 Q 491.7972,441.9442 492.4626,441.6799 Q 493.1371,441.4155 493.7113,441.2241 Q 494.2855,441.0327 494.5043,441.0327 Q 494.7595,441.0327 494.8415,441.2241 Q 494.9326,441.4064 494.9326,441.9442 Q 494.9326,442.1356 494.878,442.5913 Q 494.8233,443.0379 494.7686,443.3843 Q 495.361,442.4273 495.835,441.9168 Q 496.3181,441.4064 496.7373,441.2241 Q 497.1566,441.0327 497.5485,441.0327 Q 497.8675,441.0327 498.3142,441.3426 Q 498.7699,441.6525 499.1709,441.8166 Z"
+       id="path9094"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 505.7334,442.6369 Q 505.7334,443.0379 505.542,443.521 Q 505.3597,444.0041 504.7764,444.5601 Q 504.1931,445.107 503.0173,445.7176 Q 501.8415,446.3283 499.8545,446.9663 L 499.7907,446.0184 Q 501.0394,445.5171 501.7686,445.1252 Q 502.5069,444.7241 502.8715,444.396 Q 503.236,444.0679 503.3454,443.7671 Q 503.4548,443.4572 503.4548,443.1109 Q 503.4548,442.6916 503.2634,442.482 Q 503.0811,442.2632 502.8259,442.2632 Q 502.6801,442.2632 502.3793,442.4181 Q 502.0785,442.5731 501.8506,442.8465 Q 501.3584,443.4208 501.0577,444.1682 Q 500.766,444.9155 500.766,445.9182 Q 500.766,447.1122 501.1761,447.8231 Q 501.5954,448.5249 502.1332,448.5249 Q 502.516,448.5249 503.2543,448.1695 Q 504.0017,447.814 505.1045,446.9299 Q 505.2048,446.9846 505.3506,447.2489 Q 505.4965,447.5132 505.5238,447.577 Q 504.029,448.8804 503.0538,449.409 Q 502.0785,449.9377 501.2673,449.9377 Q 500.766,449.9377 500.1462,449.6278 Q 499.5355,449.327 499.0889,448.6434 Q 498.6514,447.9507 498.6514,446.8023 Q 498.6514,445.3713 499.3168,444.1955 Q 499.9821,443.0106 501.1306,442.0536 Q 501.5407,441.7163 502.2699,441.3791 Q 503.0082,441.0327 503.7282,441.0327 Q 504.7582,441.0327 505.2413,441.5431 Q 505.7334,442.0445 505.7334,442.6369 Z"
+       id="path9096"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 515.0303,448.5978 Q 514.2556,449.1447 513.5629,449.5458 Q 512.8702,449.9377 512.5512,449.9377 Q 512.3324,449.9377 512.0316,449.7007 Q 511.74,449.4728 511.5212,448.8804 Q 511.3025,448.288 511.3025,447.2033 Q 511.3025,446.9937 511.3572,446.5288 Q 511.421,446.064 511.503,445.4715 Q 511.5941,444.8791 511.6944,444.2866 Q 511.7947,443.6942 511.8767,443.2293 Q 511.9587,442.7554 511.9952,442.5458 Q 512.0499,442.2632 512.4782,441.9898 Q 512.9066,441.7163 513.4535,441.4702 Q 514.0004,441.2241 514.4105,441.0327 L 514.6931,441.6252 Q 514.3923,441.8804 514.2647,442.09 Q 514.1371,442.2905 514.0095,442.9103 Q 513.7269,444.2137 513.572,445.3166 Q 513.4262,446.4103 513.4262,446.8114 Q 513.4262,447.4403 513.5538,447.8505 Q 513.6905,448.2515 513.9092,448.2515 Q 514.0915,448.2515 514.3012,448.2059 Q 514.5199,448.1512 514.8845,447.9963 Z M 514.1371,442.0809 Q 513.8819,442.2632 513.6449,442.6642 Q 513.4079,443.0653 513.2074,443.4025 Q 513.0069,443.7398 512.8428,443.7398 Q 512.7243,443.7398 512.5056,443.5301 Q 512.2868,443.3205 512.0043,443.0379 Q 511.7217,442.7554 511.4027,442.5458 Q 511.0928,442.327 510.792,442.327 Q 510.2178,442.327 509.7894,442.7098 Q 509.3611,443.0926 509.0785,443.6851 Q 508.7959,444.2684 508.6501,444.9247 Q 508.5134,445.5718 508.5134,446.1096 Q 508.5134,447.1304 508.7868,447.6408 Q 509.0603,448.1421 509.3975,448.1421 Q 509.6983,448.1421 510.2725,447.5588 Q 510.8558,446.9663 511.5759,445.8726 L 511.4118,447.6317 Q 511.029,448.1877 510.546,448.7163 Q 510.072,449.245 509.5525,449.5913 Q 509.042,449.9377 508.5225,449.9377 Q 508.085,449.9377 507.6019,449.6187 Q 507.1189,449.3088 506.7816,448.6161 Q 506.4444,447.9234 506.4444,446.784 Q 506.4444,445.3439 507.1553,444.0588 Q 507.8663,442.7736 509.1514,441.8895 Q 509.6436,441.5523 510.3363,441.2971 Q 511.029,441.0327 511.7947,441.0327 Q 512.2686,441.0327 512.7243,441.2879 Q 513.1892,441.534 513.5538,441.7984 Q 513.9275,442.0536 514.1371,442.0809 Z"
+       id="path9098"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 524.3728,441.7163 Q 524.3728,441.9898 523.5981,442.646 Q 522.8324,443.3023 521.4652,444.1317 L 519.5785,445.2892 L 518.3116,444.9702 L 520.171,443.5939 Q 520.9001,443.0562 521.283,442.7189 Q 521.6749,442.3817 521.6749,442.2085 Q 521.6749,441.9806 520.7908,442.0171 L 520.7178,441.3882 Q 521.4561,441.2788 522.1762,441.1877 Q 522.9054,441.0874 523.4796,441.0874 Q 524.0173,441.0874 524.1905,441.2515 Q 524.3728,441.4155 524.3728,441.7163 Z M 519.779,436.6486 Q 519.779,437.2319 519.6423,438.2801 Q 519.5056,439.3192 519.296,440.6043 Q 519.0955,441.8895 518.8676,443.2293 Q 518.6488,444.5601 518.4665,445.7541 Q 518.2934,446.9481 518.2113,447.8049 Q 518.1384,448.6616 518.2296,448.9715 Q 518.102,449.0353 517.8012,449.1721 Q 517.5095,449.3088 517.1632,449.4637 Q 516.8168,449.6187 516.5251,449.7463 Q 516.2335,449.8739 516.1241,449.9377 L 515.7322,449.5822 Q 515.7777,449.2359 515.9145,448.37 Q 516.0603,447.5041 516.2517,446.3374 Q 516.4522,445.1708 516.6527,443.8947 Q 516.8624,442.6096 517.0356,441.4064 Q 517.2178,440.2033 517.3272,439.2645 Q 517.4457,438.3257 517.4457,437.87 Q 517.4457,437.4142 517.3272,437.3231 Q 517.2178,437.2319 517.0082,437.2319 Q 516.8715,437.2319 516.5616,437.3322 Q 516.2517,437.4233 516.0876,437.478 L 515.9236,436.8491 Q 516.3064,436.676 516.8077,436.4845 Q 517.309,436.284 517.8012,436.1108 Q 518.3025,435.9286 518.6853,435.8192 Q 519.0772,435.7098 519.2413,435.7098 Q 519.4965,435.7098 519.6332,435.8556 Q 519.779,436.0015 519.779,436.6486 Z M 524.2179,448.534 Q 523.8168,448.8713 523.3429,449.1903 Q 522.8689,449.5093 522.4405,449.7098 Q 522.0121,449.9195 521.7478,449.9195 Q 521.3559,449.9195 520.9822,449.4911 Q 520.6085,449.0536 520.253,448.3882 Q 519.8975,447.7228 519.5694,447.021 Q 519.2413,446.3101 518.9223,445.745 Q 518.6124,445.1799 518.3116,444.9702 L 519.9249,444.478 Q 520.2439,444.6695 520.5447,445.107 Q 520.8546,445.5445 521.1462,446.0822 Q 521.4379,446.6109 521.7113,447.1122 Q 521.9848,447.6044 522.24,447.9325 Q 522.5043,448.2515 522.7504,448.2515 Q 522.9874,448.2515 523.3064,448.1877 Q 523.6254,448.1148 523.9262,447.9507 Z"
+       id="path9100"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 529.3494,438.0614 Q 529.3494,438.3986 529.158,438.7632 Q 528.9757,439.1187 528.6202,439.3739 Q 528.2647,439.62 527.7452,439.62 Q 527.2621,439.62 527.0343,439.3921 Q 526.8155,439.1551 526.8155,438.8452 Q 526.8155,438.5171 526.9978,438.1525 Q 527.1892,437.7879 527.5447,437.5327 Q 527.9093,437.2775 528.4106,437.2775 Q 528.9028,437.2775 529.1215,437.5145 Q 529.3494,437.7515 529.3494,438.0614 Z M 529.1397,448.5614 Q 528.5655,448.8986 527.9731,449.2176 Q 527.3806,449.5367 526.8611,449.7372 Q 526.3507,449.9377 526.0134,449.9377 Q 525.7126,449.9377 525.4939,449.646 Q 525.2751,449.3635 525.2751,448.8713 Q 525.2751,448.5432 525.3572,447.9598 Q 525.4392,447.3674 525.5668,446.6656 Q 525.6944,445.9546 525.822,445.2619 Q 525.9496,444.5601 526.0317,444.0041 Q 526.1137,443.4481 526.1137,443.1838 Q 526.1137,442.7645 526.0134,442.6734 Q 525.9132,442.5731 525.74,442.5731 Q 525.6306,442.5731 525.3663,442.646 Q 525.102,442.7189 524.9014,442.7918 L 524.7374,442.1812 Q 525.2478,441.9442 525.9041,441.6799 Q 526.5694,441.4155 527.1345,441.2241 Q 527.6996,441.0327 527.9275,441.0327 Q 528.1827,441.0327 528.3194,441.2059 Q 528.4653,441.3791 528.4653,441.7984 Q 528.4653,442.1174 528.3741,442.7189 Q 528.283,443.3114 528.1554,444.0405 Q 528.0278,444.7606 527.891,445.4898 Q 527.7634,446.2098 527.6723,446.8023 Q 527.5811,447.3947 527.5811,447.7137 Q 527.5811,448.2515 527.8546,448.2515 Q 528.1371,448.2515 528.365,448.1877 Q 528.602,448.1148 528.9666,447.9507 Z"
+       id="path9102"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 539.0382,448.5614 Q 538.4913,448.8895 537.8806,449.2085 Q 537.2791,449.5275 536.7504,449.7281 Q 536.2218,449.9377 535.921,449.9377 Q 535.602,449.9377 535.3924,449.646 Q 535.1827,449.3635 535.1827,448.8713 Q 535.1827,448.6799 535.2556,448.1786 Q 535.3285,447.6773 535.4379,447.021 Q 535.5564,446.3648 535.6658,445.7085 Q 535.7752,445.0432 535.8481,444.5145 Q 535.9301,443.9767 535.9301,443.7307 Q 535.9301,443.1929 535.8299,442.9833 Q 535.7387,442.7645 535.447,442.7645 Q 535.2009,442.7645 534.6267,443.0926 Q 534.0525,443.4208 533.5239,444.2775 Q 533.2504,444.7059 533.0955,445.3257 Q 532.9496,445.9364 532.7947,446.8205 Q 532.6489,447.6317 532.6033,448.0965 Q 532.5668,448.5523 532.5851,448.9898 Q 532.4575,449.0445 532.1658,449.1721 Q 531.8832,449.2997 531.546,449.4546 Q 531.2088,449.6096 530.9171,449.7372 Q 530.6345,449.8739 530.5252,449.9377 L 530.1606,449.5822 Q 530.3429,448.6799 530.516,447.6955 Q 530.6892,446.702 530.8259,445.7906 Q 530.9627,444.8791 531.0447,444.1864 Q 531.1267,443.4846 531.1267,443.1655 Q 531.1267,442.7463 531.0356,442.6551 Q 530.9444,442.5549 530.7804,442.5549 Q 530.6528,442.5549 530.3337,442.646 Q 530.0239,442.7372 529.878,442.7918 L 529.7048,442.1629 Q 530.0877,441.9989 530.5798,441.8075 Q 531.0811,441.6069 531.5642,441.4338 Q 532.0564,441.2515 532.4301,441.1421 Q 532.8038,441.0327 532.9405,441.0327 Q 533.1957,441.0327 533.2778,441.2241 Q 533.3689,441.4155 533.3689,442.0627 Q 533.3689,442.5002 533.3051,442.9741 Q 534.2986,441.9898 535.2647,441.5158 Q 536.2309,441.0327 537.0512,441.0327 Q 537.6254,441.0327 537.9353,441.3153 Q 538.2543,441.5978 538.2543,442.482 Q 538.2543,442.9559 538.1358,443.6851 Q 538.0174,444.4051 537.8624,445.1981 Q 537.7166,445.982 537.5981,446.6656 Q 537.4796,447.34 537.4796,447.7137 Q 537.4796,448.0236 537.5616,448.1421 Q 537.6437,448.2515 537.8077,448.2515 Q 538.0174,448.2515 538.2361,448.1877 Q 538.4549,448.1148 538.8012,447.9507 Z"
+       id="path9104"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 547.2687,442.09 Q 547.0043,442.2723 546.7674,442.6825 Q 546.5395,443.0835 546.339,443.4299 Q 546.1476,443.7762 546.0017,443.7762 Q 545.8741,443.7762 545.6372,443.5575 Q 545.4093,443.3387 545.1176,443.0562 Q 544.8351,442.7645 544.5161,442.5458 Q 544.1971,442.327 543.9054,442.327 Q 543.3312,442.327 542.8937,442.7098 Q 542.4653,443.0926 542.1736,443.6851 Q 541.8911,444.2684 541.7452,444.9247 Q 541.6085,445.5718 541.6085,446.1096 Q 541.6085,447.1304 541.8728,447.6408 Q 542.1463,448.1421 542.5473,448.1421 Q 542.7752,448.1421 543.3859,447.5588 Q 543.9965,446.9754 544.8989,445.4351 L 544.7804,447.2307 Q 544.0421,448.37 543.2309,449.1538 Q 542.4288,449.9377 541.6176,449.9377 Q 541.2166,449.9377 540.7244,449.6187 Q 540.2322,449.3088 539.8767,448.6161 Q 539.5213,447.9234 539.5213,446.784 Q 539.5213,445.3439 540.214,444.0679 Q 540.9067,442.7827 542.2556,441.8895 Q 542.7661,441.5523 543.4497,441.2971 Q 544.1333,441.0327 544.9536,441.0327 Q 545.3637,441.0327 545.8103,441.2879 Q 546.2661,441.5431 546.658,441.8075 Q 547.0499,442.0627 547.2687,442.09 Z M 547.8611,441.6252 Q 547.5512,441.8804 547.3689,442.2541 Q 547.1866,442.6278 547.1137,443.284 Q 546.9405,444.7241 546.8859,445.7814 Q 546.8312,446.8387 546.7765,447.732 Q 546.7309,448.6161 546.5668,449.5549 Q 546.4028,450.5028 545.9015,451.3322 Q 545.4002,452.1617 544.6984,452.7814 Q 543.9965,453.4104 543.2127,453.7658 Q 542.4379,454.1213 541.727,454.1213 Q 541.1163,454.1213 540.4965,453.9481 Q 539.8858,453.7841 539.4757,453.538 Q 539.0746,453.301 539.0746,453.0822 Q 539.0746,452.9364 539.2478,452.6812 Q 539.4119,452.426 539.6398,452.1617 Q 539.8676,451.9064 540.0681,451.7242 Q 540.2687,451.551 540.3325,451.551 Q 540.4692,451.551 540.7153,451.8062 Q 540.9614,452.0614 541.3989,452.3075 Q 541.8364,452.5627 542.5564,452.5627 Q 543.2309,452.5627 543.7049,452.0341 Q 544.1788,451.5145 544.434,450.0015 Q 544.5981,449.09 544.6437,448.3518 Q 544.6892,447.6044 544.6984,446.8843 Q 544.7166,446.1642 544.7713,445.3439 Q 544.826,444.5145 545.0083,443.439 Q 545.1085,442.7827 545.5642,442.3088 Q 546.0291,441.8348 546.5851,441.5249 Q 547.1411,441.2059 547.5421,441.0327 Z"
+       id="path9106"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 558.9354,441.8713 Q 558.7257,442.1447 558.4523,442.482 Q 558.1788,442.8101 557.9328,443.0471 Q 557.6958,443.284 557.5773,443.284 Q 557.4315,443.284 557.2492,443.1017 Q 557.076,442.9195 556.8481,442.6825 Q 556.6294,442.4364 556.3559,442.2541 Q 556.0916,442.0718 555.7635,442.0718 Q 555.2622,442.0718 554.9887,442.3361 Q 554.7244,442.6004 554.7244,443.0288 Q 554.7244,443.4572 555.0981,443.7762 Q 555.4718,444.0952 556.2101,444.4689 Q 556.7023,444.7241 557.1671,445.0523 Q 557.632,445.3713 557.9236,445.827 Q 558.2244,446.2827 558.2244,446.9299 Q 558.2244,447.5588 557.8416,448.1057 Q 557.4679,448.6525 556.8663,449.0627 Q 556.2739,449.4728 555.5903,449.7007 Q 554.9158,449.9377 554.3234,449.9377 Q 553.5486,449.9377 552.9288,449.6916 Q 552.309,449.4546 551.9445,449.1265 Q 551.5799,448.7893 551.5799,448.534 Q 551.5799,448.4064 551.7075,448.133 Q 551.8351,447.8596 552.0174,447.5679 Q 552.1997,447.2671 552.3728,447.0575 Q 552.5551,446.8478 552.6463,446.8478 Q 552.7648,446.8478 552.9197,447.1395 Q 553.0747,447.4312 553.3208,447.8231 Q 553.5669,448.2059 553.9497,448.4976 Q 554.3416,448.7893 554.9158,448.7893 Q 555.5083,448.7893 555.8546,448.4611 Q 556.2101,448.1239 556.2101,447.5952 Q 556.2101,446.9754 555.6359,446.5288 Q 555.0708,446.0731 554.3872,445.7267 Q 553.421,445.2437 553.0747,444.7241 Q 552.7374,444.1955 552.7374,443.6122 Q 552.7374,443.0379 553.0656,442.564 Q 553.3937,442.09 553.9223,441.7528 Q 554.4601,441.4064 555.0708,441.2241 Q 555.6814,441.0327 556.2466,441.0327 Q 556.8937,441.0327 557.3585,441.215 Q 557.8234,441.3973 558.188,441.5978 Q 558.5617,441.7984 558.9354,441.8713 Z"
+       id="path9108"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 567.6672,443.8491 Q 567.6672,444.9155 567.3026,446.0731 Q 566.9471,447.2307 566.4458,448.051 Q 566.1724,448.5067 565.7895,448.9442 Q 565.4158,449.3726 564.9601,449.6551 Q 564.5135,449.9377 564.0213,449.9377 Q 563.52,449.9377 562.8638,449.409 Q 562.2075,448.8804 561.6333,448.0236 L 561.9158,446.8114 Q 562.0981,447.1395 562.4445,447.4403 Q 562.8,447.732 563.201,447.9234 Q 563.602,448.1148 563.921,448.1148 Q 564.3039,448.1148 564.6046,447.8869 Q 564.9145,447.659 565.0877,447.2945 Q 565.3156,446.8114 565.4158,446.1369 Q 565.5161,445.4624 565.5161,444.7788 Q 565.5161,443.8127 565.2336,443.2293 Q 564.951,442.6369 564.6138,442.6369 Q 564.395,442.6369 563.9757,442.9195 Q 563.5656,443.202 563.0916,443.7489 Q 562.6268,444.2958 562.2348,445.0705 L 562.171,443.4846 Q 562.9731,442.4546 563.5929,441.926 Q 564.2127,441.3973 564.714,441.215 Q 565.2244,441.0327 565.6711,441.0327 Q 566.4823,441.0327 567.0747,441.7619 Q 567.6672,442.482 567.6672,443.8491 Z M 562.7726,441.6343 Q 562.7726,442.0262 562.6359,442.9103 Q 562.5083,443.7945 562.2348,445.3895 Q 561.9705,446.9846 561.5604,449.5093 Q 561.2596,451.3869 561.1867,452.2163 Q 561.1138,453.0458 561.2049,453.2919 Q 561.0682,453.3283 560.7674,453.4377 Q 560.4757,453.5471 560.1294,453.6838 Q 559.783,453.8296 559.4914,453.9481 Q 559.2088,454.0666 559.0903,454.1213 L 558.7257,453.7841 Q 558.7713,453.4377 558.9171,452.6356 Q 559.0539,451.8335 559.2453,450.7671 Q 559.4458,449.7007 559.6554,448.5432 Q 559.8651,447.3856 560.0382,446.3101 Q 560.2205,445.2254 560.3299,444.396 Q 560.4484,443.5666 560.4484,443.1838 Q 560.4484,442.7645 560.3117,442.6734 Q 560.1749,442.5731 560.02,442.5731 Q 559.9015,442.5731 559.6098,442.6551 Q 559.3182,442.7372 559.1723,442.7918 L 559.0083,442.1812 Q 559.546,441.926 560.2296,441.6616 Q 560.9132,441.3973 561.4875,441.215 Q 562.0617,441.0327 562.2804,441.0327 Q 562.5083,441.0327 562.6359,441.1603 Q 562.7726,441.2788 562.7726,441.6343 Z"
+       id="path9110"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 577.1919,448.5978 Q 576.4172,449.1447 575.7245,449.5458 Q 575.0317,449.9377 574.7127,449.9377 Q 574.494,449.9377 574.1932,449.7007 Q 573.9015,449.4728 573.6828,448.8804 Q 573.464,448.288 573.464,447.2033 Q 573.464,446.9937 573.5187,446.5288 Q 573.5825,446.064 573.6646,445.4715 Q 573.7557,444.8791 573.856,444.2866 Q 573.9562,443.6942 574.0383,443.2293 Q 574.1203,442.7554 574.1567,442.5458 Q 574.2114,442.2632 574.6398,441.9898 Q 575.0682,441.7163 575.6151,441.4702 Q 576.162,441.2241 576.5721,441.0327 L 576.8547,441.6252 Q 576.5539,441.8804 576.4263,442.09 Q 576.2987,442.2905 576.1711,442.9103 Q 575.8885,444.2137 575.7336,445.3166 Q 575.5877,446.4103 575.5877,446.8114 Q 575.5877,447.4403 575.7153,447.8505 Q 575.8521,448.2515 576.0708,448.2515 Q 576.2531,448.2515 576.4627,448.2059 Q 576.6815,448.1512 577.0461,447.9963 Z M 576.2987,442.0809 Q 576.0435,442.2632 575.8065,442.6642 Q 575.5695,443.0653 575.369,443.4025 Q 575.1685,443.7398 575.0044,443.7398 Q 574.8859,443.7398 574.6672,443.5301 Q 574.4484,443.3205 574.1659,443.0379 Q 573.8833,442.7554 573.5643,442.5458 Q 573.2544,442.327 572.9536,442.327 Q 572.3794,442.327 571.951,442.7098 Q 571.5226,443.0926 571.2401,443.6851 Q 570.9575,444.2684 570.8117,444.9247 Q 570.675,445.5718 570.675,446.1096 Q 570.675,447.1304 570.9484,447.6408 Q 571.2218,448.1421 571.5591,448.1421 Q 571.8599,448.1421 572.4341,447.5588 Q 573.0174,446.9663 573.7375,445.8726 L 573.5734,447.6317 Q 573.1906,448.1877 572.7075,448.7163 Q 572.2336,449.245 571.714,449.5913 Q 571.2036,449.9377 570.6841,449.9377 Q 570.2466,449.9377 569.7635,449.6187 Q 569.2804,449.3088 568.9432,448.6161 Q 568.6059,447.9234 568.6059,446.784 Q 568.6059,445.3439 569.3169,444.0588 Q 570.0278,442.7736 571.313,441.8895 Q 571.8052,441.5523 572.4979,441.2971 Q 573.1906,441.0327 573.9562,441.0327 Q 574.4302,441.0327 574.8859,441.2879 Q 575.3508,441.534 575.7153,441.7984 Q 576.089,442.0536 576.2987,442.0809 Z"
+       id="path9112"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 585.5044,442.0627 Q 585.2492,442.3179 584.8755,442.6551 Q 584.5018,442.9833 584.1463,443.2293 Q 583.7909,443.4663 583.5995,443.4663 Q 583.4081,443.4663 583.1984,443.1838 Q 582.9888,442.9012 582.7245,442.6187 Q 582.4601,442.327 582.1047,442.327 Q 581.4393,442.327 580.9836,442.9012 Q 580.5278,443.4663 580.2817,444.3231 Q 580.0448,445.1708 580.0448,446.0275 Q 580.0448,447.2033 580.4094,447.8687 Q 580.7831,448.5249 581.3573,448.5249 Q 581.8403,448.5249 582.5331,448.1695 Q 583.2349,447.8049 584.2101,447.0028 Q 584.2831,447.0939 584.4471,447.34 Q 584.6203,447.577 584.6568,447.6499 Q 583.2258,448.9442 582.2505,449.4455 Q 581.2844,449.9377 580.464,449.9377 Q 579.9445,449.9377 579.3429,449.646 Q 578.7505,449.3544 578.3221,448.6343 Q 577.8937,447.9051 577.8937,446.6291 Q 577.8937,445.3986 578.4315,444.159 Q 578.9784,442.9195 580.3182,442.0262 Q 580.8286,441.689 581.6307,441.3609 Q 582.4328,441.0327 583.1984,441.0327 Q 583.7362,441.0327 584.1281,441.2515 Q 584.52,441.4611 584.8482,441.7163 Q 585.1763,441.9624 585.5044,442.0627 Z"
+       id="path9114"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 592.7232,442.6369 Q 592.7232,443.0379 592.5318,443.521 Q 592.3495,444.0041 591.7661,444.5601 Q 591.1828,445.107 590.007,445.7176 Q 588.8312,446.3283 586.8443,446.9663 L 586.7805,446.0184 Q 588.0292,445.5171 588.7583,445.1252 Q 589.4966,444.7241 589.8612,444.396 Q 590.2258,444.0679 590.3352,443.7671 Q 590.4445,443.4572 590.4445,443.1109 Q 590.4445,442.6916 590.2531,442.482 Q 590.0708,442.2632 589.8156,442.2632 Q 589.6698,442.2632 589.369,442.4181 Q 589.0682,442.5731 588.8404,442.8465 Q 588.3482,443.4208 588.0474,444.1682 Q 587.7557,444.9155 587.7557,445.9182 Q 587.7557,447.1122 588.1659,447.8231 Q 588.5851,448.5249 589.1229,448.5249 Q 589.5057,448.5249 590.244,448.1695 Q 590.9914,447.814 592.0943,446.9299 Q 592.1945,446.9846 592.3404,447.2489 Q 592.4862,447.5132 592.5135,447.577 Q 591.0187,448.8804 590.0435,449.409 Q 589.0682,449.9377 588.257,449.9377 Q 587.7557,449.9377 587.1359,449.6278 Q 586.5253,449.327 586.0786,448.6434 Q 585.6411,447.9507 585.6411,446.8023 Q 585.6411,445.3713 586.3065,444.1955 Q 586.9719,443.0106 588.1203,442.0536 Q 588.5305,441.7163 589.2596,441.3791 Q 589.9979,441.0327 590.718,441.0327 Q 591.7479,441.0327 592.231,441.5431 Q 592.7232,442.0445 592.7232,442.6369 Z"
+       id="path9116"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 452.486,406.0839 Q 452.486,406.4211 452.2946,406.7857 Q 452.1123,407.1412 451.7568,407.3964 Q 451.4014,407.6425 450.8818,407.6425 Q 450.3987,407.6425 450.1709,407.4146 Q 449.9521,407.1776 449.9521,406.8677 Q 449.9521,406.5396 450.1344,406.175 Q 450.3258,405.8104 450.6813,405.5552 Q 451.0459,405.3 451.5472,405.3 Q 452.0394,405.3 452.2581,405.537 Q 452.486,405.774 452.486,406.0839 Z M 452.2764,416.5839 Q 451.7021,416.9211 451.1097,417.2401 Q 450.5172,417.5591 449.9977,417.7597 Q 449.4873,417.9602 449.15,417.9602 Q 448.8493,417.9602 448.6305,417.6685 Q 448.4118,417.386 448.4118,416.8938 Q 448.4118,416.5657 448.4938,415.9823 Q 448.5758,415.3899 448.7034,414.688 Q 448.831,413.9771 448.9586,413.2844 Q 449.0862,412.5826 449.1683,412.0266 Q 449.2503,411.4706 449.2503,411.2063 Q 449.2503,410.787 449.15,410.6958 Q 449.0498,410.5956 448.8766,410.5956 Q 448.7672,410.5956 448.5029,410.6685 Q 448.2386,410.7414 448.0381,410.8143 L 447.874,410.2037 Q 448.3844,409.9667 449.0407,409.7024 Q 449.706,409.438 450.2711,409.2466 Q 450.8362,409.0552 451.0641,409.0552 Q 451.3193,409.0552 451.456,409.2284 Q 451.6019,409.4016 451.6019,409.8208 Q 451.6019,410.1399 451.5107,410.7414 Q 451.4196,411.3339 451.292,412.063 Q 451.1644,412.7831 451.0277,413.5123 Q 450.9001,414.2323 450.8089,414.8248 Q 450.7178,415.4172 450.7178,415.7362 Q 450.7178,416.274 450.9912,416.274 Q 451.2737,416.274 451.5016,416.2102 Q 451.7386,416.1373 452.1032,415.9732 Z"
+       id="path9119"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 461.555,416.6386 Q 460.7803,417.1581 460.0785,417.5591 Q 459.3857,417.9602 459.0303,417.9602 Q 458.8024,417.9602 458.5107,417.705 Q 458.2282,417.4589 458.0186,416.8573 Q 457.8089,416.2466 457.8089,415.1985 Q 457.8089,414.925 457.9001,414.2505 Q 457.9912,413.5761 458.137,412.6646 Q 458.2829,411.7531 458.4469,410.7505 Q 458.611,409.7479 458.7477,408.7909 Q 458.8936,407.8339 458.9847,407.0682 Q 459.085,406.2935 459.085,405.8651 Q 459.085,405.4458 458.9574,405.3547 Q 458.8389,405.2544 458.6748,405.2544 Q 458.5563,405.2544 458.2738,405.3365 Q 457.9912,405.4185 457.7633,405.5005 L 457.6175,404.8716 Q 458.2373,404.5708 458.8844,404.3156 Q 459.5316,404.0513 460.042,403.8964 Q 460.5615,403.7323 460.7803,403.7323 Q 461.0811,403.7323 461.2451,403.8964 Q 461.4183,404.0604 461.4183,404.4797 Q 461.4183,404.9537 461.3089,405.774 Q 461.1995,406.5943 461.0264,407.606 Q 460.8623,408.6177 460.6709,409.6932 Q 460.4886,410.7688 460.3154,411.7623 Q 460.1514,412.7557 460.042,413.5396 Q 459.9326,414.3143 459.9326,414.7245 Q 459.9326,416.2558 460.4157,416.2558 Q 460.6436,416.2558 460.8623,416.2102 Q 461.0811,416.1555 461.4001,416.0188 Z M 460.443,410.3313 L 459.3402,411.9172 Q 459.1761,411.9172 458.9482,411.6893 Q 458.7295,411.4524 458.4652,411.1425 Q 458.2008,410.8235 457.8818,410.5865 Q 457.5719,410.3495 457.2165,410.3495 Q 456.6422,410.3495 456.2139,410.7323 Q 455.7946,411.1151 455.512,411.7076 Q 455.2386,412.2909 455.1019,412.9472 Q 454.9652,413.5943 454.9652,414.1321 Q 454.9652,415.1529 455.2477,415.6633 Q 455.5303,416.1646 455.9131,416.1646 Q 456.1865,416.1646 456.7334,415.6451 Q 457.2894,415.1255 458.0915,413.8404 L 457.8818,415.6724 Q 457.1436,416.7753 456.387,417.3677 Q 455.6396,417.9602 455.0016,417.9602 Q 454.5185,417.9602 454.0355,417.6229 Q 453.5524,417.2857 453.2243,416.5657 Q 452.8961,415.8456 452.8961,414.7154 Q 452.8961,413.2753 453.5889,412.0266 Q 454.2816,410.7688 455.5758,409.912 Q 456.0771,409.5839 456.779,409.3195 Q 457.4899,409.0552 458.1553,409.0552 Q 458.4105,409.0552 458.7021,409.2466 Q 458.9938,409.438 459.2946,409.6932 Q 459.5954,409.9485 459.887,410.1399 Q 460.1787,410.3313 460.443,410.3313 Z"
+       id="path9121"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 469.348,410.6594 Q 469.348,411.0604 469.1566,411.5435 Q 468.9743,412.0266 468.391,412.5826 Q 467.8076,413.1294 466.6319,413.7401 Q 465.4561,414.3508 463.4691,414.9888 L 463.4053,414.0409 Q 464.654,413.5396 465.3831,413.1477 Q 466.1214,412.7466 466.486,412.4185 Q 466.8506,412.0904 466.96,411.7896 Q 467.0694,411.4797 467.0694,411.1334 Q 467.0694,410.7141 466.8779,410.5044 Q 466.6957,410.2857 466.4404,410.2857 Q 466.2946,410.2857 465.9938,410.4406 Q 465.693,410.5956 465.4652,410.869 Q 464.973,411.4432 464.6722,412.1906 Q 464.3805,412.938 464.3805,413.9406 Q 464.3805,415.1347 464.7907,415.8456 Q 465.21,416.5474 465.7477,416.5474 Q 466.1305,416.5474 466.8688,416.192 Q 467.6162,415.8365 468.7191,414.9524 Q 468.8194,415.0071 468.9652,415.2714 Q 469.111,415.5357 469.1384,415.5995 Q 467.6436,416.9029 466.6683,417.4315 Q 465.693,417.9602 464.8818,417.9602 Q 464.3805,417.9602 463.7608,417.6503 Q 463.1501,417.3495 462.7035,416.6659 Q 462.266,415.9732 462.266,414.8248 Q 462.266,413.3938 462.9313,412.218 Q 463.5967,411.0331 464.7451,410.0761 Q 465.1553,409.7388 465.8845,409.4016 Q 466.6227,409.0552 467.3428,409.0552 Q 468.3727,409.0552 468.8558,409.5656 Q 469.348,410.0669 469.348,410.6594 Z"
+       id="path9123"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 477.6514,412.4914 Q 477.6514,413.7037 477.0498,414.9433 Q 476.4483,416.1737 475.4274,417.0123 Q 474.9535,417.4042 474.2972,417.6776 Q 473.6501,417.9602 473.1032,417.9602 Q 472.1553,417.9602 471.4717,417.5045 Q 470.7881,417.0396 470.4235,416.2466 Q 470.0589,415.4446 470.0589,414.4511 Q 470.0589,413.1477 470.5785,412.0084 Q 471.1071,410.869 472.3285,409.9302 Q 472.8024,409.5656 473.4496,409.3104 Q 474.0967,409.0552 474.7074,409.0552 Q 476.1384,409.0552 476.8949,410.0214 Q 477.6514,410.9784 477.6514,412.4914 Z M 475.5277,413.2024 Q 475.5277,411.8169 475.0902,411.0695 Q 474.6618,410.3222 474.0785,410.3222 Q 473.3767,410.3222 472.9574,410.8599 Q 472.5472,411.3977 472.3649,412.1906 Q 472.1918,412.9745 472.1918,413.7492 Q 472.1918,414.5604 472.4105,415.244 Q 472.6384,415.9185 472.9847,416.3196 Q 473.3402,416.7206 473.723,416.7206 Q 474.2243,416.7206 474.5707,416.3925 Q 474.917,416.0552 475.1267,415.5266 Q 475.3363,414.9888 475.4274,414.3781 Q 475.5277,413.7675 475.5277,413.2024 Z"
+       id="path9125"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 486.0095,410.1125 Q 485.7452,410.2948 485.5082,410.705 Q 485.2803,411.106 485.0798,411.4524 Q 484.8884,411.7987 484.7426,411.7987 Q 484.615,411.7987 484.378,411.58 Q 484.1501,411.3612 483.8584,411.0787 Q 483.5759,410.787 483.2569,410.5682 Q 482.9379,410.3495 482.6462,410.3495 Q 482.072,410.3495 481.6345,410.7323 Q 481.2061,411.1151 480.9144,411.7076 Q 480.6319,412.2909 480.486,412.9472 Q 480.3493,413.5943 480.3493,414.1321 Q 480.3493,415.1529 480.6136,415.6633 Q 480.8871,416.1646 481.2881,416.1646 Q 481.516,416.1646 482.1267,415.5813 Q 482.7373,414.9979 483.6397,413.4576 L 483.5212,415.2531 Q 482.7829,416.3925 481.9717,417.1763 Q 481.1696,417.9602 480.3584,417.9602 Q 479.9574,417.9602 479.4652,417.6412 Q 478.973,417.3313 478.6175,416.6386 Q 478.2621,415.9459 478.2621,414.8065 Q 478.2621,413.3664 478.9548,412.0904 Q 479.6475,410.8052 480.9965,409.912 Q 481.5069,409.5748 482.1905,409.3195 Q 482.8741,409.0552 483.6944,409.0552 Q 484.1045,409.0552 484.5512,409.3104 Q 485.0069,409.5656 485.3988,409.83 Q 485.7907,410.0852 486.0095,410.1125 Z M 486.6019,409.6477 Q 486.292,409.9029 486.1097,410.2766 Q 485.9275,410.6503 485.8545,411.3065 Q 485.6814,412.7466 485.6267,413.8039 Q 485.572,414.8612 485.5173,415.7545 Q 485.4717,416.6386 485.3077,417.5774 Q 485.1436,418.5253 484.6423,419.3547 Q 484.141,420.1841 483.4392,420.8039 Q 482.7373,421.4328 481.9535,421.7883 Q 481.1788,422.1438 480.4678,422.1438 Q 479.8571,422.1438 479.2373,421.9706 Q 478.6267,421.8065 478.2165,421.5605 Q 477.8155,421.3235 477.8155,421.1047 Q 477.8155,420.9589 477.9886,420.7037 Q 478.1527,420.4485 478.3806,420.1841 Q 478.6084,419.9289 478.809,419.7466 Q 479.0095,419.5735 479.0733,419.5735 Q 479.21,419.5735 479.4561,419.8287 Q 479.7022,420.0839 480.1397,420.33 Q 480.5772,420.5852 481.2972,420.5852 Q 481.9717,420.5852 482.4457,420.0565 Q 482.9196,419.537 483.1748,418.024 Q 483.3389,417.1125 483.3845,416.3742 Q 483.4301,415.6268 483.4392,414.9068 Q 483.4574,414.1867 483.5121,413.3664 Q 483.5668,412.537 483.7491,411.4615 Q 483.8493,410.8052 484.3051,410.3313 Q 484.7699,409.8573 485.3259,409.5474 Q 485.8819,409.2284 486.2829,409.0552 Z"
+       id="path9127"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 494.8871,409.8391 Q 494.7686,409.9849 494.5863,410.2948 Q 494.404,410.6047 494.2035,410.9419 Q 494.003,411.2792 493.8298,411.5162 Q 493.6658,411.7531 493.5746,411.7531 Q 493.3467,411.7531 493.1462,411.58 Q 492.9457,411.4068 492.7543,411.2336 Q 492.572,411.0513 492.3988,411.0513 Q 492.0798,411.0513 491.6788,411.4524 Q 491.2777,411.8443 490.904,412.537 Q 490.5303,413.2206 490.2751,414.0956 Q 490.0746,414.7792 489.9561,415.5357 Q 489.8376,416.2922 489.865,417.0123 Q 489.6736,417.0943 489.2361,417.2948 Q 488.7986,417.4862 488.3793,417.6776 Q 487.96,417.8782 487.8051,417.9602 L 487.4405,417.6047 Q 487.7048,416.3104 487.9236,415.0526 Q 488.1423,413.7857 488.2699,412.774 Q 488.3975,411.7531 488.3975,411.2063 Q 488.3975,410.787 488.2881,410.6958 Q 488.1788,410.5956 488.0238,410.5956 Q 487.8962,410.5956 487.5954,410.6867 Q 487.2946,410.7688 487.1579,410.8143 L 486.9939,410.2037 Q 487.5134,409.9667 488.1788,409.7024 Q 488.8532,409.438 489.4275,409.2466 Q 490.0017,409.0552 490.2204,409.0552 Q 490.4756,409.0552 490.5577,409.2466 Q 490.6488,409.4289 490.6488,409.9667 Q 490.6488,410.1581 490.5941,410.6138 Q 490.5394,411.0604 490.4848,411.4068 Q 491.0772,410.4498 491.5512,409.9393 Q 492.0342,409.4289 492.4535,409.2466 Q 492.8728,409.0552 493.2647,409.0552 Q 493.5837,409.0552 494.0303,409.3651 Q 494.4861,409.675 494.8871,409.8391 Z"
+       id="path9129"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 503.309,416.6203 Q 502.5343,417.1672 501.8415,417.5683 Q 501.1488,417.9602 500.8298,417.9602 Q 500.6111,417.9602 500.3103,417.7232 Q 500.0186,417.4953 499.7999,416.9029 Q 499.5811,416.3104 499.5811,415.2258 Q 499.5811,415.0162 499.6358,414.5513 Q 499.6996,414.0865 499.7816,413.494 Q 499.8728,412.9016 499.9731,412.3091 Q 500.0733,411.7167 500.1553,411.2518 Q 500.2374,410.7779 500.2738,410.5682 Q 500.3285,410.2857 500.7569,410.0123 Q 501.1853,409.7388 501.7322,409.4927 Q 502.279,409.2466 502.6892,409.0552 L 502.9718,409.6477 Q 502.671,409.9029 502.5434,410.1125 Q 502.4158,410.313 502.2882,410.9328 Q 502.0056,412.2362 501.8507,413.3391 Q 501.7048,414.4328 501.7048,414.8339 Q 501.7048,415.4628 501.8324,415.8729 Q 501.9692,416.274 502.1879,416.274 Q 502.3702,416.274 502.5798,416.2284 Q 502.7986,416.1737 503.1632,416.0188 Z M 502.4158,410.1034 Q 502.1606,410.2857 501.9236,410.6867 Q 501.6866,411.0878 501.4861,411.425 Q 501.2856,411.7623 501.1215,411.7623 Q 501.003,411.7623 500.7843,411.5526 Q 500.5655,411.343 500.283,411.0604 Q 500.0004,410.7779 499.6814,410.5682 Q 499.3715,410.3495 499.0707,410.3495 Q 498.4965,410.3495 498.0681,410.7323 Q 497.6397,411.1151 497.3572,411.7076 Q 497.0746,412.2909 496.9288,412.9472 Q 496.7921,413.5943 496.7921,414.1321 Q 496.7921,415.1529 497.0655,415.6633 Q 497.3389,416.1646 497.6762,416.1646 Q 497.977,416.1646 498.5512,415.5813 Q 499.1345,414.9888 499.8546,413.8951 L 499.6905,415.6542 Q 499.3077,416.2102 498.8246,416.7388 Q 498.3507,417.2675 497.8311,417.6138 Q 497.3207,417.9602 496.8012,417.9602 Q 496.3637,417.9602 495.8806,417.6412 Q 495.3975,417.3313 495.0603,416.6386 Q 494.723,415.9459 494.723,414.8065 Q 494.723,413.3664 495.434,412.0813 Q 496.1449,410.7961 497.4301,409.912 Q 497.9223,409.5748 498.615,409.3195 Q 499.3077,409.0552 500.0733,409.0552 Q 500.5473,409.0552 501.003,409.3104 Q 501.4678,409.5565 501.8324,409.8208 Q 502.2061,410.0761 502.4158,410.1034 Z"
+       id="path9131"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 512.1137,411.8716 Q 512.1137,412.938 511.7491,414.0956 Q 511.3936,415.2531 510.8923,416.0735 Q 510.6189,416.5292 510.2361,416.9667 Q 509.8624,417.3951 509.4067,417.6776 Q 508.9601,417.9602 508.4679,417.9602 Q 507.9666,417.9602 507.3103,417.4315 Q 506.6541,416.9029 506.0798,416.0461 L 506.3624,414.8339 Q 506.5447,415.162 506.891,415.4628 Q 507.2465,415.7545 507.6475,415.9459 Q 508.0486,416.1373 508.3676,416.1373 Q 508.7504,416.1373 509.0512,415.9094 Q 509.3611,415.6815 509.5343,415.317 Q 509.7621,414.8339 509.8624,414.1594 Q 509.9627,413.4849 509.9627,412.8013 Q 509.9627,411.8352 509.6801,411.2518 Q 509.3976,410.6594 509.0603,410.6594 Q 508.8416,410.6594 508.4223,410.9419 Q 508.0121,411.2245 507.5382,411.7714 Q 507.0733,412.3182 506.6814,413.093 L 506.6176,411.507 Q 507.4197,410.4771 508.0395,409.9485 Q 508.6593,409.4198 509.1606,409.2375 Q 509.671,409.0552 510.1176,409.0552 Q 510.9288,409.0552 511.5213,409.7844 Q 512.1137,410.5044 512.1137,411.8716 Z M 507.2192,409.6568 Q 507.2192,410.0487 507.0824,410.9328 Q 506.9548,411.8169 506.6814,413.412 Q 506.4171,415.0071 506.0069,417.5318 Q 505.7061,419.4094 505.6332,420.2388 Q 505.5603,421.0683 505.6515,421.3144 Q 505.5147,421.3508 505.214,421.4602 Q 504.9223,421.5696 504.5759,421.7063 Q 504.2296,421.8521 503.9379,421.9706 Q 503.6554,422.0891 503.5369,422.1438 L 503.1723,421.8065 Q 503.2179,421.4602 503.3637,420.6581 Q 503.5004,419.856 503.6918,418.7896 Q 503.8923,417.7232 504.102,416.5657 Q 504.3116,415.4081 504.4848,414.3326 Q 504.6671,413.2479 504.7764,412.4185 Q 504.8949,411.5891 504.8949,411.2063 Q 504.8949,410.787 504.7582,410.6958 Q 504.6215,410.5956 504.4666,410.5956 Q 504.3481,410.5956 504.0564,410.6776 Q 503.7647,410.7597 503.6189,410.8143 L 503.4548,410.2037 Q 503.9926,409.9485 504.6762,409.6841 Q 505.3598,409.4198 505.934,409.2375 Q 506.5082,409.0552 506.727,409.0552 Q 506.9548,409.0552 507.0824,409.1828 Q 507.2192,409.3013 507.2192,409.6568 Z"
+       id="path9133"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 522.2583,416.5839 Q 521.6931,416.912 521.0825,417.231 Q 520.4718,417.55 519.934,417.7505 Q 519.4054,417.9602 519.0681,417.9602 Q 518.8038,417.9602 518.5942,417.6685 Q 518.3845,417.386 518.3845,416.8938 Q 518.3754,416.7024 518.4483,416.2011 Q 518.5304,415.6998 518.6398,415.0435 Q 518.7491,414.3873 518.8494,413.731 Q 518.9588,413.0656 519.0317,412.537 Q 519.1137,411.9992 519.1137,411.7531 Q 519.1137,411.1607 519.0043,410.9784 Q 518.895,410.787 518.658,410.787 Q 518.421,410.787 517.8286,411.106 Q 517.2361,411.4159 516.7166,412.2818 Q 516.4614,412.7102 516.2882,413.3755 Q 516.115,414.0318 515.9874,414.843 Q 515.8325,415.8456 515.8051,416.2922 Q 515.7778,416.7297 515.7778,417.0123 Q 515.6593,417.067 515.3676,417.1946 Q 515.0851,417.3222 514.7387,417.4771 Q 514.4015,417.6321 514.1189,417.7597 Q 513.8364,417.8964 513.727,417.9602 L 513.3533,417.6047 Q 513.4627,416.9576 513.6267,415.955 Q 513.7999,414.9433 513.9913,413.7584 Q 514.1827,412.5643 514.3741,411.343 Q 514.5655,410.1216 514.7205,409.0188 Q 514.8754,407.9068 514.9666,407.0774 Q 515.0668,406.2479 515.0668,405.8651 Q 515.0668,405.4458 514.9483,405.3547 Q 514.839,405.2544 514.6931,405.2544 Q 514.5473,405.2544 514.2101,405.3547 Q 513.8819,405.4458 513.7088,405.5005 L 513.5629,404.8716 Q 514.0733,404.6438 514.7478,404.3794 Q 515.4223,404.1151 516.0056,403.9237 Q 516.589,403.7323 516.8168,403.7323 Q 517.0629,403.7323 517.2361,403.8964 Q 517.4184,404.0604 517.4184,404.4797 Q 517.4184,404.7349 517.3455,405.3547 Q 517.2726,405.9654 517.1541,406.7675 Q 517.0447,407.5604 516.9171,408.3899 Q 516.7895,409.2102 516.6801,409.9029 Q 516.5707,410.5956 516.5069,410.9966 Q 517.5733,409.9393 518.5122,409.5018 Q 519.451,409.0552 520.2713,409.0552 Q 520.8455,409.0552 521.1463,409.3469 Q 521.4471,409.6386 521.4471,410.5227 Q 521.4471,410.9966 521.3286,411.7258 Q 521.2101,412.4459 521.0642,413.2297 Q 520.9184,414.0136 520.7999,414.688 Q 520.6905,415.3625 520.6905,415.7362 Q 520.6905,416.0461 520.7726,416.1646 Q 520.8546,416.274 521.0187,416.274 Q 521.2648,416.274 521.4835,416.2011 Q 521.7114,416.119 522.0213,415.9732 Z"
+       id="path9135"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 527.6268,406.0839 Q 527.6268,406.4211 527.4353,406.7857 Q 527.2531,407.1412 526.8976,407.3964 Q 526.5421,407.6425 526.0226,407.6425 Q 525.5395,407.6425 525.3116,407.4146 Q 525.0929,407.1776 525.0929,406.8677 Q 525.0929,406.5396 525.2752,406.175 Q 525.4666,405.8104 525.8221,405.5552 Q 526.1866,405.3 526.6879,405.3 Q 527.1801,405.3 527.3989,405.537 Q 527.6268,405.774 527.6268,406.0839 Z M 527.4171,416.5839 Q 526.8429,416.9211 526.2504,417.2401 Q 525.658,417.5591 525.1385,417.7597 Q 524.6281,417.9602 524.2908,417.9602 Q 523.99,417.9602 523.7713,417.6685 Q 523.5525,417.386 523.5525,416.8938 Q 523.5525,416.5657 523.6346,415.9823 Q 523.7166,415.3899 523.8442,414.688 Q 523.9718,413.9771 524.0994,413.2844 Q 524.227,412.5826 524.309,412.0266 Q 524.3911,411.4706 524.3911,411.2063 Q 524.3911,410.787 524.2908,410.6958 Q 524.1905,410.5956 524.0174,410.5956 Q 523.908,410.5956 523.6437,410.6685 Q 523.3793,410.7414 523.1788,410.8143 L 523.0148,410.2037 Q 523.5252,409.9667 524.1814,409.7024 Q 524.8468,409.438 525.4119,409.2466 Q 525.977,409.0552 526.2049,409.0552 Q 526.4601,409.0552 526.5968,409.2284 Q 526.7426,409.4016 526.7426,409.8208 Q 526.7426,410.1399 526.6515,410.7414 Q 526.5603,411.3339 526.4327,412.063 Q 526.3051,412.7831 526.1684,413.5123 Q 526.0408,414.2323 525.9497,414.8248 Q 525.8585,415.4172 525.8585,415.7362 Q 525.8585,416.274 526.132,416.274 Q 526.4145,416.274 526.6424,416.2102 Q 526.8794,416.1373 527.2439,415.9732 Z"
+       id="path9137"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 535.9484,410.0852 Q 535.6932,410.3404 535.3195,410.6776 Q 534.9458,411.0057 534.5903,411.2518 Q 534.2348,411.4888 534.0434,411.4888 Q 533.852,411.4888 533.6424,411.2063 Q 533.4328,410.9237 533.1684,410.6412 Q 532.9041,410.3495 532.5486,410.3495 Q 531.8833,410.3495 531.4275,410.9237 Q 530.9718,411.4888 530.7257,412.3456 Q 530.4887,413.1932 530.4887,414.05 Q 530.4887,415.2258 530.8533,415.8912 Q 531.227,416.5474 531.8012,416.5474 Q 532.2843,416.5474 532.977,416.192 Q 533.6788,415.8274 534.6541,415.0253 Q 534.727,415.1164 534.8911,415.3625 Q 535.0643,415.5995 535.1007,415.6724 Q 533.6697,416.9667 532.6945,417.468 Q 531.7283,417.9602 530.908,417.9602 Q 530.3885,417.9602 529.7869,417.6685 Q 529.1945,417.3769 528.7661,416.6568 Q 528.3377,415.9276 528.3377,414.6516 Q 528.3377,413.4211 528.8755,412.1815 Q 529.4223,410.9419 530.7622,410.0487 Q 531.2726,409.7115 532.0747,409.3833 Q 532.8768,409.0552 533.6424,409.0552 Q 534.1802,409.0552 534.5721,409.274 Q 534.964,409.4836 535.2921,409.7388 Q 535.6203,409.9849 535.9484,410.0852 Z"
+       id="path9139"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 546.5669,409.8938 Q 546.3573,410.1672 546.0838,410.5044 Q 545.8104,410.8326 545.5643,411.0695 Q 545.3273,411.3065 545.2088,411.3065 Q 545.063,411.3065 544.8807,411.1242 Q 544.7075,410.9419 544.4796,410.705 Q 544.2609,410.4589 543.9875,410.2766 Q 543.7231,410.0943 543.395,410.0943 Q 542.8937,410.0943 542.6203,410.3586 Q 542.3559,410.6229 542.3559,411.0513 Q 542.3559,411.4797 542.7296,411.7987 Q 543.1033,412.1177 543.8416,412.4914 Q 544.3338,412.7466 544.7987,413.0748 Q 545.2635,413.3938 545.5552,413.8495 Q 545.856,414.3052 545.856,414.9524 Q 545.856,415.5813 545.4731,416.1282 Q 545.0994,416.675 544.4979,417.0852 Q 543.9054,417.4953 543.2218,417.7232 Q 542.5474,417.9602 541.9549,417.9602 Q 541.1802,417.9602 540.5604,417.7141 Q 539.9406,417.4771 539.576,417.149 Q 539.2114,416.8117 539.2114,416.5565 Q 539.2114,416.4289 539.339,416.1555 Q 539.4666,415.8821 539.6489,415.5904 Q 539.8312,415.2896 540.0044,415.08 Q 540.1867,414.8703 540.2778,414.8703 Q 540.3963,414.8703 540.5513,415.162 Q 540.7062,415.4537 540.9523,415.8456 Q 541.1984,416.2284 541.5812,416.5201 Q 541.9731,416.8117 542.5474,416.8117 Q 543.1398,416.8117 543.4862,416.4836 Q 543.8416,416.1464 543.8416,415.6177 Q 543.8416,414.9979 543.2674,414.5513 Q 542.7023,414.0956 542.0187,413.7492 Q 541.0526,413.2662 540.7062,412.7466 Q 540.369,412.218 540.369,411.6347 Q 540.369,411.0604 540.6971,410.5865 Q 541.0252,410.1125 541.5539,409.7753 Q 542.0916,409.4289 542.7023,409.2466 Q 543.313,409.0552 543.8781,409.0552 Q 544.5252,409.0552 544.9901,409.2375 Q 545.4549,409.4198 545.8195,409.6203 Q 546.1932,409.8208 546.5669,409.8938 Z"
+       id="path9141"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 555.2987,411.8716 Q 555.2987,412.938 554.9341,414.0956 Q 554.5786,415.2531 554.0773,416.0735 Q 553.8039,416.5292 553.4211,416.9667 Q 553.0474,417.3951 552.5916,417.6776 Q 552.145,417.9602 551.6528,417.9602 Q 551.1515,417.9602 550.4953,417.4315 Q 549.839,416.9029 549.2648,416.0461 L 549.5474,414.8339 Q 549.7297,415.162 550.076,415.4628 Q 550.4315,415.7545 550.8325,415.9459 Q 551.2336,416.1373 551.5526,416.1373 Q 551.9354,416.1373 552.2362,415.9094 Q 552.5461,415.6815 552.7192,415.317 Q 552.9471,414.8339 553.0474,414.1594 Q 553.1476,413.4849 553.1476,412.8013 Q 553.1476,411.8352 552.8651,411.2518 Q 552.5825,410.6594 552.2453,410.6594 Q 552.0265,410.6594 551.6073,410.9419 Q 551.1971,411.2245 550.7231,411.7714 Q 550.2583,412.3182 549.8664,413.093 L 549.8026,411.507 Q 550.6047,410.4771 551.2244,409.9485 Q 551.8442,409.4198 552.3455,409.2375 Q 552.856,409.0552 553.3026,409.0552 Q 554.1138,409.0552 554.7062,409.7844 Q 555.2987,410.5044 555.2987,411.8716 Z M 550.4041,409.6568 Q 550.4041,410.0487 550.2674,410.9328 Q 550.1398,411.8169 549.8664,413.412 Q 549.602,415.0071 549.1919,417.5318 Q 548.8911,419.4094 548.8182,420.2388 Q 548.7453,421.0683 548.8364,421.3144 Q 548.6997,421.3508 548.3989,421.4602 Q 548.1073,421.5696 547.7609,421.7063 Q 547.4145,421.8521 547.1229,421.9706 Q 546.8403,422.0891 546.7218,422.1438 L 546.3573,421.8065 Q 546.4028,421.4602 546.5487,420.6581 Q 546.6854,419.856 546.8768,418.7896 Q 547.0773,417.7232 547.2869,416.5657 Q 547.4966,415.4081 547.6698,414.3326 Q 547.852,413.2479 547.9614,412.4185 Q 548.0799,411.5891 548.0799,411.2063 Q 548.0799,410.787 547.9432,410.6958 Q 547.8065,410.5956 547.6515,410.5956 Q 547.533,410.5956 547.2414,410.6776 Q 546.9497,410.7597 546.8039,410.8143 L 546.6398,410.2037 Q 547.1776,409.9485 547.8612,409.6841 Q 548.5448,409.4198 549.119,409.2375 Q 549.6932,409.0552 549.9119,409.0552 Q 550.1398,409.0552 550.2674,409.1828 Q 550.4041,409.3013 550.4041,409.6568 Z"
+       id="path9143"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 564.8234,416.6203 Q 564.0487,417.1672 563.356,417.5683 Q 562.6633,417.9602 562.3443,417.9602 Q 562.1255,417.9602 561.8247,417.7232 Q 561.5331,417.4953 561.3143,416.9029 Q 561.0956,416.3104 561.0956,415.2258 Q 561.0956,415.0162 561.1502,414.5513 Q 561.2141,414.0865 561.2961,413.494 Q 561.3872,412.9016 561.4875,412.3091 Q 561.5878,411.7167 561.6698,411.2518 Q 561.7518,410.7779 561.7883,410.5682 Q 561.843,410.2857 562.2713,410.0123 Q 562.6997,409.7388 563.2466,409.4927 Q 563.7935,409.2466 564.2036,409.0552 L 564.4862,409.6477 Q 564.1854,409.9029 564.0578,410.1125 Q 563.9302,410.313 563.8026,410.9328 Q 563.52,412.2362 563.3651,413.3391 Q 563.2193,414.4328 563.2193,414.8339 Q 563.2193,415.4628 563.3469,415.8729 Q 563.4836,416.274 563.7023,416.274 Q 563.8846,416.274 564.0943,416.2284 Q 564.313,416.1737 564.6776,416.0188 Z M 563.9302,410.1034 Q 563.675,410.2857 563.438,410.6867 Q 563.201,411.0878 563.0005,411.425 Q 562.8,411.7623 562.6359,411.7623 Q 562.5174,411.7623 562.2987,411.5526 Q 562.0799,411.343 561.7974,411.0604 Q 561.5148,410.7779 561.1958,410.5682 Q 560.8859,410.3495 560.5851,410.3495 Q 560.0109,410.3495 559.5825,410.7323 Q 559.1542,411.1151 558.8716,411.7076 Q 558.589,412.2909 558.4432,412.9472 Q 558.3065,413.5943 558.3065,414.1321 Q 558.3065,415.1529 558.5799,415.6633 Q 558.8534,416.1646 559.1906,416.1646 Q 559.4914,416.1646 560.0656,415.5813 Q 560.6489,414.9888 561.369,413.8951 L 561.2049,415.6542 Q 560.8221,416.2102 560.3391,416.7388 Q 559.8651,417.2675 559.3456,417.6138 Q 558.8351,417.9602 558.3156,417.9602 Q 557.8781,417.9602 557.395,417.6412 Q 556.912,417.3313 556.5747,416.6386 Q 556.2375,415.9459 556.2375,414.8065 Q 556.2375,413.3664 556.9484,412.0813 Q 557.6594,410.7961 558.9445,409.912 Q 559.4367,409.5748 560.1294,409.3195 Q 560.8221,409.0552 561.5878,409.0552 Q 562.0617,409.0552 562.5174,409.3104 Q 562.9823,409.5565 563.3469,409.8208 Q 563.7206,410.0761 563.9302,410.1034 Z"
+       id="path9145"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 573.1359,410.0852 Q 572.8807,410.3404 572.507,410.6776 Q 572.1333,411.0057 571.7779,411.2518 Q 571.4224,411.4888 571.231,411.4888 Q 571.0396,411.4888 570.83,411.2063 Q 570.6203,410.9237 570.356,410.6412 Q 570.0917,410.3495 569.7362,410.3495 Q 569.0708,410.3495 568.6151,410.9237 Q 568.1594,411.4888 567.9133,412.3456 Q 567.6763,413.1932 567.6763,414.05 Q 567.6763,415.2258 568.0409,415.8912 Q 568.4146,416.5474 568.9888,416.5474 Q 569.4719,416.5474 570.1646,416.192 Q 570.8664,415.8274 571.8417,415.0253 Q 571.9146,415.1164 572.0787,415.3625 Q 572.2518,415.5995 572.2883,415.6724 Q 570.8573,416.9667 569.882,417.468 Q 568.9159,417.9602 568.0956,417.9602 Q 567.576,417.9602 566.9745,417.6685 Q 566.382,417.3769 565.9536,416.6568 Q 565.5253,415.9276 565.5253,414.6516 Q 565.5253,413.4211 566.063,412.1815 Q 566.6099,410.9419 567.9497,410.0487 Q 568.4602,409.7115 569.2622,409.3833 Q 570.0643,409.0552 570.83,409.0552 Q 571.3677,409.0552 571.7596,409.274 Q 572.1516,409.4836 572.4797,409.7388 Q 572.8078,409.9849 573.1359,410.0852 Z"
+       id="path9147"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 580.3547,410.6594 Q 580.3547,411.0604 580.1633,411.5435 Q 579.981,412.0266 579.3977,412.5826 Q 578.8143,413.1294 577.6386,413.7401 Q 576.4628,414.3508 574.4758,414.9888 L 574.412,414.0409 Q 575.6607,413.5396 576.3899,413.1477 Q 577.1281,412.7466 577.4927,412.4185 Q 577.8573,412.0904 577.9667,411.7896 Q 578.0761,411.4797 578.0761,411.1334 Q 578.0761,410.7141 577.8847,410.5044 Q 577.7024,410.2857 577.4472,410.2857 Q 577.3013,410.2857 577.0005,410.4406 Q 576.6998,410.5956 576.4719,410.869 Q 575.9797,411.4432 575.6789,412.1906 Q 575.3873,412.938 575.3873,413.9406 Q 575.3873,415.1347 575.7974,415.8456 Q 576.2167,416.5474 576.7544,416.5474 Q 577.1373,416.5474 577.8755,416.192 Q 578.6229,415.8365 579.7258,414.9524 Q 579.8261,415.0071 579.9719,415.2714 Q 580.1177,415.5357 580.1451,415.5995 Q 578.6503,416.9029 577.675,417.4315 Q 576.6998,417.9602 575.8886,417.9602 Q 575.3873,417.9602 574.7675,417.6503 Q 574.1568,417.3495 573.7102,416.6659 Q 573.2727,415.9732 573.2727,414.8248 Q 573.2727,413.3938 573.938,412.218 Q 574.6034,411.0331 575.7518,410.0761 Q 576.162,409.7388 576.8912,409.4016 Q 577.6294,409.0552 578.3495,409.0552 Q 579.3794,409.0552 579.8625,409.5656 Q 580.3547,410.0669 580.3547,410.6594 Z"
+       id="path9149"
+       style="font-style:italic;font-weight:bold;font-size:18.6667px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px;display:inline" />
+    <path
+       d="M 946.2882,91.29086 L 945.9444,91.25961 Q 945.7152,90.77002 945.3663,90.58772 Q 945.0225,90.40543 944.7256,90.40543 Q 944.2048,90.40543 943.9756,90.65543 Q 943.7465,90.90543 943.7465,91.20231 Q 943.7465,91.53044 943.9861,91.77003 Q 944.2256,92.00441 944.6006,92.20233 Q 944.9809,92.40025 945.4027,92.60338 Q 945.8246,92.8065 946.1996,93.06692 Q 946.5798,93.32734 946.8194,93.68672 Q 947.059,94.0461 947.059,94.56174 Q 947.059,94.9107 946.8976,95.2805 Q 946.7413,95.65029 946.4184,95.96801 Q 946.1007,96.28572 945.6111,96.48364 Q 945.1267,96.68156 944.4652,96.68156 Q 944.2152,96.68156 943.8767,96.61906 Q 943.5381,96.55656 943.1996,96.44197 Q 942.8662,96.32739 942.6214,96.17113 Q 942.5902,96.1503 942.5694,95.96801 Q 942.5537,95.78571 942.5537,95.52529 Q 942.5537,95.26487 942.5798,94.99403 Q 942.6058,94.7232 942.6631,94.52528 L 943.0329,94.55132 Q 943.2673,95.16591 943.7048,95.55133 Q 944.1475,95.93676 944.6788,95.93676 Q 945.1475,95.93676 945.5173,95.67634 Q 945.8871,95.41071 945.8871,94.91591 Q 945.8871,94.49403 945.6475,94.21277 Q 945.4079,93.93152 945.0329,93.7336 Q 944.6631,93.53047 944.2413,93.34297 Q 943.8246,93.15547 943.4496,92.9263 Q 943.0746,92.69713 942.835,92.36379 Q 942.6006,92.03045 942.6006,91.52523 Q 942.6006,91.28565 942.736,90.98877 Q 942.8767,90.69189 943.1631,90.42626 Q 943.4548,90.15542 943.9079,89.98355 Q 944.3611,89.80646 944.9913,89.80646 Q 945.5538,89.80646 946.0486,89.94188 Q 946.5434,90.0773 946.7361,90.28563 Q 946.7673,90.32209 946.7257,90.45751 Q 946.6892,90.59293 946.6059,90.76481 Q 946.5278,90.93668 946.4392,91.08773 Q 946.3507,91.23356 946.2882,91.29086 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9292" />
+    <path
+       d="M 952.8351,92.0617 Q 952.5226,92.13462 952.4185,92.19712 Q 952.3195,92.25962 952.2622,92.41587 L 950.5226,96.91073 Q 950.0747,98.06179 949.4809,98.57221 Q 948.8924,99.08784 948.2257,99.08784 Q 947.9601,99.08784 947.7153,99.02534 Q 947.4757,98.96805 947.3194,98.88472 Q 947.1632,98.80138 947.1632,98.73367 Q 947.1632,98.692 947.2517,98.56179 Q 947.3351,98.43158 947.4653,98.27012 Q 947.5903,98.11387 947.7153,97.97845 Q 947.8455,97.84824 947.9288,97.79616 Q 948.1892,97.96804 948.4497,97.99929 Q 948.7153,98.03575 948.908,97.96804 Q 949.1007,97.90553 949.3195,97.67636 Q 949.5382,97.4524 949.7257,97.00448 L 949.8768,96.6451 L 948.1319,92.41587 Q 948.0278,92.17108 947.5538,92.0617 V 91.68149 H 949.9132 V 92.0617 Q 949.5382,92.10858 949.4549,92.18149 Q 949.3715,92.2492 949.4445,92.41587 L 950.5174,95.03049 L 951.5382,92.41587 Q 951.5955,92.25962 951.5278,92.1867 Q 951.4601,92.11378 951.132,92.0617 V 91.68149 H 952.8351 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9294" />
+    <path
+       d="M 956.9758,95.05133 Q 956.9758,95.60342 956.7414,95.93155 Q 956.5123,96.25968 956.1685,96.42114 Q 955.8248,96.5826 955.481,96.62947 Q 955.1373,96.68156 954.9081,96.68156 Q 954.5747,96.68156 954.1477,96.58781 Q 953.7206,96.49926 953.3716,96.30135 Q 953.3404,96.28051 953.3195,96.11905 Q 953.3039,95.95238 953.3039,95.71279 Q 953.3091,95.468 953.3299,95.218 Q 953.356,94.96799 953.4081,94.77528 L 953.8299,94.83257 Q 953.9393,95.38987 954.2883,95.718 Q 954.6425,96.04092 955.0904,96.04092 Q 955.83,96.04092 955.83,95.45758 Q 955.83,95.05654 955.4654,94.80132 Q 955.106,94.5409 954.5747,94.26486 Q 954.2883,94.11381 954.007,93.92631 Q 953.731,93.73881 953.5435,93.49401 Q 953.3612,93.24922 953.3612,92.91588 Q 953.3612,92.48358 953.6268,92.17629 Q 953.8977,91.86378 954.3247,91.69711 Q 954.7518,91.52523 955.2206,91.52523 Q 955.6685,91.52523 956.106,91.63461 Q 956.5487,91.74399 956.7883,91.92628 Q 956.8196,91.95232 956.7987,92.09816 Q 956.7831,92.24399 956.731,92.43671 Q 956.6842,92.62421 956.6164,92.80129 Q 956.5487,92.97317 956.4862,93.05651 L 956.1269,93.01484 Q 955.8612,92.07212 955.1633,92.07212 Q 954.8508,92.07212 954.6789,92.21795 Q 954.507,92.36379 954.507,92.57733 Q 954.507,92.88984 954.7935,93.09817 Q 955.0852,93.3013 955.6998,93.61381 Q 956.0018,93.77006 956.2935,93.95756 Q 956.5904,94.13986 956.7831,94.40028 Q 956.9758,94.6607 956.9758,95.05133 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9296" />
+    <path
+       d="M 962.7467,91.38461 Q 962.7467,92.05128 962.3978,92.52004 Q 962.0488,92.9888 961.4603,93.23359 Q 960.8769,93.47839 960.1634,93.47839 Q 960.0175,93.47839 959.8613,93.46276 Q 959.7102,93.44193 959.5488,93.40547 L 959.5175,92.83255 Q 959.6998,92.8638 959.8196,92.87421 Q 959.9446,92.88463 960.0748,92.88463 Q 960.778,92.88463 961.1061,92.53046 Q 961.4342,92.17629 961.4342,91.54607 Q 961.4342,91.22315 961.2988,90.95752 Q 961.1634,90.68668 960.83,90.52522 Q 960.4967,90.35855 959.8977,90.35855 Q 959.5904,90.35855 959.1894,90.40022 Q 958.7883,90.43668 958.3665,90.48876 Q 957.9498,90.54085 957.5956,90.59814 L 957.5279,90.11896 Q 958.0748,89.99917 958.7258,89.90542 Q 959.3821,89.80646 960.1269,89.80646 Q 961.0696,89.80646 961.6426,90.0148 Q 962.2207,90.22313 962.4811,90.58251 Q 962.7467,90.93668 962.7467,91.38461 Z M 963.8509,96.25447 Q 963.6218,96.32739 963.3249,96.41072 Q 963.0332,96.48885 962.7676,96.54093 Q 962.5072,96.59822 962.3717,96.59822 Q 962.2259,96.59822 962.0801,96.51489 Q 961.9342,96.42635 961.8613,96.31176 L 960.2988,93.33776 L 961.0748,92.99401 L 962.9342,95.56696 Q 963.1009,95.78571 963.2624,95.84821 Q 963.4238,95.90551 963.7728,95.87426 Z M 957.5956,96.52531 V 96.14509 Q 958.3092,95.99926 958.3092,95.82738 V 90.28042 H 959.6113 V 95.82738 Q 959.6113,95.88988 959.7779,95.98363 Q 959.9498,96.07218 960.33,96.14509 V 96.52531 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9298" />
+    <path
+       d="M 966.7833,99.02534 V 98.64513 Q 967.2676,98.57221 967.4656,98.48888 Q 967.6687,98.41075 967.6687,98.32221 V 92.22316 Q 967.752,92.19712 967.9239,92.11378 Q 968.0958,92.02524 968.2885,91.91587 Q 968.4864,91.80128 968.6479,91.69711 Q 968.8145,91.58774 968.877,91.52523 L 969.0802,91.71795 Q 969.0802,91.71795 969.0385,91.88461 Q 968.9968,92.05128 968.9552,92.32212 Q 968.9187,92.59296 968.9187,92.90546 V 98.32221 Q 968.9187,98.40554 969.0593,98.48888 Q 969.2052,98.57221 969.601,98.64513 V 99.02534 Z M 968.0541,95.4055 Q 967.6218,95.86384 967.2989,96.14509 Q 966.976,96.42635 966.6635,96.55135 Q 966.351,96.68156 965.9551,96.68156 Q 965.5489,96.68156 965.1322,96.38989 Q 964.7207,96.09301 964.4395,95.54092 Q 964.1634,94.98362 964.1634,94.21277 Q 964.1634,93.60339 964.3561,93.16588 Q 964.5488,92.72317 964.8249,92.4315 Q 965.1009,92.13983 965.3457,91.97837 Q 965.6374,91.79086 966.0072,91.66065 Q 966.377,91.52523 966.6947,91.52523 Q 967.0072,91.52523 967.3041,91.63461 Q 967.6062,91.74399 968.0124,92.15024 Q 968.0124,92.75963 967.7051,92.94713 Q 967.5437,92.619 967.2103,92.41587 Q 966.877,92.21274 966.5749,92.21274 Q 966.0801,92.21274 965.7468,92.60858 Q 965.4134,93.00442 965.4134,93.89506 Q 965.4134,94.78049 965.7676,95.23883 Q 966.127,95.69196 966.5593,95.69196 Q 966.877,95.69196 967.1635,95.50967 Q 967.4551,95.32737 967.8197,94.97841 Q 967.8666,94.99924 967.9135,95.09299 Q 967.9604,95.18675 967.9968,95.28571 Q 968.0385,95.37946 968.0541,95.4055 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9300" />
+    <path
+       d="M 1011.87,91.29086 L 1011.526,91.25961 Q 1011.297,90.77002 1010.948,90.58772 Q 1010.604,90.40543 1010.307,90.40543 Q 1009.787,90.40543 1009.557,90.65543 Q 1009.328,90.90543 1009.328,91.20231 Q 1009.328,91.53044 1009.568,91.77003 Q 1009.807,92.00441 1010.182,92.20233 Q 1010.563,92.40025 1010.984,92.60338 Q 1011.406,92.8065 1011.781,93.06692 Q 1012.162,93.32734 1012.401,93.68672 Q 1012.641,94.0461 1012.641,94.56174 Q 1012.641,94.9107 1012.479,95.2805 Q 1012.323,95.65029 1012,95.96801 Q 1011.682,96.28572 1011.193,96.48364 Q 1010.708,96.68156 1010.047,96.68156 Q 1009.797,96.68156 1009.458,96.61906 Q 1009.12,96.55656 1008.781,96.44197 Q 1008.448,96.32739 1008.203,96.17113 Q 1008.172,96.1503 1008.151,95.96801 Q 1008.135,95.78571 1008.135,95.52529 Q 1008.135,95.26487 1008.162,94.99403 Q 1008.188,94.7232 1008.245,94.52528 L 1008.615,94.55132 Q 1008.849,95.16591 1009.287,95.55133 Q 1009.729,95.93676 1010.26,95.93676 Q 1010.729,95.93676 1011.099,95.67634 Q 1011.469,95.41071 1011.469,94.91591 Q 1011.469,94.49403 1011.229,94.21277 Q 1010.99,93.93152 1010.615,93.7336 Q 1010.245,93.53047 1009.823,93.34297 Q 1009.406,93.15547 1009.031,92.9263 Q 1008.656,92.69713 1008.417,92.36379 Q 1008.182,92.03045 1008.182,91.52523 Q 1008.182,91.28565 1008.318,90.98877 Q 1008.458,90.69189 1008.745,90.42626 Q 1009.037,90.15542 1009.49,89.98355 Q 1009.943,89.80646 1010.573,89.80646 Q 1011.136,89.80646 1011.63,89.94188 Q 1012.125,90.0773 1012.318,90.28563 Q 1012.349,90.32209 1012.307,90.45751 Q 1012.271,90.59293 1012.188,90.76481 Q 1012.109,90.93668 1012.021,91.08773 Q 1011.932,91.23356 1011.87,91.29086 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9303" />
+    <path
+       d="M 1017.719,95.53571 Q 1017.266,96.04613 1016.901,96.29093 Q 1016.537,96.53572 1016.214,96.60864 Q 1015.896,96.68156 1015.568,96.68156 Q 1015,96.68156 1014.505,96.38989 Q 1014.016,96.09301 1013.708,95.54092 Q 1013.406,94.98362 1013.406,94.21277 Q 1013.406,93.46276 1013.766,92.85338 Q 1014.125,92.24399 1014.761,91.88461 Q 1015.396,91.52523 1016.219,91.52523 Q 1016.448,91.52523 1016.745,91.57732 Q 1017.042,91.6294 1017.302,91.72315 Q 1017.563,91.8117 1017.677,91.9367 Q 1017.688,91.9992 1017.646,92.19191 Q 1017.604,92.37941 1017.531,92.60858 Q 1017.459,92.83775 1017.386,93.03567 Q 1017.313,93.22838 1017.266,93.29609 L 1016.917,93.24401 Q 1016.745,92.73359 1016.495,92.45754 Q 1016.245,92.17629 1015.828,92.17629 Q 1015.521,92.17629 1015.255,92.36379 Q 1014.99,92.55129 1014.823,92.96796 Q 1014.656,93.37943 1014.656,94.05131 Q 1014.656,94.87945 1015.052,95.343 Q 1015.453,95.80655 1016.021,95.80655 Q 1016.219,95.80655 1016.401,95.77009 Q 1016.584,95.73363 1016.823,95.60863 Q 1017.068,95.47842 1017.438,95.20237 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9305" />
+    <path
+       d="M 1022.485,91.7544 Q 1022.532,91.78566 1022.511,92.00441 Q 1022.49,92.22316 1022.427,92.52525 Q 1022.365,92.82213 1022.287,93.09817 Q 1022.209,93.36901 1022.146,93.50964 H 1021.766 Q 1021.729,93.08776 1021.584,92.79088 Q 1021.438,92.48879 1021.188,92.48879 Q 1021.052,92.48879 1020.88,92.56692 Q 1020.709,92.63983 1020.516,92.869 Q 1020.323,93.09817 1020.115,93.55131 V 95.82738 Q 1020.115,95.90551 1020.328,95.98884 Q 1020.547,96.07218 1021.037,96.14509 V 96.52531 H 1018.177 V 96.14509 Q 1018.865,95.98884 1018.865,95.82738 V 93.06692 Q 1018.865,92.72317 1018.828,92.58775 Q 1018.792,92.45233 1018.745,92.40546 Q 1018.677,92.33775 1018.568,92.3117 Q 1018.464,92.28045 1018.177,92.26483 V 91.90024 Q 1018.557,91.84816 1018.813,91.80128 Q 1019.073,91.7492 1019.297,91.6867 Q 1019.526,91.61899 1019.818,91.52523 L 1020.037,91.74399 L 1020.104,92.49921 Q 1020.386,92.09816 1020.797,91.8117 Q 1021.214,91.52523 1021.662,91.52523 Q 1022.089,91.52523 1022.485,91.7544 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9307" />
+    <path
+       d="M 1027.969,94.94195 Q 1027.943,95.23883 1027.901,95.57217 Q 1027.865,95.9003 1027.823,96.16072 Q 1027.782,96.42114 1027.756,96.52531 H 1022.886 V 96.14509 Q 1023.599,95.99926 1023.599,95.82738 V 90.66585 Q 1023.599,90.60335 1023.427,90.50959 Q 1023.261,90.41584 1022.886,90.34293 V 89.96271 H 1025.62 V 90.34293 Q 1024.901,90.49397 1024.901,90.66585 V 95.51488 Q 1024.901,95.69717 1025.099,95.80134 Q 1025.302,95.9003 1025.87,95.9003 H 1026.459 Q 1026.782,95.9003 1026.974,95.79613 Q 1027.167,95.69196 1027.302,95.45237 Q 1027.443,95.21279 1027.589,94.80653 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9309" />
+    <path
+       d="M 1033.797,92.0617 Q 1033.568,92.08253 1033.339,92.17108 Q 1033.11,92.25441 1032.886,92.42108 L 1030.881,93.94194 L 1030.203,93.78568 L 1031.62,92.52004 Q 1031.844,92.31691 1031.865,92.21795 Q 1031.886,92.11899 1031.771,92.09295 Q 1031.657,92.0617 1031.474,92.0617 V 91.68149 H 1033.797 Z M 1028.308,96.52531 V 96.14509 Q 1028.651,96.05655 1028.823,95.98884 Q 1029,95.92113 1029,95.82738 V 89.93146 Q 1029,89.62417 1028.948,89.48875 Q 1028.901,89.35333 1028.756,89.31166 Q 1028.61,89.26479 1028.308,89.23353 V 88.86895 Q 1028.813,88.79603 1029.24,88.70228 Q 1029.667,88.60853 1030.016,88.45227 L 1030.25,88.66582 V 95.82738 Q 1030.25,95.90551 1030.344,95.96801 Q 1030.438,96.0253 1030.823,96.14509 V 96.52531 Z M 1033.98,96.35343 Q 1033.776,96.4003 1033.516,96.45239 Q 1033.256,96.50447 1033.037,96.54093 Q 1032.823,96.57739 1032.75,96.57739 Q 1032.318,96.57739 1032.11,96.30135 L 1030.214,93.78568 L 1031.11,93.38984 L 1033.188,95.74925 Q 1033.334,95.92113 1033.49,95.95759 Q 1033.646,95.99405 1033.948,95.97322 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9311" />
+    <path
+       d="M 1258.845,91.65024 Q 1258.845,92.19191 1258.631,92.59817 Q 1258.423,93.00442 1258.084,93.27526 Q 1257.751,93.5461 1257.365,93.68152 Q 1256.98,93.81693 1256.636,93.81693 Q 1256.397,93.81693 1256.162,93.78048 Q 1255.933,93.73881 1255.761,93.66068 L 1255.6,93.1138 Q 1255.813,93.21276 1255.975,93.24401 Q 1256.141,93.27005 1256.324,93.27005 Q 1256.626,93.27005 1256.902,93.12422 Q 1257.178,92.97317 1257.355,92.66588 Q 1257.532,92.35337 1257.532,91.86378 Q 1257.532,91.12419 1257.063,90.74397 Q 1256.6,90.35855 1255.855,90.35855 Q 1255.49,90.35855 1255.048,90.39501 Q 1254.605,90.43147 1254.173,90.48355 Q 1253.74,90.53564 1253.407,90.59814 L 1253.339,90.11896 Q 1253.714,90.02521 1254.193,89.9575 Q 1254.673,89.88459 1255.183,89.84813 Q 1255.693,89.80646 1256.152,89.80646 Q 1257.36,89.80646 1258.1,90.28042 Q 1258.845,90.75439 1258.845,91.65024 Z M 1253.407,96.52531 V 96.14509 Q 1254.12,95.99926 1254.12,95.82738 V 90.33772 H 1255.423 V 95.82738 Q 1255.423,95.88988 1255.584,95.97322 Q 1255.751,96.05655 1256.298,96.14509 V 96.52531 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9314" />
+    <path
+       d="M 1264.923,95.92634 Q 1264.621,96.12947 1264.303,96.30135 Q 1263.985,96.47322 1263.73,96.57739 Q 1263.48,96.68156 1263.376,96.68156 Q 1263.105,96.68156 1262.985,96.3326 Q 1262.865,95.97842 1262.865,95.10862 V 92.1867 Q 1263.084,92.09816 1263.423,91.92628 Q 1263.761,91.7492 1264.058,91.52523 L 1264.266,91.71795 Q 1264.266,91.71795 1264.225,91.90024 Q 1264.188,92.07733 1264.152,92.35337 Q 1264.115,92.62421 1264.115,92.91588 V 94.88987 Q 1264.115,95.20237 1264.131,95.40029 Q 1264.152,95.59821 1264.204,95.64509 Q 1264.256,95.69717 1264.381,95.68675 Q 1264.511,95.67113 1264.777,95.54613 Q 1264.777,95.54092 1264.813,95.63988 Q 1264.85,95.73363 1264.886,95.83259 Q 1264.923,95.92634 1264.923,95.92634 Z M 1263.256,95.4055 Q 1262.85,95.89509 1262.537,96.17113 Q 1262.23,96.44718 1261.949,96.56177 Q 1261.667,96.68156 1261.339,96.68156 Q 1260.897,96.68156 1260.49,96.4003 Q 1260.084,96.11905 1259.824,95.57217 Q 1259.568,95.02529 1259.568,94.23361 Q 1259.568,93.77006 1259.735,93.29609 Q 1259.902,92.81692 1260.22,92.41587 Q 1260.542,92.01482 1261.001,91.77003 Q 1261.459,91.52523 1262.042,91.52523 Q 1262.355,91.52523 1262.621,91.64503 Q 1262.886,91.75961 1263.204,92.10858 Q 1263.204,92.75442 1262.902,92.94713 Q 1262.792,92.619 1262.527,92.41587 Q 1262.266,92.21274 1261.964,92.21274 Q 1261.678,92.21274 1261.412,92.369 Q 1261.152,92.52004 1260.985,92.89505 Q 1260.819,93.26484 1260.819,93.91589 Q 1260.819,94.50444 1260.975,94.90028 Q 1261.136,95.29612 1261.376,95.49404 Q 1261.621,95.69196 1261.871,95.69196 Q 1262.095,95.69196 1262.329,95.55654 Q 1262.569,95.42112 1263.022,94.97841 Q 1263.069,94.99924 1263.115,95.09299 Q 1263.162,95.18675 1263.199,95.28571 Q 1263.24,95.37946 1263.256,95.4055 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9316" />
+    <path
+       d="M 1270.918,95.94196 Q 1270.662,96.10863 1270.345,96.28051 Q 1270.032,96.45239 1269.772,96.56697 Q 1269.511,96.68156 1269.428,96.68156 Q 1269.241,96.68156 1269.084,96.5201 Q 1268.928,96.35343 1268.866,95.81696 Q 1268.433,96.19197 1268.115,96.37947 Q 1267.798,96.56177 1267.553,96.61906 Q 1267.308,96.68156 1267.084,96.68156 Q 1266.761,96.68156 1266.459,96.55135 Q 1266.157,96.42114 1265.959,96.07218 Q 1265.766,95.72321 1265.766,95.07216 V 92.93671 Q 1265.766,92.60858 1265.735,92.46275 Q 1265.709,92.31691 1265.574,92.27004 Q 1265.444,92.22316 1265.136,92.19191 V 91.82732 Q 1265.657,91.78045 1266.027,91.72315 Q 1266.402,91.66065 1266.834,91.52523 L 1267.017,91.76482 V 94.74403 Q 1267.017,95.38987 1267.173,95.58779 Q 1267.329,95.7805 1267.621,95.7805 Q 1267.839,95.7805 1268.136,95.6555 Q 1268.438,95.5305 1268.866,95.1607 V 92.93671 Q 1268.866,92.62421 1268.824,92.47316 Q 1268.787,92.32212 1268.642,92.26483 Q 1268.496,92.20754 1268.178,92.19191 V 91.82732 Q 1268.699,91.78045 1269.121,91.70232 Q 1269.548,91.61899 1269.923,91.52523 L 1270.116,91.76482 V 95.04612 Q 1270.116,95.36383 1270.142,95.49404 Q 1270.168,95.61904 1270.235,95.67113 Q 1270.293,95.718 1270.407,95.69196 Q 1270.522,95.66592 1270.787,95.55133 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9318" />
+    <path
+       d="M 1275.037,95.05133 Q 1275.037,95.60342 1274.803,95.93155 Q 1274.574,96.25968 1274.23,96.42114 Q 1273.886,96.5826 1273.543,96.62947 Q 1273.199,96.68156 1272.97,96.68156 Q 1272.636,96.68156 1272.209,96.58781 Q 1271.782,96.49926 1271.433,96.30135 Q 1271.402,96.28051 1271.381,96.11905 Q 1271.366,95.95238 1271.366,95.71279 Q 1271.371,95.468 1271.392,95.218 Q 1271.418,94.96799 1271.47,94.77528 L 1271.892,94.83257 Q 1272.001,95.38987 1272.35,95.718 Q 1272.704,96.04092 1273.152,96.04092 Q 1273.892,96.04092 1273.892,95.45758 Q 1273.892,95.05654 1273.527,94.80132 Q 1273.168,94.5409 1272.636,94.26486 Q 1272.35,94.11381 1272.069,93.92631 Q 1271.793,93.73881 1271.605,93.49401 Q 1271.423,93.24922 1271.423,92.91588 Q 1271.423,92.48358 1271.688,92.17629 Q 1271.959,91.86378 1272.386,91.69711 Q 1272.813,91.52523 1273.282,91.52523 Q 1273.73,91.52523 1274.168,91.63461 Q 1274.61,91.74399 1274.85,91.92628 Q 1274.881,91.95232 1274.86,92.09816 Q 1274.845,92.24399 1274.793,92.43671 Q 1274.746,92.62421 1274.678,92.80129 Q 1274.61,92.97317 1274.548,93.05651 L 1274.188,93.01484 Q 1273.923,92.07212 1273.225,92.07212 Q 1272.912,92.07212 1272.741,92.21795 Q 1272.569,92.36379 1272.569,92.57733 Q 1272.569,92.88984 1272.855,93.09817 Q 1273.147,93.3013 1273.761,93.61381 Q 1274.063,93.77006 1274.355,93.95756 Q 1274.652,94.13986 1274.845,94.40028 Q 1275.037,94.6607 1275.037,95.05133 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9320" />
+    <path
+       d="M 1280.256,93.66068 Q 1280.163,93.77006 1279.928,93.90027 Q 1279.694,94.02527 1279.527,94.08777 H 1276.381 L 1276.392,93.50443 H 1278.814 Q 1278.933,93.50443 1278.97,93.46797 Q 1279.011,93.4263 1279.011,93.31693 Q 1279.011,93.10859 1278.928,92.83775 Q 1278.85,92.56171 1278.647,92.35858 Q 1278.449,92.15024 1278.095,92.15024 Q 1277.527,92.15024 1277.293,92.65025 Q 1277.064,93.14505 1277.064,93.97319 Q 1277.064,94.76486 1277.397,95.28571 Q 1277.735,95.80655 1278.371,95.80655 Q 1278.59,95.80655 1278.798,95.77009 Q 1279.006,95.72842 1279.277,95.593 Q 1279.548,95.45758 1279.954,95.17633 Q 1280.022,95.21279 1280.11,95.343 Q 1280.204,95.468 1280.225,95.50967 Q 1279.741,95.99926 1279.381,96.25447 Q 1279.022,96.50447 1278.683,96.59302 Q 1278.35,96.68156 1277.933,96.68156 Q 1277.34,96.68156 1276.85,96.37426 Q 1276.36,96.06697 1276.064,95.51488 Q 1275.772,94.95758 1275.772,94.22319 Q 1275.772,92.80129 1276.845,92.01482 Q 1277.121,91.8117 1277.501,91.67107 Q 1277.886,91.52523 1278.282,91.52523 Q 1278.965,91.52523 1279.397,91.82732 Q 1279.834,92.12941 1280.043,92.619 Q 1280.256,93.10338 1280.256,93.66068 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9322" />
+    <path
+       d="M 1316.104,94.67111 Q 1316.104,95.55654 1315.386,96.07738 Q 1314.667,96.59822 1313.412,96.59822 Q 1313.063,96.59822 1312.609,96.5826 Q 1312.156,96.57218 1311.698,96.55656 Q 1311.24,96.54093 1310.865,96.52531 L 1312.412,95.89509 Q 1312.573,95.98363 1312.776,96.01488 Q 1312.984,96.04092 1313.219,96.04092 Q 1313.969,96.04092 1314.354,95.69717 Q 1314.74,95.35341 1314.74,94.77007 Q 1314.74,94.38465 1314.599,94.02527 Q 1314.458,93.66589 1314.115,93.43151 Q 1313.771,93.19713 1313.167,93.19713 Q 1312.823,93.19713 1312.599,93.23359 Q 1312.375,93.27005 1312.182,93.31693 L 1312.13,92.67108 H 1312.563 Q 1313.255,92.67108 1313.609,92.494 Q 1313.964,92.31691 1314.083,92.04087 Q 1314.208,91.76482 1314.208,91.46794 Q 1314.208,90.9471 1313.875,90.65543 Q 1313.542,90.35855 1312.651,90.35855 Q 1312.375,90.35855 1311.969,90.3898 Q 1311.563,90.41584 1311.151,90.46272 Q 1310.74,90.50439 1310.448,90.55647 L 1310.38,90.11896 Q 1310.688,90.04084 1311.135,89.97313 Q 1311.589,89.90021 1312.073,89.85334 Q 1312.563,89.80646 1312.979,89.80646 Q 1314.172,89.80646 1314.849,90.18147 Q 1315.526,90.55647 1315.526,91.21273 Q 1315.526,91.77003 1315.224,92.17629 Q 1314.922,92.57733 1314.339,92.75963 Q 1314.859,92.84296 1315.255,93.1138 Q 1315.656,93.38464 1315.88,93.78568 Q 1316.104,94.18673 1316.104,94.67111 Z M 1310.448,96.52531 V 96.14509 Q 1311.162,95.99926 1311.162,95.82738 V 90.22313 L 1312.464,90.11376 V 95.86384 Q 1312.464,95.92634 1312.594,96.02009 Q 1312.724,96.11384 1313.104,96.18155 V 96.52531 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9325" />
+    <path
+       d="M 1321.193,91.7544 Q 1321.24,91.78566 1321.219,92.00441 Q 1321.198,92.22316 1321.136,92.52525 Q 1321.073,92.82213 1320.995,93.09817 Q 1320.917,93.36901 1320.854,93.50964 H 1320.474 Q 1320.438,93.08776 1320.292,92.79088 Q 1320.146,92.48879 1319.896,92.48879 Q 1319.761,92.48879 1319.589,92.56692 Q 1319.417,92.63983 1319.224,92.869 Q 1319.031,93.09817 1318.823,93.55131 V 95.82738 Q 1318.823,95.90551 1319.037,95.98884 Q 1319.255,96.07218 1319.745,96.14509 V 96.52531 H 1316.886 V 96.14509 Q 1317.573,95.98884 1317.573,95.82738 V 93.06692 Q 1317.573,92.72317 1317.537,92.58775 Q 1317.5,92.45233 1317.453,92.40546 Q 1317.386,92.33775 1317.276,92.3117 Q 1317.172,92.28045 1316.886,92.26483 V 91.90024 Q 1317.266,91.84816 1317.521,91.80128 Q 1317.781,91.7492 1318.005,91.6867 Q 1318.235,91.61899 1318.526,91.52523 L 1318.745,91.74399 L 1318.813,92.49921 Q 1319.094,92.09816 1319.505,91.8117 Q 1319.922,91.52523 1320.37,91.52523 Q 1320.797,91.52523 1321.193,91.7544 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9327" />
+    <path
+       d="M 1326.032,93.66068 Q 1325.938,93.77006 1325.703,93.90027 Q 1325.469,94.02527 1325.302,94.08777 H 1322.156 L 1322.167,93.50443 H 1324.589 Q 1324.709,93.50443 1324.745,93.46797 Q 1324.787,93.4263 1324.787,93.31693 Q 1324.787,93.10859 1324.703,92.83775 Q 1324.625,92.56171 1324.422,92.35858 Q 1324.224,92.15024 1323.87,92.15024 Q 1323.302,92.15024 1323.068,92.65025 Q 1322.839,93.14505 1322.839,93.97319 Q 1322.839,94.76486 1323.172,95.28571 Q 1323.511,95.80655 1324.146,95.80655 Q 1324.365,95.80655 1324.573,95.77009 Q 1324.782,95.72842 1325.052,95.593 Q 1325.323,95.45758 1325.729,95.17633 Q 1325.797,95.21279 1325.886,95.343 Q 1325.979,95.468 1326,95.50967 Q 1325.516,95.99926 1325.157,96.25447 Q 1324.797,96.50447 1324.459,96.59302 Q 1324.125,96.68156 1323.709,96.68156 Q 1323.115,96.68156 1322.625,96.37426 Q 1322.136,96.06697 1321.839,95.51488 Q 1321.547,94.95758 1321.547,94.22319 Q 1321.547,92.80129 1322.62,92.01482 Q 1322.896,91.8117 1323.276,91.67107 Q 1323.662,91.52523 1324.058,91.52523 Q 1324.74,91.52523 1325.172,91.82732 Q 1325.61,92.12941 1325.818,92.619 Q 1326.032,93.10338 1326.032,93.66068 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9329" />
+    <path
+       d="M 1332.063,95.92634 Q 1331.761,96.12947 1331.443,96.30135 Q 1331.125,96.47322 1330.87,96.57739 Q 1330.62,96.68156 1330.516,96.68156 Q 1330.245,96.68156 1330.125,96.3326 Q 1330.006,95.97842 1330.006,95.10862 V 92.1867 Q 1330.224,92.09816 1330.563,91.92628 Q 1330.901,91.7492 1331.198,91.52523 L 1331.407,91.71795 Q 1331.407,91.71795 1331.365,91.90024 Q 1331.328,92.07733 1331.292,92.35337 Q 1331.256,92.62421 1331.256,92.91588 V 94.88987 Q 1331.256,95.20237 1331.271,95.40029 Q 1331.292,95.59821 1331.344,95.64509 Q 1331.396,95.69717 1331.521,95.68675 Q 1331.651,95.67113 1331.917,95.54613 Q 1331.917,95.54092 1331.953,95.63988 Q 1331.99,95.73363 1332.026,95.83259 Q 1332.063,95.92634 1332.063,95.92634 Z M 1330.396,95.4055 Q 1329.99,95.89509 1329.677,96.17113 Q 1329.37,96.44718 1329.089,96.56177 Q 1328.808,96.68156 1328.479,96.68156 Q 1328.037,96.68156 1327.631,96.4003 Q 1327.224,96.11905 1326.964,95.57217 Q 1326.709,95.02529 1326.709,94.23361 Q 1326.709,93.77006 1326.875,93.29609 Q 1327.042,92.81692 1327.36,92.41587 Q 1327.683,92.01482 1328.141,91.77003 Q 1328.599,91.52523 1329.183,91.52523 Q 1329.495,91.52523 1329.761,91.64503 Q 1330.026,91.75961 1330.344,92.10858 Q 1330.344,92.75442 1330.042,92.94713 Q 1329.933,92.619 1329.667,92.41587 Q 1329.407,92.21274 1329.104,92.21274 Q 1328.818,92.21274 1328.552,92.369 Q 1328.292,92.52004 1328.125,92.89505 Q 1327.959,93.26484 1327.959,93.91589 Q 1327.959,94.50444 1328.115,94.90028 Q 1328.276,95.29612 1328.516,95.49404 Q 1328.761,95.69196 1329.011,95.69196 Q 1329.235,95.69196 1329.469,95.55654 Q 1329.709,95.42112 1330.162,94.97841 Q 1330.209,94.99924 1330.256,95.09299 Q 1330.302,95.18675 1330.339,95.28571 Q 1330.381,95.37946 1330.396,95.4055 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9331" />
+    <path
+       d="M 1337.803,92.0617 Q 1337.573,92.08253 1337.344,92.17108 Q 1337.115,92.25441 1336.891,92.42108 L 1334.886,93.94194 L 1334.209,93.78568 L 1335.625,92.52004 Q 1335.849,92.31691 1335.87,92.21795 Q 1335.891,92.11899 1335.776,92.09295 Q 1335.662,92.0617 1335.48,92.0617 V 91.68149 H 1337.803 Z M 1332.313,96.52531 V 96.14509 Q 1332.657,96.05655 1332.828,95.98884 Q 1333.006,95.92113 1333.006,95.82738 V 89.93146 Q 1333.006,89.62417 1332.953,89.48875 Q 1332.907,89.35333 1332.761,89.31166 Q 1332.615,89.26479 1332.313,89.23353 V 88.86895 Q 1332.818,88.79603 1333.245,88.70228 Q 1333.672,88.60853 1334.021,88.45227 L 1334.256,88.66582 V 95.82738 Q 1334.256,95.90551 1334.349,95.96801 Q 1334.443,96.0253 1334.829,96.14509 V 96.52531 Z M 1337.985,96.35343 Q 1337.782,96.4003 1337.521,96.45239 Q 1337.261,96.50447 1337.042,96.54093 Q 1336.829,96.57739 1336.756,96.57739 Q 1336.323,96.57739 1336.115,96.30135 L 1334.219,93.78568 L 1335.115,93.38984 L 1337.193,95.74925 Q 1337.339,95.92113 1337.495,95.95759 Q 1337.651,95.99405 1337.954,95.97322 Z"
+       style="font-weight:bold;font-size:10.6668px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px;stroke-width:1.00001"
+       id="path9333" />
+    <path
+       d="M 1008.134,85.70439 V 85.27666 Q 1008.937,85.11259 1008.937,84.91924 V 79.11259 Q 1008.937,79.04228 1008.744,78.93681 Q 1008.556,78.83134 1008.134,78.74931 V 78.32158 H 1011.21 V 78.74931 Q 1010.402,78.91924 1010.402,79.11259 V 84.91924 Q 1010.402,84.98955 1010.595,85.09502 Q 1010.788,85.19463 1011.21,85.27666 V 85.70439 Z"
+       id="path9336"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1015.576,85.70439 V 85.27666 Q 1015.997,85.16533 1016.173,85.0833 Q 1016.349,84.99541 1016.349,84.91924 V 82.25908 Q 1016.349,81.61455 1016.214,81.38017 Q 1016.079,81.1458 1015.734,81.1458 Q 1015.453,81.1458 1015.083,81.31572 Q 1014.72,81.47978 1014.152,81.96025 V 84.91924 Q 1014.152,85.11259 1014.931,85.27666 V 85.70439 H 1011.972 V 85.27666 Q 1012.745,85.07158 1012.745,84.91924 V 81.66728 Q 1012.745,81.36259 1012.71,81.22197 Q 1012.675,81.07549 1012.511,81.01689 Q 1012.353,80.9583 1011.972,80.91142 V 80.50127 Q 1012.529,80.44267 1012.956,80.34306 Q 1013.39,80.24345 1013.818,80.07939 L 1014.064,80.32549 L 1014.128,81.16924 Q 1014.808,80.58916 1015.406,80.3372 Q 1016.003,80.07939 1016.46,80.07939 Q 1016.964,80.07939 1017.357,80.41924 Q 1017.755,80.75908 1017.755,81.57939 V 84.91924 Q 1017.755,84.99541 1017.913,85.07744 Q 1018.072,85.15947 1018.535,85.27666 V 85.70439 Z"
+       id="path9338"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1023.245,84.04619 Q 1023.245,84.66728 1022.982,85.03642 Q 1022.724,85.40556 1022.337,85.5872 Q 1021.951,85.76884 1021.564,85.82158 Q 1021.177,85.88017 1020.919,85.88017 Q 1020.544,85.88017 1020.064,85.7747 Q 1019.583,85.67509 1019.191,85.45244 Q 1019.156,85.429 1019.132,85.24736 Q 1019.115,85.05986 1019.115,84.79033 Q 1019.12,84.51494 1019.144,84.23369 Q 1019.173,83.95244 1019.232,83.73564 L 1019.706,83.80009 Q 1019.829,84.42705 1020.222,84.79619 Q 1020.62,85.15947 1021.124,85.15947 Q 1021.956,85.15947 1021.956,84.50322 Q 1021.956,84.05205 1021.546,83.76494 Q 1021.142,83.47197 1020.544,83.16142 Q 1020.222,82.9915 1019.906,82.78056 Q 1019.595,82.56963 1019.384,82.29424 Q 1019.179,82.01884 1019.179,81.64384 Q 1019.179,81.15752 1019.478,80.81181 Q 1019.783,80.46025 1020.263,80.27275 Q 1020.744,80.07939 1021.271,80.07939 Q 1021.775,80.07939 1022.267,80.20244 Q 1022.765,80.32549 1023.035,80.53056 Q 1023.07,80.55986 1023.046,80.72392 Q 1023.029,80.88799 1022.97,81.10478 Q 1022.917,81.31572 1022.841,81.51494 Q 1022.765,81.7083 1022.695,81.80205 L 1022.29,81.75517 Q 1021.992,80.69463 1021.206,80.69463 Q 1020.855,80.69463 1020.661,80.85869 Q 1020.468,81.02275 1020.468,81.26299 Q 1020.468,81.61455 1020.79,81.84892 Q 1021.119,82.07744 1021.81,82.429 Q 1022.15,82.60478 1022.478,82.81572 Q 1022.812,83.0208 1023.029,83.31377 Q 1023.245,83.60674 1023.245,84.04619 Z"
+       id="path9340"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 948.7471,80.22002 Q 948.7471,80.82939 948.5069,81.28642 Q 948.2725,81.74345 947.8917,82.04814 Q 947.5167,82.35283 947.0831,82.50517 Q 946.6495,82.65752 946.2628,82.65752 Q 945.9932,82.65752 945.7296,82.6165 Q 945.4717,82.56963 945.2784,82.48174 L 945.0967,81.8665 Q 945.337,81.97783 945.5186,82.01299 Q 945.7061,82.04228 945.9112,82.04228 Q 946.251,82.04228 946.5616,81.87822 Q 946.8721,81.7083 947.0714,81.36259 Q 947.2706,81.01103 947.2706,80.46025 Q 947.2706,79.62822 946.7432,79.20049 Q 946.2217,78.76689 945.3839,78.76689 Q 944.9737,78.76689 944.4756,78.80791 Q 943.9776,78.84892 943.4913,78.90752 Q 943.0049,78.96611 942.6299,79.03642 L 942.5538,78.49736 Q 942.9756,78.39189 943.5147,78.31572 Q 944.0538,78.23369 944.628,78.19267 Q 945.2022,78.1458 945.7178,78.1458 Q 947.0772,78.1458 947.9092,78.679 Q 948.7471,79.2122 948.7471,80.22002 Z M 942.6299,85.70439 V 85.27666 Q 943.4327,85.11259 943.4327,84.91924 V 78.74345 H 944.8975 V 84.91924 Q 944.8975,84.98955 945.0792,85.0833 Q 945.2667,85.17705 945.8819,85.27666 V 85.70439 Z"
+       id="path9343"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 954.3077,80.3372 Q 954.3604,80.37236 954.337,80.61845 Q 954.3135,80.86455 954.2432,81.20439 Q 954.1729,81.53838 954.085,81.84892 Q 953.9971,82.15361 953.9268,82.31181 H 953.4991 Q 953.4581,81.8372 953.294,81.50322 Q 953.1299,81.16338 952.8487,81.16338 Q 952.6964,81.16338 952.503,81.25127 Q 952.3096,81.3333 952.0928,81.59111 Q 951.876,81.84892 951.6417,82.35869 V 84.91924 Q 951.6417,85.00713 951.8819,85.10088 Q 952.128,85.19463 952.6788,85.27666 V 85.70439 H 949.462 V 85.27666 Q 950.2354,85.10088 950.2354,84.91924 V 81.81377 Q 950.2354,81.42705 950.1944,81.2747 Q 950.1534,81.12236 950.1006,81.06963 Q 950.0245,80.99345 949.9014,80.96416 Q 949.7842,80.929 949.462,80.91142 V 80.50127 Q 949.8897,80.44267 950.1768,80.38994 Q 950.4698,80.33134 950.7217,80.26103 Q 950.9796,80.18486 951.3077,80.07939 L 951.5538,80.32549 L 951.6299,81.17509 Q 951.9464,80.72392 952.4092,80.40166 Q 952.878,80.07939 953.3819,80.07939 Q 953.8624,80.07939 954.3077,80.3372 Z"
+       id="path9345"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 958.8194,84.79619 Q 958.046,85.35869 957.501,85.62236 Q 956.9561,85.88017 956.6514,85.88017 Q 956.1475,85.88017 955.7784,85.48759 Q 955.4151,85.09502 955.4151,84.2747 V 80.98759 H 954.7061 L 954.5362,80.77666 L 954.9932,80.25517 H 955.4151 V 79.03056 L 956.5987,78.15752 L 956.8214,78.35088 V 80.25517 H 958.6085 L 958.8194,80.46611 Q 958.7081,80.66533 958.5264,80.88799 Q 958.3448,81.10478 958.2276,81.19267 Q 958.087,81.12236 957.8057,81.05791 Q 957.5245,80.98759 957.2139,80.98759 H 956.8214 V 83.72978 Q 956.8214,84.3333 956.9561,84.57353 Q 957.0967,84.80791 957.3194,84.80791 Q 957.5245,84.80791 957.794,84.72002 Q 958.0694,84.63213 958.5616,84.36845 Z"
+       id="path9347"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 963.753,79.81572 L 963.3663,79.78056 Q 963.1085,79.22978 962.7159,79.0247 Q 962.3292,78.81963 961.9952,78.81963 Q 961.4092,78.81963 961.1514,79.10088 Q 960.8936,79.38213 960.8936,79.71611 Q 960.8936,80.08525 961.1631,80.35478 Q 961.4327,80.61845 961.8546,80.84111 Q 962.2823,81.06377 962.7569,81.29228 Q 963.2315,81.5208 963.6534,81.81377 Q 964.0811,82.10674 964.3506,82.51103 Q 964.6202,82.91533 964.6202,83.49541 Q 964.6202,83.88799 964.4385,84.304 Q 964.2628,84.72002 963.8995,85.07744 Q 963.5421,85.43486 962.9913,85.65752 Q 962.4464,85.88017 961.7022,85.88017 Q 961.421,85.88017 961.0401,85.80986 Q 960.6592,85.73955 960.2784,85.61064 Q 959.9034,85.48174 959.628,85.30595 Q 959.5928,85.28252 959.5694,85.07744 Q 959.5518,84.87236 959.5518,84.57939 Q 959.5518,84.28642 959.5811,83.98174 Q 959.6104,83.67705 959.6749,83.45439 L 960.0909,83.48369 Q 960.3546,84.17509 960.8467,84.60869 Q 961.3448,85.04228 961.9424,85.04228 Q 962.4698,85.04228 962.8858,84.74931 Q 963.3018,84.45049 963.3018,83.89384 Q 963.3018,83.41924 963.0323,83.10283 Q 962.7628,82.78642 962.3409,82.56377 Q 961.9249,82.33525 961.4503,82.12431 Q 960.9815,81.91338 960.5596,81.65556 Q 960.1378,81.39775 959.8682,81.02275 Q 959.6046,80.64775 959.6046,80.07939 Q 959.6046,79.80986 959.7569,79.47588 Q 959.9151,79.14189 960.2374,78.84306 Q 960.5655,78.53838 961.0753,78.34502 Q 961.585,78.1458 962.294,78.1458 Q 962.9268,78.1458 963.4835,78.29814 Q 964.0401,78.45049 964.2569,78.68486 Q 964.2921,78.72588 964.2452,78.87822 Q 964.2042,79.03056 964.1104,79.22392 Q 964.0225,79.41728 963.9229,79.5872 Q 963.8233,79.75127 963.753,79.81572 Z"
+       id="path9349"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 970.3331,84.59111 Q 969.8233,85.16533 969.4131,85.44072 Q 969.003,85.71611 968.6397,85.79814 Q 968.2823,85.88017 967.9131,85.88017 Q 967.2745,85.88017 966.7178,85.55205 Q 966.1671,85.21806 965.8214,84.59697 Q 965.4815,83.97002 965.4815,83.10283 Q 965.4815,82.25908 965.8858,81.57353 Q 966.2901,80.88799 967.0049,80.48369 Q 967.7198,80.07939 968.6456,80.07939 Q 968.9034,80.07939 969.2374,80.13799 Q 969.5714,80.19658 969.8643,80.30205 Q 970.1573,80.40166 970.2862,80.54228 Q 970.2979,80.61259 970.251,80.82939 Q 970.2042,81.04033 970.1221,81.29814 Q 970.0401,81.55595 969.9581,81.77861 Q 969.876,81.99541 969.8233,82.07158 L 969.4307,82.01299 Q 969.2374,81.43877 968.9561,81.12822 Q 968.6749,80.81181 968.2061,80.81181 Q 967.8604,80.81181 967.5616,81.02275 Q 967.2628,81.23369 967.0753,81.70244 Q 966.8878,82.16533 966.8878,82.92119 Q 966.8878,83.85283 967.3331,84.37431 Q 967.7842,84.8958 968.4229,84.8958 Q 968.6456,84.8958 968.8506,84.85478 Q 969.0557,84.81377 969.3253,84.67314 Q 969.6006,84.52666 970.0167,84.21611 Z"
+       id="path9351"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1073.77,85.70439 V 85.27666 Q 1074.573,85.11259 1074.573,84.91924 V 78.91924 Q 1074.344,78.95439 1074.139,78.98369 Q 1073.934,79.01299 1073.77,79.03642 L 1073.694,78.49736 Q 1074.08,78.39775 1074.637,78.32158 Q 1075.2,78.23955 1075.797,78.19267 Q 1076.401,78.1458 1076.905,78.1458 Q 1078.698,78.1458 1079.682,79.09502 Q 1080.672,80.04424 1080.672,81.74345 Q 1080.672,82.83916 1080.35,83.60088 Q 1080.028,84.35674 1079.506,84.82549 Q 1078.985,85.28838 1078.364,85.49931 Q 1077.748,85.70439 1077.145,85.70439 H 1076.67 Q 1075.985,85.70439 1075.393,85.70439 Q 1074.807,85.70439 1073.998,85.70439 Z M 1076.928,85.07744 Q 1077.268,85.07744 1077.643,84.90166 Q 1078.024,84.72588 1078.352,84.35088 Q 1078.686,83.97588 1078.891,83.38994 Q 1079.102,82.79814 1079.102,81.97197 Q 1079.102,80.41338 1078.428,79.59306 Q 1077.76,78.76689 1076.483,78.76689 Q 1076.377,78.76689 1076.266,78.77275 Q 1076.155,78.77861 1076.037,78.78447 V 84.71416 Q 1076.037,84.94853 1076.307,85.01299 Q 1076.577,85.07744 1076.928,85.07744 Z"
+       id="path9354"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1086.584,82.48174 Q 1086.479,82.60478 1086.215,82.75127 Q 1085.952,82.89189 1085.764,82.9622 H 1082.225 L 1082.237,82.30595 H 1084.961 Q 1085.096,82.30595 1085.137,82.26494 Q 1085.184,82.21806 1085.184,82.09502 Q 1085.184,81.86064 1085.09,81.55595 Q 1085.002,81.24541 1084.774,81.01689 Q 1084.551,80.78252 1084.153,80.78252 Q 1083.514,80.78252 1083.25,81.34502 Q 1082.993,81.90166 1082.993,82.8333 Q 1082.993,83.72392 1083.368,84.30986 Q 1083.748,84.8958 1084.463,84.8958 Q 1084.709,84.8958 1084.944,84.85478 Q 1085.178,84.80791 1085.483,84.65556 Q 1085.787,84.50322 1086.245,84.18681 Q 1086.321,84.22783 1086.42,84.37431 Q 1086.526,84.51494 1086.549,84.56181 Q 1086.004,85.11259 1085.6,85.3997 Q 1085.196,85.68095 1084.815,85.78056 Q 1084.44,85.88017 1083.971,85.88017 Q 1083.303,85.88017 1082.752,85.53447 Q 1082.202,85.18877 1081.868,84.56767 Q 1081.539,83.94072 1081.539,83.11455 Q 1081.539,81.51494 1082.746,80.63017 Q 1083.057,80.40166 1083.485,80.24345 Q 1083.918,80.07939 1084.364,80.07939 Q 1085.131,80.07939 1085.618,80.41924 Q 1086.11,80.75908 1086.344,81.30986 Q 1086.584,81.85478 1086.584,82.48174 Z"
+       id="path9356"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1087.276,85.70439 V 85.27666 Q 1087.78,85.18877 1087.944,85.10088 Q 1088.108,85.01299 1088.108,84.91924 V 78.28642 Q 1088.108,77.94072 1088.049,77.78838 Q 1087.991,77.63603 1087.827,77.58916 Q 1087.662,77.53642 1087.334,77.50127 V 77.09111 Q 1087.92,77.00908 1088.36,76.90947 Q 1088.799,76.80986 1089.262,76.62236 L 1089.514,76.86259 V 84.91924 Q 1089.514,85.00713 1089.69,85.10088 Q 1089.871,85.19463 1090.352,85.27666 V 85.70439 Z"
+       id="path9358"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1143.787,85.70439 V 85.27666 Q 1144.589,85.11259 1144.589,84.91924 V 79.11259 Q 1144.589,79.04228 1144.396,78.93681 Q 1144.208,78.83134 1143.787,78.74931 V 78.32158 H 1146.863 V 78.74931 Q 1146.054,78.91924 1146.054,79.11259 V 84.91924 Q 1146.054,84.98955 1146.248,85.09502 Q 1146.441,85.19463 1146.863,85.27666 V 85.70439 Z M 1141.378,82.18877 V 81.48564 H 1144.707 V 82.18877 Z M 1139.275,85.70439 V 85.27666 Q 1140.078,85.11259 1140.078,84.91924 V 79.11259 Q 1140.078,79.04228 1139.884,78.93681 Q 1139.697,78.83134 1139.275,78.74931 V 78.32158 H 1142.351 V 78.74931 Q 1141.542,78.91924 1141.542,79.11259 V 84.91924 Q 1141.542,84.98955 1141.73,85.09502 Q 1141.923,85.19463 1142.351,85.27666 V 85.70439 Z"
+       id="path9361"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1153.138,82.86259 Q 1153.138,83.44853 1152.91,83.98759 Q 1152.681,84.52666 1152.283,84.95439 Q 1151.884,85.38213 1151.363,85.63408 Q 1150.841,85.88017 1150.261,85.88017 Q 1149.453,85.88017 1148.855,85.51689 Q 1148.257,85.15361 1147.929,84.52666 Q 1147.601,83.8997 1147.601,83.10283 Q 1147.601,82.52275 1147.812,81.98369 Q 1148.023,81.43877 1148.41,81.01103 Q 1148.796,80.57744 1149.324,80.33134 Q 1149.857,80.07939 1150.49,80.07939 Q 1151.287,80.07939 1151.884,80.44267 Q 1152.482,80.80595 1152.81,81.43291 Q 1153.138,82.05986 1153.138,82.86259 Z M 1151.662,83.12627 Q 1151.662,82.50517 1151.492,81.98369 Q 1151.322,81.45634 1151.017,81.13408 Q 1150.718,80.81181 1150.32,80.81181 Q 1149.833,80.81181 1149.564,81.09306 Q 1149.294,81.36845 1149.189,81.84892 Q 1149.083,82.32939 1149.083,82.93291 Q 1149.083,83.54814 1149.265,84.05205 Q 1149.453,84.55595 1149.757,84.85478 Q 1150.062,85.14775 1150.425,85.14775 Q 1151.123,85.14775 1151.392,84.62041 Q 1151.662,84.09306 1151.662,83.12627 Z"
+       id="path9363"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1160.603,85.70439 V 85.27666 Q 1161.025,85.16533 1161.154,85.0833 Q 1161.283,84.99541 1161.283,84.91924 V 82.17119 Q 1161.283,81.69072 1161.212,81.4622 Q 1161.148,81.22783 1161.013,81.15752 Q 1160.878,81.0872 1160.667,81.0872 Q 1160.41,81.0872 1160.058,81.26884 Q 1159.712,81.45049 1159.337,81.81963 V 84.91924 Q 1159.337,84.99541 1159.472,85.07744 Q 1159.613,85.15947 1160.076,85.27666 V 85.70439 H 1157.246 V 85.27666 Q 1157.667,85.16533 1157.796,85.0833 Q 1157.931,84.99541 1157.931,84.91924 V 82.17119 Q 1157.931,81.69072 1157.878,81.4622 Q 1157.826,81.22783 1157.697,81.15752 Q 1157.574,81.0872 1157.357,81.0872 Q 1156.818,81.0872 1155.98,81.81963 V 84.91924 Q 1155.98,85.12431 1156.712,85.27666 V 85.70439 H 1153.8 V 85.27666 Q 1154.574,85.07158 1154.574,84.91924 V 81.66728 Q 1154.574,81.35674 1154.539,81.21611 Q 1154.503,81.06963 1154.339,81.01689 Q 1154.175,80.9583 1153.8,80.91142 V 80.50127 Q 1154.404,80.43095 1154.814,80.33134 Q 1155.23,80.23174 1155.646,80.07939 L 1155.892,80.32549 L 1155.957,81.05205 Q 1156.613,80.47197 1157.087,80.27861 Q 1157.568,80.07939 1157.99,80.07939 Q 1158.546,80.07939 1158.851,80.3372 Q 1159.162,80.59502 1159.232,80.97002 L 1159.25,81.05205 Q 1159.906,80.48369 1160.386,80.28447 Q 1160.873,80.07939 1161.3,80.07939 Q 1161.857,80.07939 1162.273,80.41924 Q 1162.689,80.75908 1162.689,81.57939 V 84.91924 Q 1162.689,84.99541 1162.871,85.07744 Q 1163.052,85.15947 1163.515,85.27666 V 85.70439 Z"
+       id="path9365"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1169.07,82.48174 Q 1168.964,82.60478 1168.701,82.75127 Q 1168.437,82.89189 1168.25,82.9622 H 1164.71 L 1164.722,82.30595 H 1167.447 Q 1167.582,82.30595 1167.623,82.26494 Q 1167.669,82.21806 1167.669,82.09502 Q 1167.669,81.86064 1167.576,81.55595 Q 1167.488,81.24541 1167.259,81.01689 Q 1167.037,80.78252 1166.638,80.78252 Q 1166,80.78252 1165.736,81.34502 Q 1165.478,81.90166 1165.478,82.8333 Q 1165.478,83.72392 1165.853,84.30986 Q 1166.234,84.8958 1166.949,84.8958 Q 1167.195,84.8958 1167.429,84.85478 Q 1167.664,84.80791 1167.968,84.65556 Q 1168.273,84.50322 1168.73,84.18681 Q 1168.806,84.22783 1168.906,84.37431 Q 1169.011,84.51494 1169.035,84.56181 Q 1168.49,85.11259 1168.085,85.3997 Q 1167.681,85.68095 1167.3,85.78056 Q 1166.925,85.88017 1166.457,85.88017 Q 1165.789,85.88017 1165.238,85.53447 Q 1164.687,85.18877 1164.353,84.56767 Q 1164.025,83.94072 1164.025,83.11455 Q 1164.025,81.51494 1165.232,80.63017 Q 1165.542,80.40166 1165.97,80.24345 Q 1166.404,80.07939 1166.849,80.07939 Q 1167.617,80.07939 1168.103,80.41924 Q 1168.595,80.75908 1168.83,81.30986 Q 1169.07,81.85478 1169.07,82.48174 Z"
+       id="path9367"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1201.711,78.50908 Q 1201.7,78.7083 1201.659,79.03642 Q 1201.624,79.36455 1201.571,79.67509 Q 1201.518,79.98564 1201.471,80.13799 H 1201.032 Q 1200.979,79.0247 1200.551,79.0247 H 1198.278 L 1198.448,78.32158 H 1201.477 Z M 1201.108,81.60283 Q 1201.014,81.76689 1200.856,82.01299 Q 1200.698,82.25322 1200.569,82.34111 Q 1200.387,82.17119 1200.141,82.09502 Q 1199.901,82.01884 1199.409,82.01884 H 1198.196 L 1198.325,81.39775 H 1200.915 Z M 1202.092,83.92314 Q 1202.063,84.25713 1202.016,84.63213 Q 1201.975,85.00127 1201.928,85.29424 Q 1201.887,85.5872 1201.852,85.70439 H 1196.315 V 85.27666 Q 1197.118,85.11259 1197.118,84.91924 V 79.11259 Q 1197.118,79.04228 1196.924,78.93681 Q 1196.737,78.83134 1196.315,78.74931 V 78.32158 H 1199.432 V 78.74931 Q 1199.04,78.79033 1198.811,78.84892 Q 1198.583,78.90166 1198.583,78.98369 V 84.62627 Q 1198.583,84.73759 1198.665,84.82549 Q 1198.752,84.90752 1199.004,84.95439 Q 1199.262,85.00127 1199.778,85.00127 H 1200.358 Q 1200.897,85.00127 1201.155,84.73174 Q 1201.413,84.45634 1201.665,83.7708 Z"
+       id="path9370"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1206.252,85.70439 V 85.27666 Q 1206.674,85.16533 1206.85,85.0833 Q 1207.026,84.99541 1207.026,84.91924 V 82.25908 Q 1207.026,81.61455 1206.891,81.38017 Q 1206.756,81.1458 1206.411,81.1458 Q 1206.129,81.1458 1205.76,81.31572 Q 1205.397,81.47978 1204.829,81.96025 V 84.91924 Q 1204.829,85.11259 1205.608,85.27666 V 85.70439 H 1202.649 V 85.27666 Q 1203.422,85.07158 1203.422,84.91924 V 81.66728 Q 1203.422,81.36259 1203.387,81.22197 Q 1203.352,81.07549 1203.188,81.01689 Q 1203.03,80.9583 1202.649,80.91142 V 80.50127 Q 1203.206,80.44267 1203.633,80.34306 Q 1204.067,80.24345 1204.495,80.07939 L 1204.741,80.32549 L 1204.805,81.16924 Q 1205.485,80.58916 1206.083,80.3372 Q 1206.68,80.07939 1207.137,80.07939 Q 1207.641,80.07939 1208.034,80.41924 Q 1208.432,80.75908 1208.432,81.57939 V 84.91924 Q 1208.432,84.99541 1208.59,85.07744 Q 1208.749,85.15947 1209.211,85.27666 V 85.70439 Z"
+       id="path9372"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1216.026,85.03642 Q 1215.668,85.27666 1215.305,85.47002 Q 1214.948,85.65752 1214.672,85.76884 Q 1214.397,85.88017 1214.286,85.88017 Q 1213.706,85.88017 1213.706,83.93486 V 78.41533 Q 1213.706,77.98174 1213.665,77.78252 Q 1213.629,77.57744 1213.459,77.50713 Q 1213.29,77.43681 1212.903,77.40752 V 77.00322 Q 1213.542,76.93877 1214.063,76.8333 Q 1214.584,76.72197 1214.889,76.62236 L 1215.112,76.83916 V 83.95244 Q 1215.112,84.36259 1215.141,84.52666 Q 1215.176,84.68486 1215.247,84.73174 Q 1215.311,84.77275 1215.428,84.76103 Q 1215.545,84.74345 1215.862,84.60869 Z M 1214.139,84.44463 Q 1213.659,84.96025 1213.307,85.27666 Q 1212.956,85.59306 1212.622,85.73369 Q 1212.293,85.88017 1211.866,85.88017 Q 1211.344,85.88017 1210.852,85.55205 Q 1210.36,85.21806 1210.038,84.59697 Q 1209.721,83.97002 1209.721,83.10283 Q 1209.721,82.31767 1210.084,81.63213 Q 1210.448,80.94072 1211.086,80.51299 Q 1211.731,80.07939 1212.569,80.07939 Q 1212.92,80.07939 1213.278,80.19658 Q 1213.635,80.31377 1214.092,80.73564 Q 1214.092,81.42705 1213.747,81.63213 Q 1213.536,81.26299 1213.208,81.05791 Q 1212.885,80.85283 1212.475,80.85283 Q 1211.895,80.85283 1211.508,81.31572 Q 1211.127,81.77275 1211.127,82.78642 Q 1211.127,83.40752 1211.327,83.85283 Q 1211.526,84.29228 1211.831,84.53252 Q 1212.135,84.76689 1212.458,84.76689 Q 1212.809,84.76689 1213.131,84.57353 Q 1213.459,84.37431 1213.881,83.96416 Q 1213.928,83.98759 1213.981,84.09306 Q 1214.04,84.19853 1214.081,84.30986 Q 1214.127,84.41533 1214.139,84.44463 Z"
+       id="path9374"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1259.529,80.22002 Q 1259.529,80.82939 1259.289,81.28642 Q 1259.055,81.74345 1258.674,82.04814 Q 1258.299,82.35283 1257.865,82.50517 Q 1257.432,82.65752 1257.045,82.65752 Q 1256.775,82.65752 1256.512,82.6165 Q 1256.254,82.56963 1256.06,82.48174 L 1255.879,81.8665 Q 1256.119,81.97783 1256.301,82.01299 Q 1256.488,82.04228 1256.693,82.04228 Q 1257.033,82.04228 1257.344,81.87822 Q 1257.654,81.7083 1257.853,81.36259 Q 1258.053,81.01103 1258.053,80.46025 Q 1258.053,79.62822 1257.525,79.20049 Q 1257.004,78.76689 1256.166,78.76689 Q 1255.756,78.76689 1255.258,78.80791 Q 1254.76,78.84892 1254.273,78.90752 Q 1253.787,78.96611 1253.412,79.03642 L 1253.336,78.49736 Q 1253.758,78.39189 1254.297,78.31572 Q 1254.836,78.23369 1255.41,78.19267 Q 1255.984,78.1458 1256.5,78.1458 Q 1257.859,78.1458 1258.691,78.679 Q 1259.529,79.2122 1259.529,80.22002 Z M 1253.412,85.70439 V 85.27666 Q 1254.215,85.11259 1254.215,84.91924 V 78.74345 H 1255.68 V 84.91924 Q 1255.68,84.98955 1255.861,85.0833 Q 1256.049,85.17705 1256.664,85.27666 V 85.70439 Z"
+       id="path9377"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1264.656,84.26884 Q 1264.199,84.90166 1263.842,85.25322 Q 1263.484,85.60478 1263.144,85.73955 Q 1262.81,85.88017 1262.4,85.88017 Q 1261.896,85.88017 1261.422,85.58134 Q 1260.953,85.27666 1260.648,84.7083 Q 1260.344,84.13408 1260.344,83.32549 Q 1260.344,82.82158 1260.531,82.25908 Q 1260.724,81.69658 1261.088,81.20439 Q 1261.457,80.70634 1261.984,80.3958 Q 1262.517,80.07939 1263.191,80.07939 Q 1263.543,80.07939 1263.836,80.20244 Q 1264.135,80.32549 1264.598,80.78252 Q 1264.598,81.46806 1264.246,81.679 Q 1264.064,81.30986 1263.777,81.08134 Q 1263.496,80.85283 1263.144,80.85283 Q 1262.459,80.85283 1262.101,81.45634 Q 1261.75,82.05986 1261.75,83.01494 Q 1261.75,83.57744 1261.937,83.97002 Q 1262.125,84.35674 1262.418,84.56181 Q 1262.717,84.76689 1263.039,84.76689 Q 1263.256,84.76689 1263.578,84.62041 Q 1263.9,84.46806 1264.439,83.87627 Q 1264.504,83.91142 1264.562,84.06963 Q 1264.621,84.22197 1264.656,84.26884 Z M 1265.793,80.29619 Q 1265.734,80.46025 1265.67,80.78838 Q 1265.611,81.1165 1265.617,81.50322 L 1265.705,84.97197 Q 1265.728,85.7747 1265.506,86.37236 Q 1265.289,86.97588 1264.926,87.39775 Q 1264.562,87.82549 1264.135,88.0833 Q 1263.707,88.34697 1263.297,88.46416 Q 1262.892,88.5872 1262.594,88.5872 Q 1262.019,88.5872 1261.533,88.429 Q 1261.047,88.27666 1260.754,88.06572 Q 1260.461,87.86064 1260.461,87.70244 Q 1260.461,87.64384 1260.596,87.49736 Q 1260.736,87.35674 1260.93,87.19267 Q 1261.129,87.02861 1261.31,86.8997 Q 1261.498,86.77666 1261.592,86.74736 Q 1261.984,87.23955 1262.336,87.45634 Q 1262.693,87.679 1263.068,87.679 Q 1263.385,87.679 1263.666,87.52666 Q 1263.947,87.37431 1264.111,86.88799 Q 1264.281,86.40752 1264.269,85.429 L 1264.211,80.82353 Q 1264.34,80.78252 1264.603,80.64775 Q 1264.873,80.51299 1265.142,80.35478 Q 1265.418,80.19072 1265.57,80.07353 Z"
+       id="path9379"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1273.867,78.74931 Q 1273.058,78.91924 1273.058,79.11259 V 82.63408 Q 1273.058,83.65947 1272.683,84.38603 Q 1272.314,85.11259 1271.658,85.49931 Q 1271.008,85.88017 1270.164,85.88017 Q 1269.361,85.88017 1268.693,85.58134 Q 1268.025,85.28252 1267.627,84.66728 Q 1267.228,84.05205 1267.228,83.10283 V 79.11259 Q 1267.228,79.04228 1267.035,78.93681 Q 1266.848,78.83134 1266.426,78.74931 V 78.32158 H 1269.502 V 78.74931 Q 1268.693,78.91924 1268.693,79.11259 V 82.72197 Q 1268.693,83.84697 1269.109,84.43877 Q 1269.525,85.03056 1270.527,85.03056 Q 1271.084,85.03056 1271.412,84.71416 Q 1271.74,84.39189 1271.887,83.88213 Q 1272.033,83.3665 1272.033,82.78642 V 79.11259 Q 1272.033,79.04228 1271.84,78.93681 Q 1271.652,78.83134 1271.23,78.74931 V 78.32158 H 1273.867 Z"
+       id="path9381"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1278.244,85.88017 Q 1277.898,85.88017 1277.529,85.72783 Q 1277.166,85.57549 1276.656,85.21806 V 87.72588 Q 1276.656,87.81963 1276.873,87.91338 Q 1277.096,88.00713 1277.646,88.08916 V 88.51689 H 1274.476 V 88.08916 Q 1275.25,87.90166 1275.25,87.72588 V 81.66728 Q 1275.25,81.37431 1275.209,81.22197 Q 1275.174,81.06377 1275.01,80.99931 Q 1274.846,80.929 1274.476,80.91142 V 80.50127 Q 1274.922,80.44267 1275.221,80.38994 Q 1275.519,80.33134 1275.771,80.26103 Q 1276.023,80.18486 1276.322,80.07939 L 1276.568,80.32549 L 1276.621,81.04619 Q 1277.271,80.47783 1277.74,80.27861 Q 1278.215,80.07939 1278.549,80.07939 Q 1279.082,80.07939 1279.527,80.37236 Q 1279.978,80.65947 1280.248,81.25713 Q 1280.523,81.85478 1280.523,82.7747 Q 1280.523,83.35478 1280.307,83.90556 Q 1280.09,84.45634 1279.744,84.90752 Q 1279.398,85.35283 1279,85.6165 Q 1278.601,85.88017 1278.244,85.88017 Z M 1277.846,81.07549 Q 1277.705,81.07549 1277.558,81.12236 Q 1277.418,81.16924 1277.207,81.30986 Q 1277.002,81.45049 1276.656,81.73174 V 84.36845 Q 1277.072,84.60869 1277.342,84.72588 Q 1277.611,84.8372 1277.805,84.8665 Q 1277.998,84.8958 1278.185,84.8958 Q 1278.637,84.8958 1278.918,84.4622 Q 1279.205,84.02275 1279.205,83.2083 Q 1279.205,82.4583 1279,81.98955 Q 1278.801,81.5208 1278.49,81.29814 Q 1278.18,81.07549 1277.846,81.07549 Z"
+       id="path9383"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1316.569,80.22002 Q 1316.569,80.82939 1316.329,81.28642 Q 1316.094,81.74345 1315.714,82.04814 Q 1315.339,82.35283 1314.905,82.50517 Q 1314.471,82.65752 1314.085,82.65752 Q 1313.815,82.65752 1313.552,82.6165 Q 1313.294,82.56963 1313.1,82.48174 L 1312.919,81.8665 Q 1313.159,81.97783 1313.341,82.01299 Q 1313.528,82.04228 1313.733,82.04228 Q 1314.073,82.04228 1314.384,81.87822 Q 1314.694,81.7083 1314.893,81.36259 Q 1315.093,81.01103 1315.093,80.46025 Q 1315.093,79.62822 1314.565,79.20049 Q 1314.044,78.76689 1313.206,78.76689 Q 1312.796,78.76689 1312.298,78.80791 Q 1311.8,78.84892 1311.313,78.90752 Q 1310.827,78.96611 1310.452,79.03642 L 1310.376,78.49736 Q 1310.798,78.39189 1311.337,78.31572 Q 1311.876,78.23369 1312.45,78.19267 Q 1313.024,78.1458 1313.54,78.1458 Q 1314.899,78.1458 1315.731,78.679 Q 1316.569,79.2122 1316.569,80.22002 Z M 1310.452,85.70439 V 85.27666 Q 1311.255,85.11259 1311.255,84.91924 V 78.74345 H 1312.719 V 84.91924 Q 1312.719,84.98955 1312.901,85.0833 Q 1313.089,85.17705 1313.704,85.27666 V 85.70439 Z"
+       id="path9386"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1321.696,84.26884 Q 1321.239,84.90166 1320.882,85.25322 Q 1320.524,85.60478 1320.184,85.73955 Q 1319.85,85.88017 1319.44,85.88017 Q 1318.936,85.88017 1318.462,85.58134 Q 1317.993,85.27666 1317.688,84.7083 Q 1317.384,84.13408 1317.384,83.32549 Q 1317.384,82.82158 1317.571,82.25908 Q 1317.764,81.69658 1318.128,81.20439 Q 1318.497,80.70634 1319.024,80.3958 Q 1319.557,80.07939 1320.231,80.07939 Q 1320.583,80.07939 1320.876,80.20244 Q 1321.175,80.32549 1321.637,80.78252 Q 1321.637,81.46806 1321.286,81.679 Q 1321.104,81.30986 1320.817,81.08134 Q 1320.536,80.85283 1320.184,80.85283 Q 1319.499,80.85283 1319.141,81.45634 Q 1318.79,82.05986 1318.79,83.01494 Q 1318.79,83.57744 1318.977,83.97002 Q 1319.165,84.35674 1319.458,84.56181 Q 1319.757,84.76689 1320.079,84.76689 Q 1320.296,84.76689 1320.618,84.62041 Q 1320.94,84.46806 1321.479,83.87627 Q 1321.544,83.91142 1321.602,84.06963 Q 1321.661,84.22197 1321.696,84.26884 Z M 1322.833,80.29619 Q 1322.774,80.46025 1322.71,80.78838 Q 1322.651,81.1165 1322.657,81.50322 L 1322.745,84.97197 Q 1322.768,85.7747 1322.546,86.37236 Q 1322.329,86.97588 1321.966,87.39775 Q 1321.602,87.82549 1321.175,88.0833 Q 1320.747,88.34697 1320.337,88.46416 Q 1319.932,88.5872 1319.634,88.5872 Q 1319.059,88.5872 1318.573,88.429 Q 1318.087,88.27666 1317.794,88.06572 Q 1317.501,87.86064 1317.501,87.70244 Q 1317.501,87.64384 1317.635,87.49736 Q 1317.776,87.35674 1317.969,87.19267 Q 1318.169,87.02861 1318.35,86.8997 Q 1318.538,86.77666 1318.632,86.74736 Q 1319.024,87.23955 1319.376,87.45634 Q 1319.733,87.679 1320.108,87.679 Q 1320.425,87.679 1320.706,87.52666 Q 1320.987,87.37431 1321.151,86.88799 Q 1321.321,86.40752 1321.309,85.429 L 1321.251,80.82353 Q 1321.38,80.78252 1321.643,80.64775 Q 1321.913,80.51299 1322.182,80.35478 Q 1322.458,80.19072 1322.61,80.07353 Z"
+       id="path9388"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1323.466,85.70439 V 85.27666 Q 1324.268,85.11259 1324.268,84.91924 V 78.91924 Q 1324.04,78.95439 1323.835,78.98369 Q 1323.63,79.01299 1323.466,79.03642 L 1323.389,78.49736 Q 1323.776,78.39775 1324.333,78.32158 Q 1324.895,78.23955 1325.493,78.19267 Q 1326.096,78.1458 1326.6,78.1458 Q 1328.393,78.1458 1329.378,79.09502 Q 1330.368,80.04424 1330.368,81.74345 Q 1330.368,82.83916 1330.046,83.60088 Q 1329.723,84.35674 1329.202,84.82549 Q 1328.68,85.28838 1328.059,85.49931 Q 1327.444,85.70439 1326.841,85.70439 H 1326.366 Q 1325.68,85.70439 1325.089,85.70439 Q 1324.503,85.70439 1323.694,85.70439 Z M 1326.624,85.07744 Q 1326.964,85.07744 1327.339,84.90166 Q 1327.719,84.72588 1328.048,84.35088 Q 1328.382,83.97588 1328.587,83.38994 Q 1328.798,82.79814 1328.798,81.97197 Q 1328.798,80.41338 1328.124,79.59306 Q 1327.456,78.76689 1326.178,78.76689 Q 1326.073,78.76689 1325.962,78.77275 Q 1325.85,78.77861 1325.733,78.78447 V 84.71416 Q 1325.733,84.94853 1326.003,85.01299 Q 1326.272,85.07744 1326.624,85.07744 Z"
+       id="path9390"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 1334.739,85.70439 V 85.27666 Q 1335.161,85.16533 1335.337,85.0833 Q 1335.512,84.99541 1335.512,84.91924 V 82.25908 Q 1335.512,81.61455 1335.378,81.38017 Q 1335.243,81.1458 1334.897,81.1458 Q 1334.616,81.1458 1334.247,81.31572 Q 1333.884,81.47978 1333.315,81.96025 V 84.91924 Q 1333.315,85.11259 1334.094,85.27666 V 85.70439 H 1331.135 V 85.27666 Q 1331.909,85.07158 1331.909,84.91924 V 81.66728 Q 1331.909,81.36259 1331.874,81.22197 Q 1331.839,81.07549 1331.675,81.01689 Q 1331.516,80.9583 1331.135,80.91142 V 80.50127 Q 1331.692,80.44267 1332.12,80.34306 Q 1332.553,80.24345 1332.981,80.07939 L 1333.227,80.32549 L 1333.292,81.16924 Q 1333.971,80.58916 1334.569,80.3372 Q 1335.167,80.07939 1335.624,80.07939 Q 1336.128,80.07939 1336.52,80.41924 Q 1336.919,80.75908 1336.919,81.57939 V 84.91924 Q 1336.919,84.99541 1337.077,85.07744 Q 1337.235,85.15947 1337.698,85.27666 V 85.70439 Z"
+       id="path9392"
+       style="font-weight:bold;font-size:12px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+    <path
+       d="M 92.59843,219.6477 V 216.9915 H 108.8797 L 105.2234,213.3665 L 107.0984,211.4915 L 113.2547,217.6165 V 212.3977 H 115.9109 V 224.2727 H 113.2547 V 219.0227 L 107.0984,225.1477 L 105.2234,223.2727 L 108.8797,219.6477 Z M 115.9109,210.2727 H 99.62968 L 103.2859,213.8977 L 101.4109,215.7727 L 95.25468,209.6477 V 214.8977 H 92.59843 V 203.0227 H 95.25468 V 208.2415 L 101.4109,202.1165 L 103.2859,203.9915 L 99.62968,207.6165 H 115.9109 Z"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg';word-spacing:0px"
+       id="path9445" />
+    <path
+       d="M 245.2773,165.9523 L 244.9173,165.299 C 244.4773,165.5923 243.9973,165.739 243.4906,165.739 C 243.144,165.739 242.7973,165.659 242.464,165.5257 C 242.1306,165.3657 241.824,165.1523 241.5573,164.859 C 241.2906,164.5657 241.0773,164.1924 240.9173,163.7391 C 240.744,163.2991 240.664,162.7658 240.664,162.1658 C 240.664,161.5392 240.7306,161.0059 240.8773,160.5659 C 241.024,160.1259 241.2106,159.7526 241.424,159.4726 C 241.664,159.1927 241.9173,158.9793 242.1973,158.8327 C 242.4773,158.6994 242.7706,158.6327 243.0506,158.6327 C 243.2906,158.6327 243.5173,158.6727 243.7439,158.7793 C 243.9573,158.8593 244.1439,158.9927 244.3039,159.1527 C 244.4773,159.326 244.5973,159.5126 244.7039,159.7393 C 244.7839,159.9526 244.8373,160.1793 244.8373,160.4326 H 244.6373 C 243.6506,160.4326 242.9306,160.6059 242.4906,160.9659 C 242.0373,161.3259 241.8106,161.8192 241.8106,162.4725 C 241.8106,162.6858 241.8506,162.8858 241.944,163.0858 C 242.0373,163.2858 242.1573,163.4591 242.3173,163.6058 C 242.4773,163.7657 242.664,163.8991 242.8773,163.9791 C 243.0906,164.0857 243.3306,164.1257 243.5839,164.1257 C 244.1039,164.1257 244.5306,163.9257 244.8773,163.5124 V 164.0191 H 245.6773 V 161.3125 C 245.6773,160.7126 245.6106,160.2059 245.4773,159.766 C 245.3573,159.3393 245.1706,158.9927 244.9439,158.7127 C 244.7173,158.4327 244.4373,158.2327 244.1173,158.1127 C 243.8106,157.9794 243.464,157.9127 243.0906,157.9127 C 242.704,157.9127 242.3306,157.9927 241.9573,158.166 C 241.5706,158.3394 241.2373,158.5927 240.9173,158.9393 C 240.624,159.286 240.3706,159.726 240.1706,160.2726 C 239.984,160.8059 239.8906,161.4459 239.8906,162.1792 C 239.8906,162.9258 239.984,163.5658 240.1973,164.1124 C 240.384,164.659 240.6506,165.099 240.9973,165.4457 C 241.3173,165.8056 241.704,166.059 242.1173,166.2456 C 242.5306,166.4056 242.9706,166.4989 243.4106,166.4989 C 244.0773,166.4989 244.7039,166.3123 245.2773,165.9523 Z M 244.8773,161.0992 V 161.3525 C 244.8773,162.0458 244.7973,162.5658 244.6239,162.8858 C 244.4639,163.2324 244.1306,163.3924 243.6239,163.3924 C 243.3706,163.3924 243.144,163.2858 242.944,163.0991 C 242.744,162.8858 242.6373,162.6191 242.6373,162.2858 C 242.6373,161.9392 242.7973,161.6592 243.1306,161.4325 C 243.4506,161.2059 243.9573,161.0992 244.6506,161.0992 Z"
+       id="path1332"
+       style="font-size:13.3333px;line-height:1.25;font-family:Inconsolatazi4varl_qu;-inkscape-font-specification:Inconsolatazi4varl_qu;word-spacing:0px;stroke-width:0.999975" />
+    <path
+       d="M 311.7359,157.4194 V 167.5389 H 315.5625 V 166.7789 H 312.5892 V 158.2194 H 315.5492 V 157.4194 Z"
+       id="path1336"
+       style="font-size:13.3333px;line-height:1.25;font-family:Inconsolatazi4varl_qu;-inkscape-font-specification:Inconsolatazi4varl_qu;word-spacing:0px;stroke-width:0.999975" />
+    <path
+       d="M 387.0025,166.5256 L 382.8159,157.4861 L 382.0292,157.8994 L 386.2159,166.9122 Z"
+       id="path1339"
+       style="font-size:13.3333px;line-height:1.25;font-family:Inconsolatazi4varl_qu;-inkscape-font-specification:Inconsolatazi4varl_qu;word-spacing:0px;stroke-width:0.999975" />
+    <path
+       d="M 457.2879,157.4194 H 453.4879 V 158.2194 H 456.4479 V 166.7789 H 453.4746 V 167.5389 H 457.2879 Z"
+       id="path1343"
+       style="font-size:13.3333px;line-height:1.25;font-family:Inconsolatazi4varl_qu;-inkscape-font-specification:Inconsolatazi4varl_qu;word-spacing:0px;stroke-width:0.999975" />
+    <path
+       d="M 524.1799,161.4592 L 524.8466,161.7792 L 526.3132,159.446 L 527.6066,161.7792 L 528.3132,161.4459 L 526.5132,158.046 H 526.2199 Z"
+       id="path1346"
+       style="font-size:13.3333px;line-height:1.25;font-family:Inconsolatazi4varl_qu;-inkscape-font-specification:Inconsolatazi4varl_qu;word-spacing:0px;stroke-width:0.999975" />
+    <path
+       d="M 594.2385,166.6056 V 167.4189 H 599.9851 V 166.6056 Z"
+       id="path1349"
+       style="font-size:13.3333px;line-height:1.25;font-family:Inconsolatazi4varl_qu;-inkscape-font-specification:Inconsolatazi4varl_qu;word-spacing:0px;stroke-width:0.999975" />
+    <path
+       d="M 668.6985,165.219 C 668.5252,165.0723 668.3385,164.9923 668.1385,164.9923 C 667.9252,164.9923 667.7385,165.0723 667.5918,165.2323 C 667.4318,165.379 667.3518,165.5657 667.3518,165.7656 C 667.3518,165.9656 667.4318,166.1523 667.5918,166.2989 C 667.7385,166.4456 667.9252,166.5256 668.1385,166.5256 C 668.3518,166.5256 668.5385,166.4456 668.6852,166.2989 C 668.8452,166.1523 668.9252,165.9656 668.9252,165.7656 C 668.9252,165.5657 668.8452,165.3923 668.6985,165.219 Z M 665.5118,158.8727 L 666.1918,159.5126 C 666.3918,159.1527 666.6585,158.8727 666.9785,158.6727 C 667.3118,158.4594 667.6585,158.3527 668.0318,158.3527 C 668.2185,158.3527 668.3918,158.3927 668.5518,158.4594 C 668.7252,158.526 668.8718,158.6327 668.9918,158.7527 C 669.1118,158.886 669.2185,159.046 669.2852,159.206 C 669.3518,159.3926 669.3918,159.566 669.3918,159.766 C 669.3918,160.0193 669.3252,160.2593 669.2185,160.5126 C 669.0852,160.7659 668.8718,161.0459 668.5652,161.3525 C 668.3518,161.5659 668.1785,161.7525 668.0718,161.9258 C 667.9385,162.0858 667.8585,162.2458 667.8052,162.3792 C 667.7385,162.5391 667.6985,162.6858 667.6985,162.8325 C 667.6718,162.9791 667.6718,163.1524 667.6718,163.3391 V 163.8857 H 668.5518 V 163.3391 C 668.5518,163.0591 668.5785,162.8058 668.6452,162.5925 C 668.7118,162.3925 668.8718,162.1792 669.1252,161.9792 L 669.4185,161.7392 C 669.5385,161.6325 669.6718,161.5259 669.7918,161.4059 C 669.9118,161.2859 670.0185,161.1525 670.1252,161.0059 C 670.2052,160.8592 670.2852,160.6859 670.3518,160.4859 C 670.4185,160.2993 670.4452,160.0859 670.4452,159.8326 C 670.4452,159.5126 670.3918,159.206 670.2718,158.926 C 670.1518,158.646 669.9918,158.3927 669.7918,158.1794 C 669.5918,157.9661 669.3385,157.7927 669.0585,157.6727 C 668.7652,157.5527 668.4452,157.4861 668.0852,157.4861 C 667.5785,157.4861 667.0985,157.6061 666.6318,157.8461 C 666.1652,158.0994 665.7918,158.4327 665.5118,158.8727 Z"
+       id="path1352"
+       style="font-size:13.3333px;line-height:1.25;font-family:Inconsolatazi4varl_qu;-inkscape-font-specification:Inconsolatazi4varl_qu;word-spacing:0px;stroke-width:0.999975" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.944858;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 246.5635,156.8814 L 242.7839,154.0469 L 239.0044,156.8814"
+       id="path1355"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.944858;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 317.4288,156.8814 L 313.6492,154.0469 L 309.8697,156.8814"
+       id="path1355-6"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.944858;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 388.2955,156.8814 L 384.5159,154.0469 L 380.7364,156.8814"
+       id="path1355-9"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.944858;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 459.1608,156.8814 L 455.3812,154.0469 L 451.6017,156.8814"
+       id="path1355-2"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.944858;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 530.0261,156.8814 L 526.2465,154.0469 L 522.467,156.8814"
+       id="path1355-24"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.944858;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 600.8914,156.8814 L 597.1118,154.0469 L 593.3323,156.8814"
+       id="path1355-7"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.944858;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 671.7581,156.8814 L 667.9785,154.0469 L 664.199,156.8814"
+       id="path1355-75"
+       sodipodi:nodetypes="ccc" />
+    <path
+       d="M 1322.857,409.5468 Q 1322.857,410.0969 1322.552,410.4016 L 1317.203,415.7252 Q 1316.881,416.0468 1315.654,416.0468 V 417.7903 Q 1315.654,418.1796 1315.358,418.1796 Q 1315.206,418.1796 1315.062,418.0357 L 1310.965,413.9309 Q 1310.864,413.8293 1310.864,413.6855 Q 1310.864,413.5416 1310.965,413.44 L 1315.062,409.3352 Q 1315.206,409.1913 1315.358,409.1913 Q 1315.654,409.1913 1315.654,409.5806 V 411.3241 H 1318.126 V 405.0527 Q 1318.126,404.6633 1318.422,404.6633 Q 1318.574,404.6633 1318.718,404.8072 L 1320.487,406.5846 L 1322.264,404.8072 Q 1322.408,404.6633 1322.56,404.6633 Q 1322.857,404.6633 1322.857,405.0527 Z M 1322.163,409.5468 V 405.8905 L 1320.732,407.3209 Q 1320.639,407.414 1320.47,407.414 Q 1320.343,407.414 1320.25,407.3209 L 1318.82,405.8905 V 411.3241 H 1320.639 L 1322.061,409.9107 Q 1322.163,409.8092 1322.163,409.5468 Z M 1319.937,412.0181 H 1315.307 Q 1314.96,412.0181 1314.96,411.6711 V 410.4185 L 1311.702,413.6855 L 1314.96,416.9524 V 415.6998 Q 1314.96,415.3528 1315.307,415.3528 Q 1316.594,415.3528 1316.712,415.2343 Z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.3333px;line-height:1.25;font-family:Symbola;-inkscape-font-specification:'Symbola Bold';word-spacing:0px"
+       id="path2312" />
+    <path
+       d="M 1069.16,295.9393 Q 1069.16,296.4471 1068.889,297.0227 Q 1068.618,297.5897 1068.085,298.0975 Q 1067.561,298.6053 1066.799,298.927 Q 1066.046,299.2401 1065.072,299.2401 Q 1064.776,299.2401 1064.387,299.2062 Q 1064.006,299.1724 1063.735,299.0708 L 1063.87,298.1314 Q 1064.124,298.2329 1064.361,298.2668 Q 1064.598,298.3007 1064.861,298.3007 Q 1065.453,298.3007 1065.969,298.0552 Q 1066.486,297.8098 1066.807,297.3358 Q 1067.129,296.8619 1067.129,296.1848 Q 1067.129,295.3469 1066.79,294.9068 Q 1066.452,294.4667 1065.961,294.3059 Q 1065.479,294.1366 1065.005,294.1366 Q 1064.15,294.1366 1063.143,294.2551 Q 1062.144,294.3736 1061.374,294.5428 L 1061.382,293.7727 Q 1062.144,293.5526 1063.202,293.4003 Q 1064.268,293.2395 1065.428,293.2395 Q 1067.205,293.2395 1068.178,293.9335 Q 1069.16,294.6275 1069.16,295.9393 Z M 1070.066,303.1672 Q 1069.626,303.4634 1069.092,303.7173 Q 1068.568,303.9712 1068.136,304.1236 Q 1067.713,304.2759 1067.561,304.2759 Q 1067.273,304.2759 1066.993,304.0812 Q 1066.723,303.8866 1066.443,303.1672 L 1064.818,298.9777 L 1066.198,298.6307 L 1068.297,302.3462 Q 1068.542,302.7779 1068.847,302.7948 Q 1069.16,302.8117 1069.846,302.5917 Z M 1064.666,293.6796 L 1063.396,303.0233 Q 1063.371,303.1249 1063.633,303.2772 Q 1063.904,303.4211 1064.437,303.5396 L 1064.353,304.1574 H 1060.189 L 1060.265,303.5396 Q 1061.365,303.3026 1061.399,303.0233 L 1062.669,293.6796 Z"
+       id="path2330"
+       style="font-style:italic;font-weight:bold;font-size:17.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 1076.921,297.7251 Q 1076.921,298.0975 1076.743,298.5461 Q 1076.574,298.9947 1076.033,299.5109 Q 1075.491,300.0187 1074.399,300.5858 Q 1073.307,301.1529 1071.462,301.7453 L 1071.403,300.8651 Q 1072.562,300.3996 1073.24,300.0357 Q 1073.925,299.6633 1074.264,299.3586 Q 1074.602,299.0539 1074.704,298.7746 Q 1074.805,298.4868 1074.805,298.1652 Q 1074.805,297.7759 1074.628,297.5813 Q 1074.458,297.3781 1074.221,297.3781 Q 1074.086,297.3781 1073.807,297.522 Q 1073.527,297.6659 1073.316,297.9198 Q 1072.859,298.453 1072.579,299.147 Q 1072.309,299.841 1072.309,300.772 Q 1072.309,301.8807 1072.689,302.5409 Q 1073.079,303.1926 1073.578,303.1926 Q 1073.934,303.1926 1074.619,302.8625 Q 1075.313,302.5324 1076.337,301.7115 Q 1076.43,301.7622 1076.566,302.0077 Q 1076.701,302.2531 1076.727,302.3124 Q 1075.339,303.5226 1074.433,304.0135 Q 1073.527,304.5044 1072.774,304.5044 Q 1072.309,304.5044 1071.733,304.2167 Q 1071.166,303.9374 1070.751,303.3026 Q 1070.345,302.6594 1070.345,301.593 Q 1070.345,300.2642 1070.963,299.1724 Q 1071.581,298.0721 1072.647,297.1835 Q 1073.028,296.8703 1073.705,296.5572 Q 1074.391,296.2356 1075.059,296.2356 Q 1076.016,296.2356 1076.464,296.7095 Q 1076.921,297.175 1076.921,297.7251 Z"
+       id="path2332"
+       style="font-style:italic;font-weight:bold;font-size:17.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 1083.387,296.7941 Q 1083.269,296.9549 1083.032,297.1919 Q 1082.795,297.4289 1082.558,297.632 Q 1082.321,297.8352 1082.219,297.8944 Q 1082.118,297.6574 1081.822,297.5897 Q 1081.525,297.5135 1080.984,297.5135 H 1077.827 L 1077.632,297.1835 L 1078.648,296.4979 H 1083.15 Z M 1082.871,302.8456 Q 1081.94,303.5819 1081.043,304.0474 Q 1080.146,304.5044 1079.68,304.5044 Q 1079.164,304.5044 1078.699,304.0305 Q 1078.242,303.548 1078.242,302.8032 Q 1078.242,302.4816 1078.258,302.1516 Q 1078.284,301.813 1078.36,301.3475 L 1079.181,296.2017 Q 1079.283,295.5415 1079.409,295.33 Q 1079.536,295.1184 1079.765,294.9999 L 1081.381,294.2043 L 1081.618,294.4159 Q 1081.551,294.4751 1081.424,294.8645 Q 1081.305,295.2453 1081.187,296.007 L 1080.467,300.5689 Q 1080.417,300.899 1080.391,301.2629 Q 1080.366,301.6268 1080.366,301.7961 Q 1080.366,302.3208 1080.518,302.5409 Q 1080.679,302.7609 1080.916,302.7609 Q 1081.441,302.7609 1082.643,302.2193 Z"
+       id="path2334"
+       style="font-style:italic;font-weight:bold;font-size:17.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 1092.172,303.2603 Q 1091.504,303.7173 1090.835,304.1151 Q 1090.175,304.5044 1089.76,304.5044 Q 1089.464,304.5044 1089.168,304.1743 Q 1088.88,303.8443 1088.719,303.1672 Q 1088.567,302.4901 1088.669,301.4491 Q 1088.719,300.9243 1088.821,300.315 Q 1088.931,299.6971 1089.024,299.1385 Q 1089.117,298.5799 1089.117,298.2329 Q 1089.117,297.8436 1089.032,297.759 Q 1088.948,297.6659 1088.804,297.6659 Q 1088.694,297.6659 1088.465,297.7336 Q 1088.245,297.8013 1088.068,297.869 L 1087.915,297.302 Q 1088.389,297.0819 1089.007,296.8365 Q 1089.625,296.591 1090.15,296.4133 Q 1090.683,296.2356 1090.886,296.2356 Q 1091.123,296.2356 1091.199,296.3964 Q 1091.275,296.5572 1091.275,296.9465 Q 1091.275,297.3189 1091.182,297.9283 Q 1091.089,298.5292 1090.971,299.2147 Q 1090.852,299.8918 1090.759,300.5181 Q 1090.666,301.1444 1090.666,301.5591 Q 1090.666,302.3293 1090.784,302.634 Q 1090.903,302.9387 1091.115,302.9387 Q 1091.335,302.9387 1091.521,302.8879 Q 1091.715,302.8286 1092.02,302.7017 Z M 1088.787,300.6874 L 1088.694,302.3124 Q 1088.042,303.2518 1087.187,303.8781 Q 1086.333,304.5044 1085.554,304.5044 Q 1085.232,304.5044 1084.885,304.2674 Q 1084.538,304.0389 1084.293,303.5734 Q 1084.056,303.1079 1084.056,302.4224 Q 1084.056,302.0415 1084.141,301.466 Q 1084.225,300.8905 1084.335,300.2642 Q 1084.445,299.6294 1084.53,299.0878 Q 1084.615,298.5461 1084.615,298.2329 Q 1084.615,297.8436 1084.513,297.759 Q 1084.42,297.6659 1084.268,297.6659 Q 1084.166,297.6659 1083.912,297.7336 Q 1083.658,297.8013 1083.463,297.869 L 1083.328,297.302 Q 1083.811,297.0819 1084.445,296.8365 Q 1085.08,296.591 1085.622,296.4133 Q 1086.172,296.2356 1086.375,296.2356 Q 1086.62,296.2356 1086.705,296.3964 Q 1086.79,296.5572 1086.79,296.9465 Q 1086.79,297.3189 1086.688,297.9875 Q 1086.587,298.6561 1086.451,299.4178 Q 1086.316,300.1711 1086.214,300.8397 Q 1086.113,301.5083 1086.113,301.8723 Q 1086.113,302.3462 1086.248,302.6001 Q 1086.392,302.8456 1086.561,302.8456 Q 1086.857,302.8456 1087.441,302.3462 Q 1088.025,301.8384 1088.787,300.6874 Z"
+       id="path2336"
+       style="font-style:italic;font-weight:bold;font-size:17.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 1099.993,296.9634 Q 1099.883,297.0988 1099.713,297.3866 Q 1099.544,297.6743 1099.358,297.9875 Q 1099.172,298.3007 1099.011,298.5207 Q 1098.859,298.7408 1098.774,298.7408 Q 1098.562,298.7408 1098.376,298.5799 Q 1098.19,298.4191 1098.012,298.2583 Q 1097.843,298.0891 1097.682,298.0891 Q 1097.386,298.0891 1097.014,298.4615 Q 1096.641,298.8254 1096.294,299.4686 Q 1095.947,300.1034 1095.71,300.9159 Q 1095.524,301.5506 1095.414,302.2531 Q 1095.304,302.9556 1095.329,303.6242 Q 1095.152,303.7004 1094.745,303.8866 Q 1094.339,304.0643 1093.95,304.242 Q 1093.56,304.4282 1093.417,304.5044 L 1093.078,304.1743 Q 1093.324,302.9725 1093.527,301.8045 Q 1093.73,300.6281 1093.848,299.6887 Q 1093.967,298.7408 1093.967,298.2329 Q 1093.967,297.8436 1093.865,297.759 Q 1093.764,297.6659 1093.62,297.6659 Q 1093.501,297.6659 1093.222,297.7505 Q 1092.943,297.8267 1092.816,297.869 L 1092.663,297.302 Q 1093.146,297.0819 1093.764,296.8365 Q 1094.39,296.591 1094.923,296.4133 Q 1095.456,296.2356 1095.659,296.2356 Q 1095.896,296.2356 1095.973,296.4133 Q 1096.057,296.5826 1096.057,297.0819 Q 1096.057,297.2596 1096.006,297.6828 Q 1095.956,298.0975 1095.905,298.4191 Q 1096.455,297.5305 1096.895,297.0565 Q 1097.344,296.5826 1097.733,296.4133 Q 1098.122,296.2356 1098.486,296.2356 Q 1098.782,296.2356 1099.197,296.5233 Q 1099.62,296.8111 1099.993,296.9634 Z"
+       id="path2338"
+       style="font-style:italic;font-weight:bold;font-size:17.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 1108.456,303.2264 Q 1107.948,303.5311 1107.381,303.8273 Q 1106.823,304.1236 1106.332,304.3098 Q 1105.841,304.5044 1105.562,304.5044 Q 1105.266,304.5044 1105.071,304.2336 Q 1104.876,303.9712 1104.876,303.5142 Q 1104.876,303.3364 1104.944,302.871 Q 1105.012,302.4055 1105.113,301.7961 Q 1105.223,301.1867 1105.325,300.5773 Q 1105.426,299.9595 1105.494,299.4686 Q 1105.57,298.9693 1105.57,298.7408 Q 1105.57,298.2414 1105.477,298.0467 Q 1105.392,297.8436 1105.122,297.8436 Q 1104.893,297.8436 1104.36,298.1483 Q 1103.827,298.453 1103.336,299.2486 Q 1103.082,299.6464 1102.938,300.2219 Q 1102.803,300.7889 1102.659,301.6099 Q 1102.523,302.3631 1102.481,302.7948 Q 1102.447,303.218 1102.464,303.6242 Q 1102.346,303.675 1102.075,303.7935 Q 1101.812,303.912 1101.499,304.0558 Q 1101.186,304.1997 1100.915,304.3182 Q 1100.653,304.4452 1100.551,304.5044 L 1100.213,304.1743 Q 1100.382,303.3364 1100.543,302.4224 Q 1100.704,301.4999 1100.831,300.6535 Q 1100.958,299.8072 1101.034,299.1639 Q 1101.11,298.5122 1101.11,298.216 Q 1101.11,297.8267 1101.025,297.7421 Q 1100.941,297.649 1100.788,297.649 Q 1100.67,297.649 1100.374,297.7336 Q 1100.086,297.8182 1099.95,297.869 L 1099.79,297.285 Q 1100.145,297.1327 1100.602,296.9549 Q 1101.068,296.7688 1101.516,296.6079 Q 1101.973,296.4387 1102.32,296.3371 Q 1102.667,296.2356 1102.794,296.2356 Q 1103.031,296.2356 1103.107,296.4133 Q 1103.192,296.591 1103.192,297.1919 Q 1103.192,297.5982 1103.133,298.0383 Q 1104.055,297.1242 1104.952,296.6841 Q 1105.85,296.2356 1106.611,296.2356 Q 1107.144,296.2356 1107.432,296.4979 Q 1107.728,296.7603 1107.728,297.5813 Q 1107.728,298.0214 1107.618,298.6984 Q 1107.508,299.3671 1107.364,300.1034 Q 1107.229,300.8312 1107.119,301.466 Q 1107.009,302.0923 1107.009,302.4393 Q 1107.009,302.7271 1107.085,302.8371 Q 1107.161,302.9387 1107.314,302.9387 Q 1107.508,302.9387 1107.711,302.8794 Q 1107.915,302.8117 1108.236,302.6594 Z"
+       id="path2340"
+       style="font-style:italic;font-weight:bold;font-size:17.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold Italic';word-spacing:0px" />
+    <path
+       d="M 435.9787,456.6968 L 435.6187,456.0435 C 435.1787,456.3368 434.6987,456.4835 434.192,456.4835 C 433.8454,456.4835 433.4987,456.4035 433.1654,456.2702 C 432.832,456.1102 432.5254,455.8968 432.2587,455.6035 C 431.992,455.3102 431.7787,454.9369 431.6187,454.4835 C 431.4454,454.0435 431.3654,453.5102 431.3654,452.9102 C 431.3654,452.2835 431.432,451.7502 431.5787,451.3102 C 431.7254,450.8702 431.912,450.4968 432.1254,450.2168 C 432.3654,449.9369 432.6187,449.7235 432.8987,449.5769 C 433.1787,449.4436 433.472,449.3769 433.752,449.3769 C 433.992,449.3769 434.2187,449.4169 434.4453,449.5235 C 434.6587,449.6035 434.8453,449.7369 435.0053,449.8969 C 435.1787,450.0702 435.2987,450.2568 435.4053,450.4835 C 435.4853,450.6968 435.5387,450.9236 435.5387,451.1769 H 435.3387 C 434.352,451.1769 433.632,451.3502 433.192,451.7102 C 432.7387,452.0702 432.512,452.5635 432.512,453.2169 C 432.512,453.4302 432.552,453.6302 432.6454,453.8302 C 432.7387,454.0302 432.8587,454.2035 433.0187,454.3502 C 433.1787,454.5101 433.3654,454.6435 433.5787,454.7235 C 433.792,454.8301 434.032,454.8702 434.2853,454.8702 C 434.8053,454.8702 435.232,454.6701 435.5787,454.2568 V 454.7635 H 436.3787 V 452.0568 C 436.3787,451.4569 436.312,450.9502 436.1787,450.5102 C 436.0587,450.0835 435.872,449.7369 435.6453,449.4569 C 435.4187,449.1769 435.1387,448.9769 434.8187,448.8569 C 434.512,448.7235 434.1654,448.6568 433.792,448.6568 C 433.4054,448.6568 433.032,448.7368 432.6587,448.9102 C 432.272,449.0836 431.9387,449.3369 431.6187,449.6835 C 431.3254,450.0302 431.072,450.4702 430.872,451.0169 C 430.6854,451.5502 430.592,452.1902 430.592,452.9236 C 430.592,453.6702 430.6854,454.3102 430.8987,454.8569 C 431.0854,455.4035 431.352,455.8435 431.6987,456.1902 C 432.0187,456.5501 432.4054,456.8035 432.8187,456.9902 C 433.232,457.1502 433.672,457.2435 434.112,457.2435 C 434.7787,457.2435 435.4053,457.0569 435.9787,456.6968 Z M 435.5787,451.8435 V 452.0968 C 435.5787,452.7901 435.4987,453.3102 435.3253,453.6302 C 435.1653,453.9768 434.832,454.1368 434.3253,454.1368 C 434.072,454.1368 433.8454,454.0302 433.6454,453.8435 C 433.4454,453.6302 433.3387,453.3635 433.3387,453.0302 C 433.3387,452.6835 433.4987,452.4035 433.832,452.1768 C 434.152,451.9502 434.6587,451.8435 435.352,451.8435 Z"
+       id="path1332-8"
+       style="font-size:13.3333px;line-height:1.25;font-family:Inconsolatazi4varl_qu;-inkscape-font-specification:Inconsolatazi4varl_qu;word-spacing:0px;display:inline;stroke-width:0.999999" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.94488;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 437.2649,447.6255 L 433.4853,444.7909 L 429.7058,447.6255"
+       id="path1355-25"
+       sodipodi:nodetypes="ccc" />
+    <path
+       d="M 235.4014,130.5214 Q 235.4014,131.8443 234.9535,132.9901 Q 234.5056,134.1255 233.7556,134.9797 Q 233.0056,135.8339 232.0889,136.313 Q 231.1827,136.7922 230.2556,136.7922 Q 229.6306,136.7922 229.1723,136.438 Q 228.7139,136.0735 228.516,135.1047 Q 227.9535,135.7818 227.5577,136.1464 Q 227.1619,136.511 226.766,136.6464 Q 226.3806,136.7922 225.8285,136.7922 Q 225.1202,136.7922 224.4119,136.2714 Q 223.7035,135.7505 223.2348,134.6776 Q 222.766,133.5943 222.766,131.9276 Q 222.766,130.9485 223.0681,129.9797 Q 223.3702,129.011 223.9535,128.2193 Q 224.5473,127.4276 225.391,126.9589 Q 226.2348,126.4797 227.3077,126.4797 Q 227.7869,126.4797 228.1723,126.6568 Q 228.5681,126.8235 229.0681,127.4276 Q 229.6306,127.2297 230.0473,127.0214 Q 230.4743,126.8026 230.9431,126.4797 L 231.266,126.7922 Q 231.1618,127.1881 231.0577,127.8756 Q 230.9535,128.5526 230.9535,129.1776 V 133.511 Q 230.9535,134.1464 231.0993,134.4693 Q 231.2452,134.7922 231.6931,134.7922 Q 232.0368,134.7922 232.4223,134.3755 Q 232.8181,133.9485 233.0889,133.136 Q 233.3702,132.313 233.3702,131.1464 Q 233.3702,128.7714 232.6098,127.2089 Q 231.8493,125.636 230.4952,124.8547 Q 229.141,124.0735 227.3494,124.0735 Q 225.2244,124.0735 223.766,125.0318 Q 222.3077,125.9797 221.5577,127.5631 Q 220.8077,129.136 220.8077,131.0214 Q 220.8077,133.6568 221.7452,135.4276 Q 222.6827,137.1985 224.2556,138.0839 Q 225.8389,138.9797 227.766,138.9797 Q 229.0994,138.9797 230.2035,138.6776 Q 231.3077,138.3755 232.1098,137.9485 Q 232.9223,137.5318 233.3389,137.1776 L 233.8285,138.0735 Q 233.3285,138.6464 232.4223,139.2714 Q 231.5264,139.8964 230.2348,140.3339 Q 228.9431,140.7714 227.2556,140.7714 Q 224.6723,140.7714 222.6827,139.6776 Q 220.7035,138.5943 219.5785,136.5422 Q 218.4639,134.5005 218.4639,131.636 Q 218.4639,129.7505 219.1723,128.0631 Q 219.891,126.3756 221.1514,125.0735 Q 222.4223,123.7714 224.1098,123.0318 Q 225.7973,122.2818 227.7556,122.2818 Q 230.016,122.2818 231.7348,123.1881 Q 233.4639,124.0839 234.4327,125.9172 Q 235.4014,127.7401 235.4014,130.5214 Z M 228.4535,128.8651 Q 228.2244,128.4068 227.9327,128.136 Q 227.6514,127.8547 227.141,127.8547 Q 226.2244,127.8547 225.7452,128.761 Q 225.266,129.6568 225.266,131.6047 Q 225.266,132.7922 225.5056,133.5005 Q 225.7556,134.1985 226.1306,134.511 Q 226.5056,134.813 226.8806,134.813 Q 227.2869,134.813 227.5889,134.563 Q 227.9014,134.313 228.4535,133.563 Z"
+       id="path2396"
+       style="font-weight:bold;font-size:21.3333px;line-height:1.25;font-family:'Gentium Plus mbg';-inkscape-font-specification:'Gentium Plus mbg Bold';word-spacing:0px" />
+  </g>
+</svg>


### PR DESCRIPTION
Ihr werdet den PR vermutlich nicht mergen, weil das Layout nicht eurem CI/CD entspricht. Ich reiche es aber trotzdem als PR ein, damit das Office meines neuen Arbeitgebers das so bestellen kann. Wenn ihr das trotzdem mergt bin ich aber auch nicht traurig ☻

Falls es beim Durchsehen Probleme geben sollte, bitte direkt mit mir besprechen; ich habe mich an den Mindestabstand vom DE-Layout gehalten und dessen GRID-Layer kopiert.

Vielen Dank im Voraus!

----

This is a nōn-standard layout for most Latin-based languages.

<a align="center" href="https://mbsd.evolvis.org/mirkbd.htm"><tt>https://mbsd.evolvis.org/mirkbd.htm</tt></a>

Features Compose key, Layer 3/4 switch, lots of extra characters (line drawing, typographic apostrophes (EN) and double quotes (EN/DE), Euro, ellipsis, arrows, extra brackets, …), no Caps Lock key, swapped Esc with `` ` `` for easier reach. The depicted layout corresponds to the “default” in xkb without more options. The numpad shows the Pointer_EnableKeys mapping, and additionally the hexadecimal codepoint entry labels for the Linux text console.

This layout indeed has no Super key; the usual position is taken by the Alt modifier, whereas the Alt key has the functionality of the Meta/L3 switch. (The xkb options “lwinsuper” and “raltsuper” can be used to add a Super key, if one is desired, but it’s not part of the “standard” MirKeyboardLayout.)