### PR TITLE
Add new layout for German NEO2

### DIFF
--- a/InfinityBook Pro/Pro 14 (Gen9 & Gen10)/TUXEDO - InfinityBookPro14-Gen9 - DE NEO2.svg
+++ b/InfinityBook Pro/Pro 14 (Gen9 & Gen10)/TUXEDO - InfinityBookPro14-Gen9 - DE NEO2.svg
@@ -1,0 +1,4373 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   width="1245.6293"
+   height="510.23599"
+   viewBox="0 0 1245.6293 510.23599"
+   sodipodi:docname="TUXEDO - InfinityBookPro14-Gen9 - DE NEO2_2.svg"
+   inkscape:version="1.2 (dc2aeda, 2022-05-15)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath83">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-176.09991,-233.5777)"
+         id="path83" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath85">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-228.52381,-232.21731)"
+         id="path85" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath87">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-287.23671,-232.21731)"
+         id="path87" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath89">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-336.91641,-237.44971)"
+         id="path89" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath91">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-392.76011,-232.19781)"
+         id="path91" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath93">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-442.75131,-232.47021)"
+         id="path93" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath95">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-502.03451,-242.4859)"
+         id="path95" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath97">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-554.57161,-242.21391)"
+         id="path97" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath99">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-606.92411,-233.55811)"
+         id="path99" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath101">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-660.19562,-237.23781)"
+         id="path101" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath103">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-716.10282,-243.78181)"
+         id="path103" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath105">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-190.2366,-188.5318)"
+         id="path105" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath107">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-240.73081,-182.27691)"
+         id="path107" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath109">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-296.43691,-181.1304)"
+         id="path109" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath111">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-350.64391,-179.7808)"
+         id="path111" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath113">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-406.56281,-179.7613)"
+         id="path113" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath115">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-457.38221,-179.7613)"
+         id="path115" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath117">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-515.14192,-190.04931)"
+         id="path117" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath119">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-565.32451,-179.7613)"
+         id="path119" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath121">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-624.13412,-179.7603)"
+         id="path121" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath123">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-675.70832,-191.3443)"
+         id="path123" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath125">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-729.55992,-191.3452)"
+         id="path125" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath127">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-217.70931,-127.34721)"
+         id="path127" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath129">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-268.66341,-127.34721)"
+         id="path129" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath131">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-325.92031,-127.34721)"
+         id="path131" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath133">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-379.57361,-127.34721)"
+         id="path133" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath135">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-431.07461,-128.65581)"
+         id="path135" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath137">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-484.23181,-127.32771)"
+         id="path137" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath139">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-542.80501,-137.6158)"
+         id="path139" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath141">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-783.48572,-183.4507)"
+         id="path141" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath143">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-594.96121,-129.57081)"
+         id="path143" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath145">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-166.5736,-135.2349)"
+         id="path145" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath147">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-97.3099,-290.46391)"
+         id="path147" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath149">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-648.81772,-129.56991)"
+         id="path149" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath151">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-703.48962,-131.8111)"
+         id="path151" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath153">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-769.89782,-237.98641)"
+         id="path153" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath155">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-742.17512,-294.9043)"
+         id="path155" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath157">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-688.41832,-290.4478)"
+         id="path157" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath159">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-147.6615,-292.4317)"
+         id="path159" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath161">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-200.6488,-284.9278)"
+         id="path161" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath163">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-257.06091,-290.46391)"
+         id="path163" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath165">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-312.44961,-287.9839)"
+         id="path165" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath167">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-365.72201,-290.09571)"
+         id="path167" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath169">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-418.57261,-286.01571)"
+         id="path169" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath171">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-472.12341,-284.65581)"
+         id="path171" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath173">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-526.22782,-286.01571)"
+         id="path173" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath175">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-580.06961,-289.87161)"
+         id="path175" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath177">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-633.97592,-286.01571)"
+         id="path177" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath179">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-152.52771,-118.6314)"
+         id="path179" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath181">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-759.72489,-225.65871)"
+         id="path181" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath183">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-584.20642,-114.5376)"
+         id="path183" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath185">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-638.02672,-114.55521)"
+         id="path185" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath187">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-694.84012,-112.4878)"
+         id="path187" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath189">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-92.3167,-275.48341)"
+         id="path189" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath191">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-140.1204,-271.85791)"
+         id="path191" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath193">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-195.724,-275.1319)"
+         id="path193" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath195">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-250.2025,-274.0288)"
+         id="path195" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath197">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-303.30891,-268.82911)"
+         id="path197" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath199">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-360.75421,-273.37891)"
+         id="path199" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath201">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-410.19371,-270.94831)"
+         id="path201" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath203">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-462.63121,-270.10311)"
+         id="path203" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath205">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-517.85581,-277.74711)"
+         id="path205" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath207">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-569.62432,-268.92001)"
+         id="path207" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath209">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-623.93291,-273.4702)"
+         id="path209" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath211">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-680.26691,-271.85791)"
+         id="path211" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath213">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-772.40462,-170.99271)"
+         id="path213" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath215">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-733.60482,-276.3067)"
+         id="path215" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath217">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-547.02862,-111.2359)"
+         id="path217" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath219">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-267.18001,-276.6148)"
+         id="path219" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath221">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-483.75131,-278.46241)"
+         id="path221" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath223">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-293.4769,-217.64211)"
+         id="path223" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath225">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-184.7806,-221.17141)"
+         id="path225" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath227">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-537.51892,-268.80471)"
+         id="path227" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath229">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-173.97981,-120.96051)"
+         id="path229" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath231">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-589.35091,-268.98001)"
+         id="path231" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath233">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-644.66831,-276.54591)"
+         id="path233" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath235">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-695.75711,-278.4619)"
+         id="path235" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath237">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-778.80009,-221.2906)"
+         id="path237" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath239">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-212.23861,-274.03761)"
+         id="path239" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath241">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-762.26169,-67.775402)"
+         id="path241" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath243">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-769.43469,-87.4792)"
+         id="path243" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath245">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-703.40142,-83.7154)"
+         id="path245" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath247">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-828.2794,-76.542399)"
+         id="path247" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath249">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-97.5169,-79.767099)"
+         id="path249" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath251">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-104.00331,-78.519099)"
+         id="path251" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath253">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-107.3929,-81.135302)"
+         id="path253" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath255">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-113.32551,-78.519099)"
+         id="path255" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath257">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-639.88211,-79.767099)"
+         id="path257" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath259">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-646.05011,-78.519099)"
+         id="path259" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath261">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-649.27961,-81.135302)"
+         id="path261" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath263">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-654.92512,-78.519099)"
+         id="path263" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath265">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-267.20251,-82.895102)"
+         id="path265" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath267">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-273.27381,-78.519099)"
+         id="path267" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath269">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-275.57851,-78.519099)"
+         id="path269" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath271">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-160.099,-78.519099)"
+         id="path271" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath273">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-164.14191,-78.519099)"
+         id="path273" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath275">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-585.18101,-82.895102)"
+         id="path275" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath277">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-590.95541,-78.519099)"
+         id="path277" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath279">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-593.16052,-78.519099)"
+         id="path279" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath281">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-599.14391,-78.519099)"
+         id="path281" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath283">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-602.45252,-81.135302)"
+         id="path283" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath285">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-102.5682,-126.57531)"
+         id="path285" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath287">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-93.9577,-229.61431)"
+         id="path287" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath289">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-110.4994,-227.07021)"
+         id="path289" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath291">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-824.44075,-63.958502)"
+         id="path291" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath293">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-826.28162,-63.958502)"
+         id="path293" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath295">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-831.24055,-64.471202)"
+         id="path295" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath297">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-837.7825,-63.958502)"
+         id="path297" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath299">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-756.05214,-56.411701)"
+         id="path299" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath301">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-760.51689,-60.947799)"
+         id="path301" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath303">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-764.58819,-55.915599)"
+         id="path303" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath305">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-766.47594,-56.427301)"
+         id="path305" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath307">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-774.23469,-55.659699)"
+         id="path307" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath309">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-756.05214,-79.032699)"
+         id="path309" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath311">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-760.51689,-83.568902)"
+         id="path311" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath313">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-764.58819,-78.536702)"
+         id="path313" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath315">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-766.47594,-79.048404)"
+         id="path315" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath317">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-774.54722,-82.0708)"
+         id="path317" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath319">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-695.06182,-66.366699)"
+         id="path319" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath321">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-699.99842,-64.471202)"
+         id="path321" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath323">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-703.34892,-65.143104)"
+         id="path323" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath325">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-707.74642,-67.998602)"
+         id="path325" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath327">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-765.26694,-321.15431)"
+         id="path327" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath329">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-770.81874,-318.87751)"
+         id="path329" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath331">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-777.59799,-318.30131)"
+         id="path331" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath333">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-781.94372,-318.30131)"
+         id="path333" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath335">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-786.22689,-318.30131)"
+         id="path335" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath337">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-788.25032,-318.30131)"
+         id="path337" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath339">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-819.7903,-270.28371)"
+         id="path339" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath341">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-821.97302,-275.9449)"
+         id="path341" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath343">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-824.01205,-270.28371)"
+         id="path343" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath345">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-829.32355,-270.28371)"
+         id="path345" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath347">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-835.3138,-270.28371)"
+         id="path347" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath349">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-829.6576,-290.44741)"
+         id="path349" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath351">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-827.94865,-229.71541)"
+         id="path351" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath353">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-831.451,-126.5787)"
+         id="path353" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath355">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-101.7972,-175.5144)"
+         id="path355" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath357">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-105.4461,-227.3935)"
+         id="path357" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath359">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-98.063702,-231.1879)"
+         id="path359" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath361">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-88.839205,-318.30081)"
+         id="path361" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath363">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-92.933905,-318.30081)"
+         id="path363" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath365">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-102.4906,-318.30081)"
+         id="path365" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath367">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-104.89491,-318.87701)"
+         id="path367" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath369">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-110.7874,-318.30081)"
+         id="path369" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath371">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-113.7826,-318.30081)"
+         id="path371" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath373">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-217.19671,-83.676205)"
+         id="path373" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath375">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-98.991505,-327.15871)"
+         id="path375" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath377">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-100.3021,-328.56251)"
+         id="path377" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath379">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-107.8236,-327.15871)"
+         id="path379" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath381">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-142.8568,-322.65681)"
+         id="path381" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath383">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-146.21811,-327.03081)"
+         id="path383" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath385">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-194.15751,-322.65681)"
+         id="path385" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath387">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-197.61561,-322.80961)"
+         id="path387" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath389">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-246.03841,-322.65871)"
+         id="path389" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath391">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-251.0218,-325.92581)"
+         id="path391" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath393">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-297.94861,-322.65681)"
+         id="path393" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath395">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-303.75911,-324.52881)"
+         id="path395" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath397">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-349.97491,-322.65871)"
+         id="path397" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath399">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-355.44081,-325.71881)"
+         id="path399" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath401">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-401.93201,-322.65871)"
+         id="path401" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath403">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-406.90851,-323.42391)"
+         id="path403" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath405">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-454.25521,-322.65681)"
+         id="path405" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath407">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-458.77181,-322.65681)"
+         id="path407" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath409">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-505.78841,-322.65681)"
+         id="path409" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath411">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-510.78352,-323.42191)"
+         id="path411" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath413">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-557.81182,-322.65871)"
+         id="path413" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath415">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-562.76891,-325.59281)"
+         id="path415" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath417">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-608.11652,-322.65871)"
+         id="path417" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath419">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-611.47781,-327.03271)"
+         id="path419" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath421">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-616.35682,-323.42391)"
+         id="path421" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath423">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-660.92411,-322.65871)"
+         id="path423" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath425">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-664.28552,-327.03271)"
+         id="path425" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath427">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-667.46711,-327.03271)"
+         id="path427" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath429">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-712.20732,-322.65681)"
+         id="path429" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath431">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-715.56872,-327.03081)"
+         id="path431" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath433">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-718.88122,-322.80961)"
+         id="path433" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath435">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-824.57162,-322.65681)"
+         id="path435" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath437">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-826.6927,-322.65681)"
+         id="path437" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath439">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-833.10775,-322.65681)"
+         id="path439" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath441">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-836.44375,-322.65681)"
+         id="path441" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath443">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-767.09109,-327.92241)"
+         id="path443" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath445">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-772.18389,-330.10011)"
+         id="path445" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath447">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-779.22392,-332.94441)"
+         id="path447" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath449">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-783.67224,-327.15731)"
+         id="path449" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath451">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-787.03944,-327.15731)"
+         id="path451" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath453">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-651.98711,-70.447802)"
+         id="path453" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath455">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-107.9995,-295.90441)"
+         id="path455" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath457">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-111.31101,-296.29491)"
+         id="path457" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath459">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-112.8346,-296.29491)"
+         id="path459" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath461">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-166.3302,-299.71351)"
+         id="path461" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath463">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-163.01871,-299.32311)"
+         id="path463" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath465">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-216.52381,-295.90441)"
+         id="path465" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath467">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-219.8353,-296.29491)"
+         id="path467" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath469">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-214.8256,-322.37921)"
+         id="path469" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath471">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-162.8655,-328.09271)"
+         id="path471" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath473">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-162.8655,-329.99731)"
+         id="path473" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath475">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-162.8655,-322.37921)"
+         id="path475" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath477">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-166.6746,-326.18821)"
+         id="path477" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath479">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-159.0564,-326.18821)"
+         id="path479" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath481">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-160.1658,-328.88551)"
+         id="path481" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath483">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-165.5604,-328.88551)"
+         id="path483" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath485">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-165.5604,-323.50041)"
+         id="path485" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath487">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-160.17771,-323.50041)"
+         id="path487" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath489">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-734.11502,-321.55541)"
+         id="path489" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath491">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-269.21361,-328.05701)"
+         id="path491" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath493">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-262.26681,-323.14571)"
+         id="path493" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath495">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-271.30861,-323.14571)"
+         id="path495" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath497">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-263.78811,-323.14571)"
+         id="path497" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath499">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-582.96622,-322.27681)"
+         id="path499" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath501">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-582.58531,-323.99081)"
+         id="path501" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath503">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-579.71662,-327.53801)"
+         id="path503" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath505">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-529.31122,-322.61721)"
+         id="path505" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath507">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-530.45392,-321.47451)"
+         id="path507" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath509">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-521.88352,-327.56901)"
+         id="path509" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath511">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-526.64482,-328.90691)"
+         id="path511" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath513">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-528.16841,-323.75991)"
+         id="path513" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath515">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-477.67201,-323.75991)"
+         id="path515" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath517">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-419.28041,-327.56901)"
+         id="path517" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath519">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-422.81561,-329.36641)"
+         id="path519" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath521">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-426.63181,-325.66451)"
+         id="path521" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath523">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-633.18602,-327.85461)"
+         id="path523" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath525">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-629.48642,-328.20461)"
+         id="path525" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath527">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-636.86651,-325.66451)"
+         id="path527" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath529">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-317.24081,-81.715502)"
+         id="path529" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath531">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-319.93331,-80.599)"
+         id="path531" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath533">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-320.97131,-78.504002)"
+         id="path533" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath535">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-314.54831,-80.599)"
+         id="path535" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath537">
+      <path
+         d="M 0,382.677 H 934.222 V 0 H 0 Z"
+         transform="translate(-687.31372,-322.65771)"
+         id="path537" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="5.9375612"
+     inkscape:cx="791.655"
+     inkscape:cy="415.74308"
+     inkscape:window-width="3440"
+     inkscape:window-height="1359"
+     inkscape:window-x="0"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer-MC1"
+     showgrid="false"
+     showguides="true">
+    <inkscape:page
+       x="0"
+       y="0"
+       inkscape:label="1"
+       id="page1"
+       width="1245.6293"
+       height="510.23599"
+       margin="68.691063 110.132 60.089333 107.80427"
+       bleed="0" />
+    <sodipodi:guide
+       position="592.70969,309.59759"
+       orientation="0,-1"
+       id="guide4122"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="523.00747,323.31439"
+       orientation="0,-1"
+       id="guide4124"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="200.69,379.54092"
+       orientation="0,-1"
+       id="guide4126"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="775.15415,393.25813"
+       orientation="0,-1"
+       id="guide4128"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="365.23588,183.51359"
+       orientation="0,-1"
+       id="guide4134"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="357.42788,169.79626"
+       orientation="0,-1"
+       id="guide4136"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="166.01208,284.91688"
+       orientation="1,0"
+       id="guide4203"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="171.84751,302.0659"
+       orientation="1,0"
+       id="guide4205"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="235.716,336.58932"
+       orientation="1,0"
+       id="guide4207"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="307.556,336.58932"
+       orientation="1,0"
+       id="guide4209"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="379.356,336.58932"
+       orientation="1,0"
+       id="guide4211"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="451.15133,336.58932"
+       orientation="1,0"
+       id="guide4213"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="522.99133,336.58932"
+       orientation="1,0"
+       id="guide4215"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="594.75133,336.58932"
+       orientation="1,0"
+       id="guide4217"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="666.59,336.58932"
+       orientation="1,0"
+       id="guide4219"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="738.39466,336.58932"
+       orientation="1,0"
+       id="guide4221"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="810.19133,336.58932"
+       orientation="1,0"
+       id="guide4223"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="882.03133,336.58932"
+       orientation="1,0"
+       id="guide4225"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="953.83466,336.58932"
+       orientation="1,0"
+       id="guide4227"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1025.63,336.58932"
+       orientation="1,0"
+       id="guide4229"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="253.66667,266.69065"
+       orientation="1,0"
+       id="guide4231"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="325.50667,266.69065"
+       orientation="1,0"
+       id="guide4233"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="400.57799,365.71906"
+       orientation="1,0"
+       id="guide4235"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="469.102,266.69065"
+       orientation="1,0"
+       id="guide4237"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="540.942,266.69065"
+       orientation="1,0"
+       id="guide4239"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="612.702,266.69065"
+       orientation="1,0"
+       id="guide4241"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="684.54066,266.69065"
+       orientation="1,0"
+       id="guide4243"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="756.34533,266.69065"
+       orientation="1,0"
+       id="guide4245"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="828.142,266.69065"
+       orientation="1,0"
+       id="guide4247"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="971.78533,266.69065"
+       orientation="1,0"
+       id="guide4251"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1043.5807,266.69065"
+       orientation="1,0"
+       id="guide4253"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="217.72333,196.79199"
+       orientation="1,0"
+       id="guide4255"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="289.596,196.79199"
+       orientation="1,0"
+       id="guide4257"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="361.396,196.79199"
+       orientation="1,0"
+       id="guide4259"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="433.19,196.79199"
+       orientation="1,0"
+       id="guide4261"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="505.03133,196.79199"
+       orientation="1,0"
+       id="guide4263"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="576.79133,196.79199"
+       orientation="1,0"
+       id="guide4265"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="648.63,196.79199"
+       orientation="1,0"
+       id="guide4267"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="720.43466,196.79199"
+       orientation="1,0"
+       id="guide4269"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="792.20333,196.79199"
+       orientation="1,0"
+       id="guide4271"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="864.012,196.79199"
+       orientation="1,0"
+       id="guide4273"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="199.77333,406.53731"
+       orientation="1,0"
+       id="guide4277"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="271.61333,406.53731"
+       orientation="1,0"
+       id="guide4279"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="343.41333,406.53731"
+       orientation="1,0"
+       id="guide4281"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="415.20733,406.53731"
+       orientation="1,0"
+       id="guide4283"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="487.04867,406.53731"
+       orientation="1,0"
+       id="guide4285"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="558.80867,406.53731"
+       orientation="1,0"
+       id="guide4287"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="630.64733,406.53731"
+       orientation="1,0"
+       id="guide4289"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="702.452,406.53731"
+       orientation="1,0"
+       id="guide4291"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="774.24733,406.53731"
+       orientation="1,0"
+       id="guide4293"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="846.08733,406.53731"
+       orientation="1,0"
+       id="guide4295"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="917.89066,406.53731"
+       orientation="1,0"
+       id="guide4297"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="989.68598,406.53732"
+       orientation="1,0"
+       id="guide4299"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="527.546,246.56638"
+       orientation="0,-1"
+       id="guide5753"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="581.35599,316.45625"
+       orientation="0,-1"
+       id="guide5755"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="576.92014,176.62906"
+       orientation="0,-1"
+       id="guide5757"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="403.96921,365.72746"
+       orientation="0,-1"
+       id="guide6637"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="328.81933,371.28239"
+       orientation="1,0"
+       id="guide6639"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="355.02598,348.37065"
+       orientation="1,0"
+       id="guide6695"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="122.33667,365.70972"
+       orientation="1,0"
+       id="guide6701"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="792.23001,108.12145"
+       orientation="0,-1"
+       id="guide3717"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="130.02253,111.55079"
+       orientation="1,0"
+       id="guide8075"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="130.02254,247.95476"
+       orientation="0,-1"
+       id="guide11860"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="190.81909,178.05611"
+       orientation="0,-1"
+       id="guide14876"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <g
+     id="layer-MC0"
+     inkscape:groupmode="layer"
+     inkscape:label="GRID">
+    <path
+       id="path1"
+       d="M 124,313.843 H 80.979 v 23.642 H 124 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path2"
+       d="M 117.701,261.403 H 80.978 v 43.5 h 36.723 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path3"
+       d="m 171.58,261.403 h -43.5 v 43.5 h 43.5 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path4"
+       d="m 225.46,261.403 h -43.5 v 43.5 h 43.5 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path5"
+       d="m 279.28,261.403 h -43.44 v 43.5 h 43.44 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path6"
+       d="m 333.152,261.41 h -43.493 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path7"
+       d="M 387.033,261.41 H 343.54 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path8"
+       d="M 440.853,261.41 H 397.36 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path9"
+       d="m 494.732,261.41 h -43.493 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path10"
+       d="m 548.559,261.41 h -43.44 v 43.493 h 43.44 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path11"
+       d="m 602.432,261.41 h -43.493 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path12"
+       d="m 656.312,261.41 h -43.493 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path13"
+       d="m 710.138,261.41 h -43.44 v 43.493 h 43.44 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path14"
+       d="m 764.011,261.41 h -43.493 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path15"
+       d="m 851.492,51.643 h -43.434 v 43.5 h 43.434 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path16"
+       d="m 851.498,261.41 h -77.1 v 43.493 h 77.1 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path17"
+       d="M 144.658,208.942 H 80.981 v 43.5 h 63.677 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path18"
+       d="m 198.537,208.942 h -43.5 v 43.5 h 43.5 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path19"
+       d="m 252.417,208.942 h -43.5 v 43.5 h 43.5 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path20"
+       d="m 306.237,208.942 h -43.44 v 43.5 h 43.44 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path21"
+       d="m 360.11,208.949 h -43.493 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path22"
+       d="m 413.99,208.949 h -43.493 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path23"
+       d="m 467.81,208.949 h -43.493 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path24"
+       d="m 521.689,208.949 h -43.493 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path25"
+       d="m 575.516,208.949 h -43.44 v 43.493 h 43.44 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path26"
+       d="m 629.39,208.949 h -43.493 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path27"
+       d="m 683.27,208.949 h -43.493 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path28"
+       d="m 737.096,208.949 h -43.44 v 43.493 h 43.44 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path29"
+       d="m 790.969,208.949 h -43.493 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path30"
+       d="m 851.498,208.949 h -50.143 v 43.493 h 50.143 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path31"
+       d="M 158.121,156.518 H 80.979 v 43.5 h 77.142 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path32"
+       d="m 212,156.518 h -43.5 v 43.5 H 212 Z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path33"
+       d="m 265.88,156.518 h -43.5 v 43.5 h 43.5 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path34"
+       d="m 319.7,156.518 h -43.44 v 43.5 h 43.44 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path35"
+       d="M 373.573,156.525 H 330.08 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path36"
+       d="M 427.453,156.525 H 383.96 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path37"
+       d="M 481.273,156.525 H 437.78 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path38"
+       d="m 535.152,156.525 h -43.493 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path39"
+       d="m 588.979,156.525 h -43.44 v 43.493 h 43.44 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path40"
+       d="M 642.853,156.525 H 599.36 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path41"
+       d="M 696.733,156.525 H 653.24 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path42"
+       d="m 750.559,156.525 h -43.44 v 43.493 h 43.44 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path43"
+       d="m 804.432,156.525 h -43.493 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path44"
+       d="m 851.498,156.524 h -36.68 v 43.493 h 36.68 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path45"
+       d="M 131.188,104.094 H 80.98 v 43.5 h 50.208 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path46"
+       d="m 185.019,104.094 h -43.453 v 43.5 h 43.453 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path47"
+       d="m 238.947,104.094 h -43.5 v 43.5 h 43.5 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path48"
+       d="m 292.767,104.094 h -43.44 v 43.5 h 43.44 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path49"
+       d="m 346.639,104.101 h -43.493 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path50"
+       d="m 400.52,104.101 h -43.493 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path51"
+       d="m 454.34,104.101 h -43.493 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path52"
+       d="m 508.219,104.101 h -43.493 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path53"
+       d="m 562.046,104.101 h -43.44 v 43.493 h 43.44 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path54"
+       d="m 615.879,104.101 h -43.453 v 43.493 h 43.453 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path55"
+       d="m 669.759,104.101 h -43.5 v 43.493 h 43.5 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path56"
+       d="m 723.625,104.101 h -43.44 v 43.493 h 43.44 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path57"
+       d="M 851.498,104.101 H 734.005 v 43.493 h 117.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path58"
+       d="M 131.187,51.643 H 80.979 v 43.5 h 50.208 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path59"
+       d="m 185.019,51.643 h -43.452 v 43.5 h 43.452 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path60"
+       d="m 238.947,51.643 h -43.5 v 43.5 h 43.5 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path61"
+       d="M 292.767,51.643 H 249.28 v 43.5 h 43.487 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path62"
+       d="M 562.059,51.65 H 303.147 v 43.493 h 258.912 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path63"
+       d="m 615.919,51.65 h -43.493 v 43.493 h 43.493 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path64"
+       d="m 669.758,51.65 h -43.452 v 43.493 h 43.452 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path65"
+       d="m 723.625,51.65 h -43.44 v 43.493 h 43.44 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path66"
+       d="m 797.678,74.323 h -63.66 v 20.82 h 63.66 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path67"
+       d="m 797.678,51.71 h -63.66 v 20.753 h 63.66 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path68"
+       d="m 175.96,313.843 h -43.02 v 23.642 h 43.02 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path69"
+       d="M 227.92,313.843 H 184.9 v 23.642 h 43.02 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path70"
+       d="m 279.88,313.843 h -43.02 v 23.642 h 43.02 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path71"
+       d="m 331.84,313.843 h -43.02 v 23.642 h 43.02 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path72"
+       d="m 383.806,313.843 h -43.027 v 23.642 h 43.027 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path73"
+       d="M 435.76,313.843 H 392.8 v 23.642 h 42.96 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path74"
+       d="m 487.719,313.843 h -42.96 v 23.642 h 42.96 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path75"
+       d="m 539.739,313.843 h -43.02 v 23.642 h 43.02 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path76"
+       d="m 591.699,313.843 h -43.021 v 23.642 h 43.021 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path77"
+       d="m 643.659,313.843 h -43.02 v 23.642 h 43.02 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path78"
+       d="m 695.618,313.843 h -43.02 v 23.642 h 43.02 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path79"
+       d="m 747.578,313.843 h -43.02 v 23.642 h 43.02 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path80"
+       d="m 799.538,313.843 h -43.02 v 23.642 h 43.02 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+    <path
+       id="path81"
+       d="m 851.497,313.843 h -42.961 v 23.642 h 42.961 z"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,510.236)" />
+  </g>
+  <g
+     id="layer-MC1"
+     inkscape:groupmode="layer"
+     inkscape:label="PRINT_DE">
+    <path
+       id="path82"
+       d="M 0,0 H 1.392 C 2.16,0 2.544,0.395 2.544,1.184 v 5.2 c 0,0.789 -0.384,1.184 -1.152,1.184 L 0,7.568 c -0.769,0 -1.152,-0.395 -1.152,-1.184 v -5.2 C -1.152,0.395 -0.769,0 0,0 M 2.992,-3.488 H 2.096 c -0.235,0 -0.406,0.091 -0.512,0.272 L 0.496,-1.36 H -0.24 c -0.789,0 -1.403,0.218 -1.84,0.656 -0.438,0.437 -0.656,1.045 -0.656,1.824 v 5.328 c 0,0.789 0.218,1.4 0.656,1.832 0.437,0.431 1.051,0.648 1.84,0.648 h 1.856 c 0.789,0 1.4,-0.217 1.832,-0.648 C 3.88,7.848 4.096,7.237 4.096,6.448 V 1.12 c 0,-0.693 -0.174,-1.251 -0.52,-1.672 -0.347,-0.422 -0.835,-0.675 -1.465,-0.76 l 1.073,-1.84 C 3.237,-3.259 3.242,-3.342 3.2,-3.4 3.157,-3.459 3.088,-3.488 2.992,-3.488"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,881.12398,198.8705)"
+       clip-path="url(#clipPath83)" />
+    <path
+       id="path84"
+       d="M 0,0 H -1.696 C -1.889,0 -2,0.091 -2.032,0.272 l -1.905,9.744 c -0.021,0.181 0.07,0.272 0.273,0.272 h 1.231 c 0.204,0 0.31,-0.091 0.321,-0.272 l 1.296,-8.384 h 0.095 l 1.889,8.416 c 0.02,0.16 0.117,0.24 0.287,0.24 H 2.8 c 0.17,0 0.271,-0.08 0.304,-0.24 L 5.008,1.632 H 5.104 L 6.399,10 c 0.011,0.192 0.118,0.288 0.321,0.288 h 1.231 c 0.214,0 0.305,-0.096 0.273,-0.288 L 6.319,0.272 C 6.287,0.091 6.181,0 6,0 H 4.304 C 4.122,0 4.016,0.091 3.983,0.272 L 2.176,8.368 H 2.111 L 0.304,0.272 C 0.271,0.091 0.17,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,520.13113,200.63841)"
+       clip-path="url(#clipPath85)" />
+    <path
+       id="path86"
+       d="m 0,0 h -5.119 c -0.182,0 -0.273,0.091 -0.273,0.272 v 9.744 c 0,0.181 0.091,0.272 0.273,0.272 H 0 c 0.171,0 0.257,-0.091 0.257,-0.272 V 9.2 C 0.257,9.019 0.171,8.928 0,8.928 h -3.647 c -0.128,0 -0.193,-0.053 -0.193,-0.16 V 6.064 c 0,-0.107 0.065,-0.16 0.193,-0.16 h 3.087 c 0.193,0 0.289,-0.091 0.289,-0.272 V 4.816 c 0,-0.181 -0.096,-0.272 -0.289,-0.272 h -3.087 c -0.128,0 -0.193,-0.053 -0.193,-0.16 V 1.536 c 0,-0.117 0.065,-0.176 0.193,-0.176 H 0 c 0.171,0 0.257,-0.09 0.257,-0.272 V 0.272 C 0.257,0.091 0.171,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,472.52533,270.52828)"
+       clip-path="url(#clipPath87)" />
+    <path
+       id="path88"
+       d="M 0,0 H 2.031 C 2.82,0 3.216,0.389 3.216,1.167 v 1.345 c 0,0.789 -0.396,1.184 -1.185,1.184 L 0,3.696 c -0.118,0 -0.177,-0.054 -0.177,-0.16 V 0.16 C -0.177,0.053 -0.118,0 0,0 m -0.448,-5.232 h -1.008 c -0.182,0 -0.273,0.09 -0.273,0.272 v 9.744 c 0,0.181 0.091,0.272 0.273,0.272 h 3.743 c 0.779,0 1.39,-0.222 1.832,-0.664 C 4.562,3.949 4.783,3.338 4.783,2.56 V 1.216 c 0,-1.227 -0.507,-2 -1.519,-2.32 v -0.064 l 1.775,-3.744 c 0.118,-0.214 0.049,-0.32 -0.208,-0.32 H 3.84 c -0.256,0 -0.422,0.09 -0.496,0.272 L 1.632,-1.28 H 0.016 c -0.128,0 -0.193,-0.054 -0.193,-0.16 v -3.52 c 0,-0.182 -0.091,-0.272 -0.271,-0.272"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,754.10145,263.55228)"
+       clip-path="url(#clipPath89)" />
+    <path
+       id="path90"
+       d="M 0,0 H -1.009 C -1.2,0 -1.296,0.091 -1.296,0.272 v 8.496 c 0,0.107 -0.054,0.16 -0.16,0.16 h -2.017 c -0.191,0 -0.288,0.091 -0.288,0.272 v 0.816 c 0,0.181 0.097,0.272 0.288,0.272 h 5.937 c 0.191,0 0.288,-0.091 0.288,-0.272 V 9.2 C 2.752,9.019 2.655,8.928 2.464,8.928 H 0.447 C 0.33,8.928 0.271,8.875 0.271,8.768 V 0.272 C 0.271,0.091 0.181,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,828.81466,270.52828)"
+       clip-path="url(#clipPath91)" />
+    <path
+       id="path92"
+       d="M 0,0 V 0.752 C 0,1.029 0.048,1.227 0.144,1.344 L 4.768,8.496 V 8.56 H 0.527 c -0.191,0 -0.288,0.09 -0.288,0.272 v 0.912 c 0,0.181 0.097,0.272 0.288,0.272 h 5.664 c 0.182,0 0.273,-0.091 0.273,-0.272 V 8.688 C 6.464,8.453 6.405,8.245 6.288,8.063 L 1.84,1.248 V 1.184 h 4.512 c 0.181,0 0.272,-0.085 0.272,-0.256 V 0.032 c 0,-0.203 -0.091,-0.304 -0.272,-0.304 H 0.271 C 0.09,-0.272 0,-0.182 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,572.50414,340.10293)"
+       clip-path="url(#clipPath93)" />
+    <path
+       id="path94"
+       d="M 0,0 H 1.008 C 1.2,0 1.296,-0.085 1.296,-0.256 v -7.552 c 0,-0.779 -0.222,-1.386 -0.664,-1.824 -0.443,-0.437 -1.054,-0.656 -1.832,-0.656 h -1.776 c -0.779,0 -1.386,0.219 -1.824,0.656 -0.437,0.438 -0.656,1.045 -0.656,1.824 v 7.536 c 0,0.181 0.091,0.272 0.272,0.272 h 1.008 c 0.181,0 0.272,-0.091 0.272,-0.272 v -7.472 c 0,-0.789 0.384,-1.184 1.152,-1.184 h 1.312 c 0.779,0 1.169,0.395 1.169,1.184 v 7.472 C -0.271,-0.091 -0.182,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,256.44066,256.8108)"
+       clip-path="url(#clipPath95)" />
+    <path
+       id="path96"
+       d="m 0,0 v -9.744 c 0,-0.181 -0.091,-0.272 -0.271,-0.272 H -1.28 c -0.181,0 -0.272,0.091 -0.272,0.272 V 0 c 0,0.181 0.091,0.272 0.272,0.272 h 1.009 C -0.091,0.272 0,0.181 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,326.54133,257.17361)"
+       clip-path="url(#clipPath97)" />
+    <path
+       id="path98"
+       d="m 0,0 h 1.392 c 0.779,0 1.169,0.395 1.169,1.184 v 5.2 c 0,0.789 -0.39,1.184 -1.169,1.184 L 0,7.568 c -0.768,0 -1.152,-0.395 -1.152,-1.184 v -5.2 C -1.152,0.395 -0.768,0 0,0 m 1.632,-1.36 h -1.856 c -0.79,0 -1.4,0.218 -1.832,0.656 -0.432,0.437 -0.648,1.045 -0.648,1.824 v 5.328 c 0,0.789 0.216,1.4 0.648,1.832 0.432,0.431 1.042,0.648 1.832,0.648 H 1.632 C 2.421,8.928 3.034,8.711 3.472,8.28 3.909,7.848 4.128,7.237 4.128,6.448 V 1.12 C 4.128,0.341 3.909,-0.267 3.472,-0.704 3.034,-1.142 2.421,-1.36 1.632,-1.36"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,539.99266,268.71495)"
+       clip-path="url(#clipPath99)" />
+    <path
+       id="path100"
+       d="m 0,0 h 2.128 c 0.757,0 1.136,0.395 1.136,1.184 v 1.52 c 0,0.789 -0.379,1.184 -1.136,1.184 H 0 c -0.118,0 -0.177,-0.054 -0.177,-0.16 V 0.16 C -0.177,0.054 -0.118,0 0,0 m -0.448,-5.04 h -1.008 c -0.182,0 -0.273,0.091 -0.273,0.272 v 9.744 c 0,0.181 0.091,0.272 0.273,0.272 H 2.352 C 3.13,5.248 3.738,5.032 4.176,4.6 4.612,4.168 4.831,3.557 4.831,2.768 V 1.104 C 4.831,0.325 4.612,-0.282 4.176,-0.72 3.738,-1.157 3.13,-1.376 2.352,-1.376 H 0.016 c -0.128,0 -0.193,-0.054 -0.193,-0.16 v -3.232 c 0,-0.181 -0.091,-0.272 -0.271,-0.272"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,502.92265,333.71973)"
+       clip-path="url(#clipPath101)" />
+    <path
+       id="path102"
+       d="m 0,0 v 1.52 c 0,0.181 0.08,0.272 0.24,0.272 h 0.976 c 0.16,0 0.24,-0.085 0.24,-0.256 V 0 c 0,-0.182 -0.08,-0.272 -0.24,-0.272 H 0.24 C 0.08,-0.272 0,-0.182 0,0 m -2.88,0 v 1.52 c 0,0.181 0.085,0.272 0.256,0.272 h 0.96 c 0.16,0 0.24,-0.085 0.24,-0.256 V 0 c 0,-0.182 -0.08,-0.272 -0.24,-0.272 h -0.96 c -0.171,0 -0.256,0.09 -0.256,0.272 m 4.256,-1.296 h 1.008 c 0.192,0 0.288,-0.085 0.288,-0.256 v -7.552 c 0,-0.779 -0.222,-1.386 -0.664,-1.824 -0.443,-0.437 -1.054,-0.656 -1.832,-0.656 H -1.6 c -0.779,0 -1.386,0.219 -1.824,0.656 -0.437,0.438 -0.656,1.045 -0.656,1.824 v 7.536 c 0,0.181 0.091,0.272 0.272,0.272 H -2.8 c 0.181,0 0.272,-0.091 0.272,-0.272 V -9.04 c 0,-0.789 0.384,-1.184 1.152,-1.184 h 1.312 c 0.779,0 1.168,0.395 1.168,1.184 v 7.472 c 0,0.181 0.09,0.272 0.272,0.272"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,290.50266,324.9944)"
+       clip-path="url(#clipPath103)" />
+    <path
+       id="path104"
+       d="M 0,0 -1.407,-5.12 H 1.488 L 0.064,0 Z m -2.624,-8.752 h -1.151 c -0.15,0 -0.204,0.091 -0.161,0.273 l 2.785,9.744 c 0.052,0.18 0.18,0.271 0.383,0.271 h 1.6 c 0.214,0 0.342,-0.091 0.385,-0.271 L 4,-8.479 C 4.043,-8.661 3.984,-8.752 3.824,-8.752 H 2.688 c -0.095,0 -0.163,0.019 -0.2,0.057 -0.037,0.037 -0.066,0.108 -0.088,0.216 l -0.608,2.08 h -3.52 l -0.608,-2.08 c -0.042,-0.182 -0.139,-0.273 -0.288,-0.273"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,397.26447,258.85895)"
+       clip-path="url(#clipPath105)" />
+    <path
+       id="path106"
+       d="m 0,0 v 0.416 c 0,0.181 0.091,0.271 0.272,0.271 h 1.025 c 0.181,0 0.271,-0.09 0.271,-0.271 V 0.128 c 0,-0.448 0.099,-0.772 0.296,-0.969 0.198,-0.197 0.526,-0.296 0.985,-0.296 h 1.103 c 0.459,0 0.789,0.105 0.992,0.313 0.202,0.208 0.304,0.546 0.304,1.015 V 0.56 C 5.248,0.901 5.117,1.17 4.856,1.367 4.595,1.564 4.272,1.693 3.889,1.752 3.505,1.811 3.083,1.893 2.624,2 2.166,2.106 1.744,2.229 1.36,2.367 0.977,2.506 0.653,2.768 0.393,3.151 0.131,3.536 0,4.026 0,4.624 V 5.296 C 0,6.074 0.222,6.685 0.664,7.128 1.106,7.57 1.718,7.792 2.496,7.792 H 4.192 C 4.981,7.792 5.598,7.57 6.04,7.128 6.483,6.685 6.704,6.074 6.704,5.296 V 4.943 C 6.704,4.762 6.613,4.672 6.433,4.672 H 5.408 c -0.181,0 -0.271,0.09 -0.271,0.271 V 5.151 C 5.137,5.61 5.038,5.938 4.841,6.136 4.643,6.333 4.314,6.432 3.856,6.432 H 2.849 C 2.39,6.432 2.062,6.328 1.864,6.12 1.667,5.912 1.568,5.557 1.568,5.056 V 4.56 C 1.568,4.08 1.915,3.754 2.608,3.584 2.918,3.509 3.257,3.445 3.624,3.392 3.992,3.338 4.363,3.258 4.736,3.151 5.109,3.045 5.451,2.903 5.761,2.728 6.069,2.552 6.32,2.285 6.513,1.928 6.704,1.57 6.801,1.136 6.801,0.624 V 0 C 6.801,-0.779 6.579,-1.39 6.137,-1.832 5.693,-2.275 5.083,-2.496 4.305,-2.496 H 2.513 c -0.78,0 -1.393,0.221 -1.84,0.664 C 0.225,-1.39 0,-0.779 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,608.16799,267.20028)"
+       clip-path="url(#clipPath107)" />
+    <path
+       id="path108"
+       d="m 0,0 h 2.256 c 0.767,0 1.151,0.395 1.151,1.185 v 5.2 c 0,0.789 -0.384,1.183 -1.151,1.183 H 0 c -0.118,0 -0.177,-0.053 -0.177,-0.16 V 0.177 C -0.177,0.059 -0.118,0 0,0 m -1.729,-1.088 v 9.744 c 0,0.182 0.091,0.273 0.273,0.273 H 2.479 C 3.258,8.929 3.869,8.712 4.312,8.28 4.754,7.849 4.976,7.237 4.976,6.448 V 1.12 C 4.976,0.342 4.754,-0.267 4.312,-0.704 3.869,-1.142 3.258,-1.359 2.479,-1.359 h -3.935 c -0.182,0 -0.273,0.089 -0.273,0.271"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,897.81733,268.71628)"
+       clip-path="url(#clipPath109)" />
+    <path
+       id="path110"
+       d="M 0,0 H -1.008 C -1.189,0 -1.28,0.09 -1.28,0.271 v 9.745 c 0,0.181 0.091,0.272 0.272,0.272 h 5.024 c 0.181,0 0.272,-0.091 0.272,-0.272 V 9.2 C 4.288,9.019 4.197,8.928 4.016,8.928 H 0.464 C 0.336,8.928 0.271,8.874 0.271,8.768 V 5.744 c 0,-0.118 0.065,-0.177 0.193,-0.177 h 3.088 c 0.192,0 0.288,-0.09 0.288,-0.271 v -0.8 C 3.84,4.304 3.744,4.208 3.552,4.208 H 0.464 C 0.336,4.208 0.271,4.154 0.271,4.048 V 0.271 C 0.271,0.09 0.181,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,808.18599,200.63841)"
+       clip-path="url(#clipPath111)" />
+    <path
+       id="path112"
+       d="m 0,0 h -1.712 c -0.79,0 -1.4,0.218 -1.832,0.655 -0.433,0.438 -0.648,1.046 -0.648,1.824 v 5.329 c 0,0.789 0.215,1.4 0.648,1.832 0.432,0.431 1.042,0.648 1.832,0.648 H 0 c 0.789,0 1.399,-0.217 1.832,-0.648 C 2.264,9.208 2.479,8.597 2.479,7.808 V 7.231 C 2.479,7.04 2.389,6.943 2.208,6.943 H 1.2 c -0.181,0 -0.272,0.097 -0.272,0.288 v 0.513 c 0,0.789 -0.384,1.184 -1.153,1.184 h -1.263 c -0.768,0 -1.153,-0.395 -1.153,-1.184 v -5.2 c 0,-0.79 0.385,-1.185 1.153,-1.185 h 1.263 c 0.769,0 1.153,0.395 1.153,1.185 v 1.439 c 0,0.107 -0.059,0.161 -0.176,0.161 h -1.296 c -0.182,0 -0.272,0.09 -0.272,0.272 v 0.815 c 0,0.182 0.09,0.273 0.272,0.273 h 2.688 c 0.224,0 0.335,-0.112 0.335,-0.336 V 2.479 C 2.479,1.701 2.261,1.093 1.824,0.655 1.387,0.218 0.778,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,739.53665,200.63841)"
+       clip-path="url(#clipPath113)" />
+    <path
+       id="path114"
+       d="M 0,0 H -1.008 C -1.189,0 -1.28,0.09 -1.28,0.271 v 9.745 c 0,0.181 0.091,0.272 0.272,0.272 H 0 c 0.181,0 0.271,-0.091 0.271,-0.272 v -4 c 0,-0.107 0.065,-0.161 0.193,-0.161 H 3.84 C 3.946,5.855 4,5.909 4,6.016 v 4 c 0,0.181 0.09,0.272 0.271,0.272 h 1.025 c 0.181,0 0.271,-0.091 0.271,-0.272 V 0.271 C 5.567,0.09 5.477,0 5.296,0 H 4.271 C 4.09,0 4,0.09 4,0.271 V 4.319 C 4,4.426 3.946,4.479 3.84,4.479 H 0.464 C 0.336,4.479 0.271,4.426 0.271,4.319 V 0.271 C 0.271,0.09 0.181,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,663.73199,200.63841)"
+       clip-path="url(#clipPath115)" />
+    <path
+       id="path116"
+       d="M 0,0 H 1.008 C 1.189,0 1.28,-0.086 1.28,-0.256 v -7.553 c 0,-0.778 -0.218,-1.386 -0.656,-1.824 -0.437,-0.437 -1.045,-0.655 -1.824,-0.655 h -1.6 c -0.789,0 -1.402,0.218 -1.84,0.655 -0.437,0.438 -0.656,1.046 -0.656,1.824 v 1.441 c 0,0.181 0.096,0.271 0.288,0.271 H -4 c 0.182,0 0.272,-0.09 0.272,-0.271 v -1.376 c 0,-0.79 0.384,-1.185 1.152,-1.185 h 1.137 c 0.767,0 1.151,0.395 1.151,1.185 v 7.472 C -0.288,-0.091 -0.191,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,938.55066,326.74827)"
+       clip-path="url(#clipPath117)" />
+    <path
+       id="path118"
+       d="M 0,0 H -1.008 C -1.189,0 -1.28,0.09 -1.28,0.271 v 9.745 c 0,0.181 0.091,0.272 0.272,0.272 H 0 c 0.181,0 0.271,-0.091 0.271,-0.272 V 4.943 h 0.048 c 0.107,0.288 0.246,0.555 0.416,0.801 l 3.057,4.272 c 0.117,0.181 0.288,0.272 0.512,0.272 h 1.183 c 0.225,0 0.262,-0.101 0.113,-0.305 L 2.479,5.744 6,0.319 C 6.128,0.106 6.063,0 5.808,0 H 4.912 C 4.624,0 4.421,0.09 4.304,0.271 L 1.536,4.607 0.271,3.12 V 0.271 C 0.271,0.09 0.181,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,591.56214,200.63841)"
+       clip-path="url(#clipPath119)" />
+    <path
+       id="path120"
+       d="m 0,0 h -5.184 c -0.181,0 -0.272,0.091 -0.272,0.272 v 9.745 c 0,0.18 0.091,0.271 0.272,0.271 h 1.008 c 0.181,0 0.272,-0.091 0.272,-0.271 V 1.552 c 0,-0.107 0.064,-0.159 0.192,-0.159 H 0 c 0.182,0 0.272,-0.097 0.272,-0.289 V 0.272 C 0.272,0.091 0.182,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,382.812,200.63841)"
+       clip-path="url(#clipPath121)" />
+    <path
+       id="path122"
+       d="m 0,0 v 1.521 c 0,0.18 0.085,0.271 0.256,0.271 h 0.96 c 0.171,0 0.256,-0.085 0.256,-0.256 V 0 c 0,-0.182 -0.085,-0.271 -0.256,-0.271 H 0.256 C 0.085,-0.271 0,-0.182 0,0 m -1.408,-10.224 h 1.391 c 0.78,0 1.169,0.395 1.169,1.184 v 5.2 c 0,0.789 -0.389,1.185 -1.169,1.185 h -1.391 c -0.768,0 -1.153,-0.396 -1.153,-1.185 v -5.2 c 0,-0.789 0.385,-1.184 1.153,-1.184 M -2.88,0 v 1.521 c 0,0.18 0.085,0.271 0.256,0.271 h 0.96 c 0.171,0 0.256,-0.085 0.256,-0.256 V 0 c 0,-0.182 -0.085,-0.271 -0.256,-0.271 h -0.96 c -0.171,0 -0.256,0.089 -0.256,0.271 m 3.104,-11.584 h -1.856 c -0.79,0 -1.4,0.219 -1.832,0.656 -0.432,0.438 -0.648,1.045 -0.648,1.824 v 5.329 c 0,0.789 0.216,1.399 0.648,1.832 0.432,0.431 1.042,0.647 1.832,0.647 h 1.856 c 0.789,0 1.402,-0.216 1.839,-0.647 0.438,-0.433 0.657,-1.043 0.657,-1.832 v -5.329 c 0,-0.779 -0.219,-1.386 -0.657,-1.824 -0.437,-0.437 -1.05,-0.656 -1.839,-0.656"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,362.324,324.9944)"
+       clip-path="url(#clipPath123)" />
+    <path
+       id="path124"
+       d="m 0,0 v 1.52 c 0,0.181 0.08,0.272 0.24,0.272 h 0.976 c 0.16,0 0.24,-0.086 0.24,-0.256 V 0 c 0,-0.182 -0.08,-0.272 -0.24,-0.272 H 0.24 C 0.08,-0.272 0,-0.182 0,0 m -0.736,-2.832 -1.408,-5.12 h 2.896 l -1.424,5.12 z M -2.88,0 v 1.52 c 0,0.181 0.085,0.272 0.256,0.272 h 0.96 c 0.16,0 0.24,-0.086 0.24,-0.256 V 0 c 0,-0.182 -0.08,-0.272 -0.24,-0.272 h -0.96 c -0.171,0 -0.256,0.09 -0.256,0.272 m -0.48,-11.584 h -1.152 c -0.149,0 -0.203,0.09 -0.16,0.271 l 2.784,9.745 c 0.053,0.181 0.181,0.272 0.384,0.272 h 1.6 c 0.214,0 0.341,-0.091 0.384,-0.272 l 2.784,-9.745 c 0.043,-0.181 -0.016,-0.271 -0.176,-0.271 H 1.952 c -0.096,0 -0.163,0.019 -0.2,0.056 -0.037,0.037 -0.066,0.109 -0.088,0.215 l -0.608,2.081 h -3.52 l -0.608,-2.081 c -0.042,-0.181 -0.139,-0.271 -0.288,-0.271"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,434.12913,324.9944)"
+       clip-path="url(#clipPath125)" />
+    <path
+       id="path126"
+       d="M 0,0 H -1.024 C -1.206,0 -1.296,0.09 -1.296,0.271 V 3.808 L -4.288,10 c -0.043,0.085 -0.043,0.154 0,0.208 0.042,0.053 0.101,0.08 0.176,0.08 h 1.28 c 0.139,0 0.245,-0.091 0.32,-0.272 l 1.968,-4.4 h 0.096 l 1.936,4.4 c 0.064,0.181 0.17,0.272 0.32,0.272 h 1.28 c 0.085,0 0.146,-0.027 0.183,-0.08 C 3.309,10.154 3.307,10.085 3.264,10 L 0.271,3.808 V 0.271 C 0.271,0.09 0.181,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,972.46684,270.52828)"
+       clip-path="url(#clipPath127)" />
+    <path
+       id="path128"
+       d="M 0,0 H -1.185 C -1.27,0 -1.331,0.026 -1.368,0.08 -1.405,0.133 -1.403,0.202 -1.36,0.288 L 1.279,5.328 -1.248,10 c -0.043,0.074 -0.046,0.141 -0.008,0.2 0.037,0.058 0.098,0.088 0.184,0.088 h 1.135 c 0.214,0 0.364,-0.091 0.449,-0.272 l 1.84,-3.712 h 0.064 l 1.84,3.712 c 0.096,0.181 0.234,0.272 0.416,0.272 h 1.183 c 0.086,0 0.147,-0.032 0.185,-0.097 0.037,-0.063 0.04,-0.132 0.008,-0.208 L 3.487,5.328 6.128,0.304 C 6.17,0.218 6.176,0.146 6.144,0.088 6.111,0.029 6.048,0 5.952,0 h -1.2 C 4.581,0 4.458,0.085 4.384,0.256 L 2.416,4.16 H 2.352 L 0.384,0.256 C 0.309,0.085 0.181,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,232.5365,200.63841)"
+       clip-path="url(#clipPath129)" />
+    <path
+       id="path130"
+       d="M 0,0 H -1.855 C -2.646,0 -3.256,0.219 -3.688,0.656 -4.12,1.094 -4.336,1.701 -4.336,2.48 v 5.329 c 0,0.789 0.216,1.399 0.648,1.832 0.432,0.431 1.042,0.647 1.833,0.647 H 0 c 0.778,0 1.387,-0.216 1.824,-0.647 C 2.262,9.208 2.48,8.598 2.48,7.809 V 7.04 C 2.48,6.849 2.384,6.752 2.192,6.752 H 1.185 c -0.182,0 -0.273,0.097 -0.273,0.288 v 0.704 c 0,0.789 -0.384,1.185 -1.152,1.185 h -1.392 c -0.767,0 -1.152,-0.396 -1.152,-1.185 v -5.2 c 0,-0.789 0.385,-1.184 1.152,-1.184 h 1.392 c 0.768,0 1.152,0.395 1.152,1.184 v 0.704 c 0,0.192 0.091,0.288 0.273,0.288 H 2.192 C 2.384,3.536 2.48,3.44 2.48,3.248 V 2.48 C 2.48,1.701 2.262,1.094 1.824,0.656 1.387,0.219 0.778,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,452.38866,200.63841)"
+       clip-path="url(#clipPath131)" />
+    <path
+       id="path132"
+       d="M 0,0 H -1.584 C -1.766,0 -1.878,0.09 -1.92,0.271 l -2.656,9.712 c -0.064,0.204 0.015,0.305 0.24,0.305 H -3.2 c 0.171,0 0.272,-0.091 0.304,-0.272 l 2.064,-8.352 h 0.063 l 2.049,8.352 c 0.042,0.181 0.149,0.272 0.32,0.272 h 1.12 c 0.224,0 0.309,-0.101 0.256,-0.305 L 0.304,0.271 C 0.261,0.09 0.16,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,308.62679,200.63841)"
+       clip-path="url(#clipPath133)" />
+    <path
+       id="path134"
+       d="m 0,0 h 2.239 c 0.8,0 1.2,0.384 1.2,1.151 v 0.993 c 0,0.768 -0.421,1.152 -1.263,1.152 L 0,3.296 c -0.118,0 -0.177,-0.054 -0.177,-0.16 V 0.159 C -0.177,0.053 -0.118,0 0,0 m 0,4.575 h 2.079 c 0.811,0 1.217,0.39 1.217,1.168 V 6.479 C 3.296,7.248 2.9,7.632 2.111,7.632 H 0 c -0.118,0 -0.177,-0.054 -0.177,-0.16 V 4.735 c 0,-0.106 0.059,-0.16 0.177,-0.16 m -1.729,-5.632 v 9.745 c 0,0.181 0.091,0.272 0.273,0.272 H 2.336 C 3.125,8.96 3.738,8.746 4.176,8.319 4.612,7.893 4.831,7.29 4.831,6.512 V 5.728 C 4.831,4.8 4.394,4.202 3.52,3.936 3.936,3.882 4.279,3.701 4.552,3.392 4.823,3.082 4.96,2.666 4.96,2.144 V 1.12 C 4.96,0.341 4.741,-0.262 4.304,-0.688 3.866,-1.115 3.258,-1.328 2.479,-1.328 h -3.935 c -0.182,0 -0.273,0.09 -0.273,0.271"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,646.47599,338.69493)"
+       clip-path="url(#clipPath135)" />
+    <path
+       id="path136"
+       d="m 0,0 h -0.991 c -0.182,0 -0.273,0.09 -0.273,0.271 v 9.745 c 0,0.181 0.091,0.272 0.273,0.272 h 0.895 c 0.171,0 0.288,-0.059 0.353,-0.177 l 3.871,-6.96 h 0.064 v 6.865 c 0,0.181 0.091,0.272 0.273,0.272 h 0.991 c 0.182,0 0.273,-0.091 0.273,-0.272 V 0.271 C 5.729,0.09 5.638,0 5.456,0 H 4.593 C 4.422,0 4.283,0.085 4.177,0.256 L 0.336,7.136 H 0.272 V 0.271 C 0.272,0.09 0.182,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,681.56399,270.52828)"
+       clip-path="url(#clipPath137)" />
+    <path
+       id="path138"
+       d="m 0,0 h 1.792 c 0.182,0 0.272,-0.091 0.272,-0.272 v -9.745 c 0,-0.181 -0.09,-0.271 -0.272,-0.271 H 0.8 c -0.182,0 -0.272,0.09 -0.272,0.271 v 8.08 H 0.464 l -2.08,-5.855 C -1.68,-7.963 -1.798,-8.048 -1.968,-8.048 h -1.024 c -0.16,0 -0.272,0.085 -0.336,0.256 L -5.456,-1.92 H -5.52 v -8.097 c 0,-0.106 -0.019,-0.178 -0.056,-0.215 -0.037,-0.038 -0.11,-0.056 -0.216,-0.056 h -0.976 c -0.181,0 -0.272,0.09 -0.272,0.271 v 9.745 C -7.04,-0.091 -6.949,0 -6.768,0 h 1.792 c 0.118,0 0.203,-0.059 0.256,-0.177 l 2.192,-6.176 h 0.08 l 2.208,6.176 C -0.219,-0.059 -0.139,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,723.74,326.74827)"
+       clip-path="url(#clipPath139)" />
+    <path
+       id="path142"
+       d="m 0,0 v -1.248 c 0,-0.256 -0.102,-0.576 -0.305,-0.96 l -0.847,-1.553 c -0.043,-0.095 -0.123,-0.143 -0.241,-0.143 -0.149,0 -0.223,0.085 -0.223,0.256 V 0 c 0,0.17 0.09,0.256 0.271,0.256 h 1.088 C -0.086,0.256 0,0.17 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,793.2816,337.47493)"
+       clip-path="url(#clipPath143)" />
+    <path
+       id="path146"
+       d="M 0,0 H -0.912 C -1.146,0 -1.211,0.096 -1.104,0.288 L 0.881,4.08 C 0.965,4.24 1.045,4.346 1.121,4.4 1.195,4.453 1.312,4.48 1.473,4.48 H 2.576 C 2.736,4.48 2.854,4.453 2.928,4.4 3.004,4.346 3.084,4.24 3.168,4.08 L 5.152,0.288 C 5.26,0.096 5.195,0 4.961,0 H 4.049 C 3.889,0 3.766,0.09 3.68,0.272 L 2.016,3.488 0.369,0.272 C 0.273,0.09 0.15,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,129.74653,122.9508)"
+       clip-path="url(#clipPath147)" />
+    <path
+       id="path148"
+       d="m 0,0 v -1.951 c 0,-0.182 -0.085,-0.273 -0.256,-0.273 h -1.089 c -0.182,0 -0.272,0.091 -0.272,0.273 V 0 c 0,0.171 0.09,0.257 0.272,0.257 h 1.089 C -0.085,0.257 0,0.171 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,865.09027,337.47613)"
+       clip-path="url(#clipPath149)" />
+    <path
+       id="path150"
+       d="M 0,0 H -3.168 C -3.35,0 -3.44,0.096 -3.44,0.288 v 0.704 c 0,0.192 0.09,0.288 0.272,0.288 H 0 c 0.182,0 0.271,-0.096 0.271,-0.288 V 0.288 C 0.271,0.096 0.182,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,919.99931,124.68973)"
+       clip-path="url(#clipPath151)" />
+    <g
+       aria-label="`"
+       id="text22234"
+       style="font-weight:500;font-size:26.6667px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end;stroke-width:2.83465">
+      <path
+         d="m 991.69232,120.47028 h -1.28 q -0.37334,0 -0.61334,-0.32 l -2.26667,-2.66667 q -0.13333,-0.21334 -0.08,-0.32 0.08,-0.13334 0.29334,-0.13334 h 2.10667 q 0.45333,0 0.66666,0.42667 l 1.36001,2.56 q 0.26666,0.45334 -0.18667,0.45334 z"
+         style="font-weight:600;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39364" />
+    </g>
+    <g
+       aria-label="´"
+       id="text22234-5"
+       style="font-weight:500;font-size:26.6667px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end;stroke-width:2.83465">
+      <path
+         d="m 1025.486,186.9216 h 2.08 q 0.24,0 0.2933,0.13333 0.08,0.10667 -0.08,0.32 l -2.2667,2.66667 q -0.24,0.32 -0.6133,0.32 h -1.2533 q -0.4267,0 -0.2134,-0.45333 l 1.36,-2.56 q 0.2134,-0.42667 0.6934,-0.42667 z"
+         style="font-weight:600;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39361" />
+    </g>
+    <path
+       id="path156"
+       d="M 0,0 H 0.48 C 1.312,0 1.729,0.395 1.729,1.184 V 2 c 0,0.778 -0.396,1.168 -1.185,1.168 H -0.592 C -1.35,3.168 -1.728,2.778 -1.728,2 v -7.52 c 0,-0.182 -0.09,-0.272 -0.272,-0.272 h -1.024 c -0.181,0 -0.272,0.09 -0.272,0.272 v 7.536 c 0,0.789 0.219,1.4 0.656,1.832 0.437,0.432 1.045,0.648 1.824,0.648 H 0.768 C 1.547,4.496 2.154,4.274 2.592,3.832 3.029,3.389 3.248,2.778 3.248,2 V 1.12 c 0,-0.886 -0.384,-1.472 -1.152,-1.76 0.416,-0.086 0.739,-0.304 0.968,-0.656 0.229,-0.352 0.344,-0.768 0.344,-1.248 V -3.408 C 3.408,-4.187 3.192,-4.779 2.76,-5.184 2.328,-5.589 1.718,-5.792 0.928,-5.792 H -0.24 c -0.192,0 -0.288,0.085 -0.288,0.256 v 0.8 c 0,0.181 0.096,0.272 0.288,0.272 h 0.944 c 0.789,0 1.184,0.389 1.184,1.168 v 0.784 c 0,0.789 -0.438,1.184 -1.312,1.184 H 0 c -0.182,0 -0.271,0.085 -0.271,0.256 v 0.8 C -0.271,-0.091 -0.182,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,953.75999,192.91575)"
+       clip-path="url(#clipPath157)" />
+    <path
+       id="path158"
+       d="M 0,0 V 0.944 C 0,1.115 0.074,1.243 0.224,1.328 L 1.888,2.336 C 2.09,2.454 2.261,2.512 2.399,2.512 h 0.96 c 0.182,0 0.273,-0.091 0.273,-0.272 v -9.744 c 0,-0.182 -0.086,-0.272 -0.256,-0.272 h -1.04 c -0.182,0 -0.273,0.09 -0.273,0.272 V 0.848 L 0.319,-0.16 C 0.106,-0.256 0,-0.203 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,196.882,120.32707)"
+       clip-path="url(#clipPath159)" />
+    <path
+       id="path160"
+       d="M 0,0 V 1.472 C 0,2.133 0.282,2.688 0.848,3.136 L 3.872,5.6 C 4.384,6.005 4.64,6.475 4.64,7.008 v 0.528 c 0,0.768 -0.4,1.152 -1.2,1.152 H 2.656 C 2.25,8.688 1.957,8.597 1.776,8.416 1.595,8.234 1.504,7.941 1.504,7.536 V 6.944 C 1.504,6.752 1.413,6.656 1.232,6.656 H 0.208 c -0.182,0 -0.272,0.096 -0.272,0.288 v 0.624 c 0,0.779 0.218,1.381 0.656,1.808 0.437,0.427 1.051,0.64 1.84,0.64 H 3.68 c 0.778,0 1.386,-0.213 1.824,-0.64 C 5.941,8.949 6.16,8.347 6.16,7.568 V 6.912 C 6.16,6.08 5.834,5.397 5.184,4.864 L 2.112,2.352 C 1.866,2.149 1.744,1.909 1.744,1.632 V 1.12 h 4.16 c 0.192,0 0.288,-0.091 0.288,-0.272 V 0 c 0,-0.182 -0.096,-0.272 -0.288,-0.272 H 0.288 C 0.096,-0.272 0,-0.182 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,267.53173,130.33227)"
+       clip-path="url(#clipPath161)" />
+    <path
+       id="path162"
+       d="M 0,0 H 0.88 C 1.669,0 2.063,0.389 2.063,1.168 V 2 c 0,0.768 -0.394,1.152 -1.183,1.152 H -0.064 C -0.459,3.152 -0.75,3.061 -0.937,2.88 -1.123,2.698 -1.216,2.405 -1.216,2 V 1.536 c 0,-0.182 -0.091,-0.272 -0.272,-0.272 h -1.024 c -0.181,0 -0.272,0.09 -0.272,0.272 v 0.496 c 0,0.779 0.219,1.381 0.656,1.808 0.438,0.427 1.051,0.64 1.84,0.64 h 1.392 c 0.79,0 1.403,-0.213 1.84,-0.64 C 3.381,3.413 3.6,2.811 3.6,2.032 V 1.152 C 3.6,0.213 3.173,-0.384 2.32,-0.64 3.173,-0.843 3.6,-1.44 3.6,-2.432 V -3.36 c 0,-0.779 -0.219,-1.382 -0.656,-1.808 -0.437,-0.427 -1.05,-0.64 -1.84,-0.64 h -1.392 c -0.789,0 -1.402,0.213 -1.84,0.64 -0.437,0.426 -0.656,1.029 -0.656,1.808 v 0.56 c 0,0.192 0.091,0.288 0.272,0.288 h 1.024 c 0.181,0 0.272,-0.096 0.272,-0.288 v -0.528 c 0,-0.395 0.093,-0.686 0.279,-0.872 0.187,-0.187 0.478,-0.28 0.873,-0.28 H 0.88 c 0.789,0 1.183,0.384 1.183,1.152 v 0.88 c 0,0.779 -0.394,1.168 -1.183,1.168 H 0 c -0.182,0 -0.272,0.091 -0.272,0.272 v 0.72 C -0.272,-0.096 -0.182,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,342.74787,122.9508)"
+       clip-path="url(#clipPath163)" />
+    <path
+       id="path164"
+       d="M 0,0 V 5.664 L -3.152,0 Z M 1.216,-3.328 H 0.272 C 0.091,-3.328 0,-3.238 0,-3.056 v 1.68 h -4.224 c -0.309,0 -0.463,0.154 -0.463,0.464 v 0.496 c 0,0.234 0.047,0.442 0.143,0.624 l 3.568,6.352 c 0.085,0.16 0.165,0.266 0.24,0.32 0.075,0.053 0.186,0.08 0.337,0.08 h 1.407 c 0.309,0 0.464,-0.155 0.464,-0.464 L 1.472,0 H 2.64 c 0.181,0 0.272,-0.091 0.272,-0.272 v -0.8 c 0,-0.203 -0.091,-0.304 -0.272,-0.304 H 1.472 v -1.68 c 0,-0.182 -0.085,-0.272 -0.256,-0.272"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,416.59947,126.25747)"
+       clip-path="url(#clipPath165)" />
+    <path
+       id="path166"
+       d="M 0,0 H -0.992 C -1.194,0 -1.362,-0.038 -1.496,-0.112 -1.63,-0.187 -1.718,-0.267 -1.76,-0.352 -1.878,-0.598 -2.021,-0.72 -2.192,-0.72 H -3.2 c -0.182,0 -0.272,0.091 -0.272,0.272 v 5.024 c 0,0.181 0.09,0.272 0.272,0.272 h 5.424 c 0.192,0 0.288,-0.091 0.288,-0.272 V 3.664 C 2.512,3.482 2.416,3.392 2.224,3.392 H -1.904 V 0.48 c 0.181,0.522 0.63,0.784 1.344,0.784 h 0.944 c 0.768,0 1.354,-0.2 1.76,-0.6 0.405,-0.4 0.608,-0.99 0.608,-1.768 V -2.96 C 2.752,-3.739 2.533,-4.347 2.096,-4.784 1.658,-5.222 1.051,-5.44 0.272,-5.44 h -1.36 c -0.79,0 -1.4,0.218 -1.832,0.656 -0.432,0.437 -0.648,1.045 -0.648,1.824 v 0.416 c 0,0.192 0.09,0.288 0.272,0.288 h 1.008 c 0.182,0 0.272,-0.096 0.272,-0.288 v -0.4 c 0,-0.779 0.384,-1.168 1.152,-1.168 h 0.912 c 0.789,0 1.184,0.389 1.184,1.168 v 1.616 c 0,0.48 -0.093,0.821 -0.28,1.024 C 0.766,-0.102 0.448,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,487.62933,123.44173)"
+       clip-path="url(#clipPath167)" />
+    <path
+       id="path168"
+       d="M 0,0 H 1.088 C 1.856,0 2.24,0.395 2.24,1.184 v 1.28 c 0,0.789 -0.384,1.184 -1.152,1.184 h -2.24 V 1.184 C -1.152,0.395 -0.768,0 0,0 m 1.312,-1.36 h -1.536 c -0.79,0 -1.403,0.218 -1.84,0.656 -0.438,0.437 -0.656,1.045 -0.656,1.824 v 5.328 c 0,0.789 0.218,1.4 0.656,1.832 0.437,0.432 1.05,0.648 1.84,0.648 H 2.96 c 0.182,0 0.272,-0.091 0.272,-0.272 V 7.824 C 3.232,7.653 3.142,7.568 2.96,7.568 H 0 c -0.768,0 -1.152,-0.395 -1.152,-1.184 V 5.008 h 2.464 c 0.79,0 1.403,-0.216 1.84,-0.648 C 3.589,3.928 3.808,3.317 3.808,2.528 V 1.12 C 3.808,0.341 3.589,-0.267 3.152,-0.704 2.715,-1.142 2.102,-1.36 1.312,-1.36"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,558.0968,128.88173)"
+       clip-path="url(#clipPath169)" />
+    <path
+       id="path170"
+       d="m 0,0 h -1.104 c -0.203,0 -0.25,0.101 -0.144,0.304 l 3.424,8.544 h -4.032 c -0.181,0 -0.272,0.096 -0.272,0.288 v 0.88 c 0,0.181 0.091,0.272 0.272,0.272 h 5.424 c 0.192,0 0.288,-0.091 0.288,-0.272 V 9.024 C 3.856,8.853 3.797,8.629 3.68,8.352 L 0.448,0.256 C 0.384,0.085 0.234,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,629.49787,130.69493)"
+       clip-path="url(#clipPath171)" />
+    <path
+       id="path172"
+       d="M 0,0 H 1.266 C 1.658,0 1.949,0.091 2.137,0.272 2.322,0.454 2.416,0.741 2.416,1.136 V 2 c 0,0.8 -0.383,1.2 -1.15,1.2 H 0 C -0.768,3.2 -1.15,2.8 -1.15,2 V 1.136 c 0,-0.395 0.091,-0.682 0.279,-0.864 C -0.686,0.091 -0.395,0 0,0 m 0,4.448 h 1.266 c 0.767,0 1.15,0.4 1.15,1.2 V 6.432 C 2.416,6.827 2.322,7.115 2.137,7.296 1.949,7.478 1.658,7.568 1.266,7.568 H 0 c -0.395,0 -0.686,-0.09 -0.871,-0.272 C -1.059,7.115 -1.15,6.827 -1.15,6.432 V 5.648 c 0,-0.8 0.382,-1.2 1.15,-1.2 M 1.488,-1.36 h -1.695 c -0.789,0 -1.402,0.203 -1.84,0.608 -0.437,0.405 -0.656,0.998 -0.656,1.776 v 0.864 c 0,0.982 0.367,1.621 1.103,1.92 -0.736,0.298 -1.103,0.944 -1.103,1.936 V 6.56 c 0,0.768 0.219,1.355 0.656,1.76 0.438,0.406 1.051,0.608 1.84,0.608 H 1.488 C 2.277,8.928 2.889,8.726 3.32,8.32 3.752,7.915 3.969,7.328 3.969,6.56 V 5.744 C 3.969,5.253 3.869,4.837 3.672,4.496 3.475,4.155 3.211,3.925 2.881,3.808 3.605,3.52 3.969,2.875 3.969,1.872 V 1.024 C 3.969,0.246 3.752,-0.347 3.32,-0.752 2.889,-1.157 2.277,-1.36 1.488,-1.36"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,701.63707,128.88173)"
+       clip-path="url(#clipPath173)" />
+    <path
+       id="path174"
+       d="m 0,0 h 2.24 v 2.528 c 0,0.789 -0.389,1.184 -1.168,1.184 L 0,3.712 c -0.768,0 -1.152,-0.395 -1.152,-1.184 V 1.168 C -1.152,0.39 -0.768,0 0,0 m 1.296,-5.216 h -3.248 c -0.202,0 -0.304,0.091 -0.304,0.272 v 0.832 c 0,0.171 0.102,0.256 0.304,0.256 h 3.024 c 0.768,0 1.152,0.395 1.152,1.184 v 1.296 H -0.24 c -0.789,0 -1.403,0.216 -1.84,0.648 -0.438,0.432 -0.656,1.038 -0.656,1.816 v 1.504 c 0,0.789 0.218,1.4 0.656,1.832 0.437,0.432 1.051,0.648 1.84,0.648 h 1.536 c 0.789,0 1.402,-0.216 1.84,-0.648 C 3.573,3.992 3.792,3.381 3.792,2.592 V -2.736 C 3.792,-3.515 3.573,-4.123 3.136,-4.56 2.698,-4.998 2.085,-5.216 1.296,-5.216"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,773.42613,123.74053)"
+       clip-path="url(#clipPath175)" />
+    <path
+       id="path176"
+       d="m 0,0 h 1.136 c 0.768,0 1.152,0.395 1.152,1.184 v 5.2 c 0,0.789 -0.384,1.184 -1.152,1.184 L 0,7.568 c -0.768,0 -1.152,-0.395 -1.152,-1.184 v -5.2 C -1.152,0.395 -0.768,0 0,0 m 1.36,-1.36 h -1.6 c -0.789,0 -1.403,0.218 -1.84,0.656 -0.438,0.437 -0.656,1.045 -0.656,1.824 v 5.328 c 0,0.789 0.218,1.4 0.656,1.832 0.437,0.432 1.051,0.648 1.84,0.648 h 1.6 C 2.139,8.928 2.746,8.712 3.184,8.28 3.621,7.848 3.84,7.237 3.84,6.448 V 1.12 C 3.84,0.341 3.621,-0.267 3.184,-0.704 2.746,-1.142 2.139,-1.36 1.36,-1.36"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,845.3012,128.88173)"
+       clip-path="url(#clipPath177)" />
+    <path
+       id="path218"
+       d="M 0,0 H 0.44 C 0.869,0 1.084,0.214 1.084,0.644 V 1.076 C 1.084,1.505 0.869,1.72 0.44,1.72 H -0.083 C -0.508,1.72 -0.72,1.505 -0.72,1.076 V 0.833 C -0.72,0.758 -0.755,0.72 -0.826,0.72 h -0.341 c -0.07,0 -0.105,0.038 -0.105,0.113 v 0.25 c 0,0.349 0.099,0.621 0.298,0.815 0.2,0.195 0.474,0.292 0.823,0.292 H 0.508 C 0.856,2.19 1.131,2.093 1.33,1.898 1.53,1.704 1.63,1.432 1.63,1.083 V 0.637 C 1.63,0.187 1.423,-0.104 1.009,-0.235 1.423,-0.341 1.63,-0.629 1.63,-1.099 v -0.478 c 0,-0.348 -0.1,-0.62 -0.3,-0.814 C 1.131,-2.586 0.856,-2.683 0.508,-2.683 h -0.659 c -0.349,0 -0.623,0.097 -0.823,0.292 -0.199,0.194 -0.298,0.466 -0.298,0.814 v 0.304 c 0,0.075 0.035,0.113 0.105,0.113 h 0.341 c 0.071,0 0.106,-0.038 0.106,-0.113 v -0.296 c 0,-0.43 0.212,-0.644 0.637,-0.644 H 0.44 c 0.429,0 0.644,0.214 0.644,0.644 v 0.463 c 0,0.429 -0.215,0.644 -0.644,0.644 H 0 c -0.071,0 -0.106,0.035 -0.106,0.106 v 0.25 C -0.106,-0.036 -0.071,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,356.24,141.41627)"
+       clip-path="url(#clipPath219)" />
+    <path
+       id="path238"
+       d="M 0,0 V 0.682 C 0,1.021 0.142,1.299 0.425,1.516 L 1.888,2.668 C 2.14,2.86 2.267,3.097 2.267,3.38 v 0.273 c 0,0.43 -0.218,0.644 -0.653,0.644 H 1.152 C 0.728,4.297 0.516,4.083 0.516,3.653 V 3.342 C 0.516,3.267 0.48,3.229 0.409,3.229 H 0.068 c -0.065,0 -0.098,0.038 -0.098,0.113 v 0.319 c 0,0.348 0.098,0.62 0.296,0.815 0.197,0.194 0.469,0.292 0.818,0.292 H 1.69 C 2.039,4.768 2.312,4.67 2.509,4.476 2.706,4.281 2.805,4.009 2.805,3.661 V 3.35 C 2.805,2.956 2.647,2.635 2.334,2.388 L 0.849,1.213 C 0.683,1.082 0.599,0.922 0.599,0.735 V 0.387 h 2.115 c 0.07,0 0.105,-0.036 0.105,-0.106 L 2.819,0 c 0,-0.071 -0.035,-0.106 -0.105,-0.106 H 0.106 C 0.035,-0.106 0,-0.071 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,282.9848,144.85253)"
+       clip-path="url(#clipPath239)" />
+    <path
+       id="path240"
+       d="m 0,0 3.173,-3.702 c 0.196,-0.23 0.541,-0.254 0.768,-0.059 0.02,0.018 0.04,0.038 0.059,0.059 L 7.173,0 C 7.475,0.354 7.225,0.899 6.76,0.899 H 0.413 C -0.052,0.901 -0.304,0.354 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1016.3489,419.8688)"
+       clip-path="url(#clipPath241)" />
+    <path
+       id="path242"
+       d="M 0,0 -3.173,3.702 C -3.369,3.932 -3.714,3.956 -3.941,3.761 -3.961,3.743 -3.981,3.723 -4,3.702 L -7.173,0 c -0.302,-0.354 -0.052,-0.899 0.413,-0.899 h 6.347 C 0.052,-0.901 0.304,-0.354 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1025.9129,393.59707)"
+       clip-path="url(#clipPath243)" />
+    <path
+       id="path244"
+       d="m 0,0 -3.702,-3.173 c -0.23,-0.196 -0.255,-0.541 -0.059,-0.768 0.018,-0.02 0.038,-0.04 0.059,-0.059 L 0,-7.173 c 0.354,-0.302 0.899,-0.052 0.899,0.413 v 6.347 C 0.901,0.052 0.354,0.304 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,937.86853,398.61547)"
+       clip-path="url(#clipPath245)" />
+    <path
+       id="path246"
+       d="M 0,0 3.702,3.173 C 3.932,3.369 3.956,3.714 3.761,3.941 3.743,3.961 3.723,3.981 3.702,4 L 0,7.173 C -0.354,7.475 -0.899,7.225 -0.899,6.76 V 0.413 C -0.901,-0.052 -0.354,-0.304 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1104.3725,408.17947)"
+       clip-path="url(#clipPath247)" />
+    <path
+       id="path284"
+       d="M 0,0 V -3.691 H -1.543 V 0 H -2.794 L -0.771,2.022 1.251,0 Z m 2.812,-0.146 -3.23,3.229 c -0.195,0.195 -0.512,0.195 -0.707,0 L -4.354,-0.146 C -4.45,-0.242 -4.501,-0.37 -4.501,-0.5 c 0,-0.064 0.012,-0.13 0.038,-0.191 C -4.386,-0.878 -4.203,-1 -4.001,-1 h 1.458 v -3.191 c 0,-0.277 0.223,-0.5 0.5,-0.5 0.001,0 0.002,10e-4 0.004,10e-4 v -10e-4 h 2.554 v 0.003 C 0.784,-4.68 1,-4.462 1,-4.191 V -1 h 1.458 c 0.202,0 0.385,0.122 0.462,0.309 0.078,0.185 0.034,0.401 -0.108,0.545"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,136.7576,341.46893)"
+       clip-path="url(#clipPath285)" />
+    <path
+       id="path286"
+       d="m 0,0 v 4.691 c 0,0.277 -0.224,0.5 -0.5,0.5 -0.276,0 -0.5,-0.223 -0.5,-0.5 V 0 c 0,-0.276 0.224,-0.5 0.5,-0.5 0.276,0 0.5,0.224 0.5,0.5"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,125.27693,204.0836)"
+       clip-path="url(#clipPath287)" />
+    <path
+       id="path288"
+       d="m 0,0 v 4.691 c 0,0.277 -0.224,0.5 -0.5,0.5 -0.276,0 -0.5,-0.223 -0.5,-0.5 V 0 c 0,-0.276 0.224,-0.5 0.5,-0.5 0.276,0 0.5,0.224 0.5,0.5"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,147.33253,207.47573)"
+       clip-path="url(#clipPath289)" />
+    <path
+       id="path290"
+       d="m 0,0 h -2.512 c -0.075,0 -0.112,0.037 -0.112,0.112 v 4.92 c 0,0.074 0.037,0.113 0.112,0.113 H 0 c 0.075,0 0.112,-0.039 0.112,-0.113 V 4.744 C 0.112,4.67 0.075,4.632 0,4.632 h -1.96 c -0.054,0 -0.08,-0.024 -0.08,-0.071 V 2.944 c 0,-0.048 0.026,-0.072 0.08,-0.072 h 1.712 c 0.075,0 0.112,-0.037 0.112,-0.112 V 2.473 C -0.136,2.397 -0.173,2.36 -0.248,2.36 H -1.96 c -0.054,0 -0.08,-0.024 -0.08,-0.072 V 0.584 c 0,-0.048 0.026,-0.071 0.08,-0.071 H 0 C 0.075,0.513 0.112,0.475 0.112,0.4 V 0.112 C 0.112,0.037 0.075,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1099.2543,424.958)"
+       clip-path="url(#clipPath291)" />
+    <path
+       id="path292"
+       d="m 0,0 h -0.352 c -0.075,0 -0.112,0.037 -0.112,0.112 v 4.92 c 0,0.074 0.037,0.113 0.112,0.113 h 0.329 C 0.04,5.145 0.083,5.123 0.104,5.08 L 2.313,1.2 h 0.032 v 3.832 c 0,0.074 0.037,0.113 0.111,0.113 H 2.809 C 2.883,5.145 2.92,5.106 2.92,5.032 V 0.112 C 2.92,0.037 2.883,0 2.809,0 H 2.513 C 2.453,0 2.397,0.035 2.345,0.104 l -2.2,3.84 H 0.112 V 0.112 C 0.112,0.037 0.075,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1101.7088,424.958)"
+       clip-path="url(#clipPath293)" />
+    <path
+       id="path294"
+       d="m 0,0 h 1.344 c 0.448,0 0.672,0.231 0.672,0.695 v 2.729 c 0,0.464 -0.224,0.695 -0.672,0.695 H 0 c -0.054,0 -0.08,-0.023 -0.08,-0.071 V 0.071 C -0.08,0.023 -0.054,0 0,0 m -0.664,-0.4 v 4.92 c 0,0.074 0.037,0.112 0.112,0.112 h 1.968 c 0.368,0 0.657,-0.106 0.868,-0.317 0.211,-0.211 0.317,-0.5 0.317,-0.868 V 0.672 C 2.601,0.304 2.495,0.015 2.284,-0.196 2.073,-0.407 1.784,-0.513 1.416,-0.513 h -1.968 c -0.075,0 -0.112,0.037 -0.112,0.113"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1108.3207,424.2744)"
+       clip-path="url(#clipPath295)" />
+    <path
+       id="path296"
+       d="m 0,0 h -2.512 c -0.075,0 -0.112,0.037 -0.112,0.112 v 4.92 c 0,0.074 0.037,0.113 0.112,0.113 H 0 c 0.075,0 0.112,-0.039 0.112,-0.113 V 4.744 C 0.112,4.67 0.075,4.632 0,4.632 h -1.96 c -0.054,0 -0.08,-0.024 -0.08,-0.071 V 2.944 c 0,-0.048 0.026,-0.072 0.08,-0.072 h 1.712 c 0.075,0 0.112,-0.037 0.112,-0.112 V 2.473 C -0.136,2.397 -0.173,2.36 -0.248,2.36 H -1.96 c -0.054,0 -0.08,-0.024 -0.08,-0.072 V 0.584 c 0,-0.048 0.026,-0.071 0.08,-0.071 H 0 C 0.075,0.513 0.112,0.475 0.112,0.4 V 0.112 C 0.112,0.037 0.075,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1117.0433,424.958)"
+       clip-path="url(#clipPath297)" />
+    <path
+       id="path298"
+       d="M 0,0 H 1.312 C 1.771,0 2,0.227 2,0.68 V 1.2 C 2,1.653 1.755,1.88 1.264,1.88 H 0 c -0.054,0 -0.08,-0.025 -0.08,-0.072 V 0.08 C -0.08,0.026 -0.054,0 0,0 m 0,2.368 h 1.232 c 0.469,0 0.705,0.227 0.705,0.68 v 0.424 c 0,0.453 -0.228,0.68 -0.681,0.68 H 0 c -0.054,0 -0.08,-0.027 -0.08,-0.08 V 2.439 C -0.08,2.392 -0.054,2.368 0,2.368 m -0.664,-2.752 v 4.92 c 0,0.074 0.037,0.111 0.112,0.111 h 1.88 C 1.696,4.647 1.984,4.545 2.192,4.34 2.4,4.135 2.504,3.848 2.504,3.479 V 3.04 C 2.504,2.565 2.28,2.259 1.832,2.12 2.035,2.104 2.208,2.015 2.353,1.852 2.496,1.689 2.568,1.475 2.568,1.208 V 0.672 c 0,-0.368 -0.105,-0.654 -0.316,-0.86 -0.211,-0.206 -0.5,-0.308 -0.868,-0.308 h -1.936 c -0.075,0 -0.112,0.037 -0.112,0.112"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1008.0695,435.0204)"
+       clip-path="url(#clipPath299)" />
+    <path
+       id="path300"
+       d="m 0,0 v -4.92 c 0,-0.075 -0.037,-0.112 -0.112,-0.112 h -0.36 c -0.075,0 -0.112,0.037 -0.112,0.112 V 0 c 0,0.074 0.037,0.111 0.112,0.111 h 0.36 C -0.037,0.111 0,0.074 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1014.0225,428.97227)"
+       clip-path="url(#clipPath301)" />
+    <path
+       id="path302"
+       d="M 0,0 H -2.567 C -2.643,0 -2.68,0.037 -2.68,0.112 v 4.92 c 0,0.074 0.037,0.112 0.113,0.112 h 0.359 c 0.075,0 0.112,-0.038 0.112,-0.112 V 0.6 c 0,-0.048 0.027,-0.072 0.08,-0.072 H 0 c 0.075,0 0.112,-0.04 0.112,-0.12 V 0.112 C 0.112,0.037 0.075,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1019.4509,435.68187)"
+       clip-path="url(#clipPath303)" />
+    <path
+       id="path304"
+       d="M 0,0 H 1.344 C 1.792,0 2.016,0.232 2.016,0.696 V 3.424 C 2.016,3.889 1.792,4.12 1.344,4.12 H 0 c -0.054,0 -0.08,-0.023 -0.08,-0.072 V 0.072 C -0.08,0.024 -0.054,0 0,0 m -0.664,-0.399 v 4.92 c 0,0.074 0.037,0.111 0.112,0.111 h 1.968 c 0.368,0 0.657,-0.105 0.868,-0.316 0.211,-0.211 0.317,-0.5 0.317,-0.868 V 0.672 C 2.601,0.305 2.495,0.015 2.284,-0.195 2.073,-0.406 1.784,-0.512 1.416,-0.512 h -1.968 c -0.075,0 -0.112,0.037 -0.112,0.113"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1021.9679,434.9996)"
+       clip-path="url(#clipPath305)" />
+    <path
+       id="path306"
+       d="M 0,0 -1.99,1.991 V 2.839 L -0.312,1.144 V 4.781 H 0.312 V 1.144 L 1.991,2.839 V 1.991 Z"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1032.3129,436.02307)"
+       clip-path="url(#clipPath307)" />
+    <path
+       id="path308"
+       d="M 0,0 H 1.312 C 1.771,0 2,0.227 2,0.68 V 1.2 C 2,1.653 1.755,1.88 1.264,1.88 H 0 c -0.054,0 -0.08,-0.025 -0.08,-0.072 V 0.08 C -0.08,0.026 -0.054,0 0,0 m 0,2.368 h 1.232 c 0.469,0 0.705,0.227 0.705,0.68 v 0.424 c 0,0.453 -0.228,0.68 -0.681,0.68 H 0 c -0.054,0 -0.08,-0.027 -0.08,-0.08 V 2.439 C -0.08,2.392 -0.054,2.368 0,2.368 m -0.664,-2.752 v 4.92 c 0,0.074 0.037,0.111 0.112,0.111 h 1.88 C 1.696,4.647 1.984,4.545 2.192,4.34 2.4,4.135 2.504,3.848 2.504,3.479 V 3.04 C 2.504,2.565 2.28,2.259 1.832,2.12 2.035,2.104 2.208,2.015 2.353,1.852 2.496,1.689 2.568,1.475 2.568,1.208 V 0.672 c 0,-0.368 -0.105,-0.654 -0.316,-0.86 -0.211,-0.206 -0.5,-0.308 -0.868,-0.308 h -1.936 c -0.075,0 -0.112,0.037 -0.112,0.112"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1008.0695,404.85907)"
+       clip-path="url(#clipPath309)" />
+    <path
+       id="path310"
+       d="m 0,0 v -4.92 c 0,-0.075 -0.037,-0.112 -0.112,-0.112 h -0.36 c -0.075,0 -0.112,0.037 -0.112,0.112 V 0 c 0,0.074 0.037,0.111 0.112,0.111 h 0.36 C -0.037,0.111 0,0.074 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1014.0225,398.8108)"
+       clip-path="url(#clipPath311)" />
+    <path
+       id="path312"
+       d="M 0,0 H -2.567 C -2.643,0 -2.68,0.037 -2.68,0.112 v 4.92 c 0,0.074 0.037,0.112 0.113,0.112 h 0.359 c 0.075,0 0.112,-0.038 0.112,-0.112 V 0.6 c 0,-0.048 0.027,-0.072 0.08,-0.072 H 0 c 0.075,0 0.112,-0.04 0.112,-0.12 V 0.112 C 0.112,0.037 0.075,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1019.4509,405.5204)"
+       clip-path="url(#clipPath313)" />
+    <path
+       id="path314"
+       d="M 0,0 H 1.344 C 1.792,0 2.016,0.232 2.016,0.696 V 3.424 C 2.016,3.889 1.792,4.12 1.344,4.12 H 0 c -0.054,0 -0.08,-0.023 -0.08,-0.072 V 0.072 C -0.08,0.024 -0.054,0 0,0 m -0.664,-0.399 v 4.92 c 0,0.074 0.037,0.111 0.112,0.111 h 1.968 c 0.368,0 0.657,-0.105 0.868,-0.316 0.211,-0.211 0.317,-0.5 0.317,-0.868 V 0.672 C 2.601,0.305 2.495,0.015 2.284,-0.195 2.073,-0.406 1.784,-0.512 1.416,-0.512 h -1.968 c -0.075,0 -0.112,0.037 -0.112,0.113"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1021.9679,404.83813)"
+       clip-path="url(#clipPath315)" />
+    <path
+       id="path316"
+       d="M 0,0 V -3.63 H -0.624 V 0 l -1.679,-1.695 v 0.847 l 1.991,1.999 1.991,-1.999 v -0.847 z"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1032.7296,400.80827)"
+       clip-path="url(#clipPath317)" />
+    <path
+       id="path318"
+       d="m 0,0 h 1.24 c 0.448,0 0.672,0.229 0.672,0.688 v 0.84 c 0,0.464 -0.224,0.696 -0.672,0.696 H 0 C -0.054,2.224 -0.08,2.2 -0.08,2.152 V 0.072 C -0.08,0.024 -0.054,0 0,0 m -0.192,-2.408 h -0.36 c -0.075,0 -0.112,0.037 -0.112,0.112 v 4.92 c 0,0.074 0.037,0.112 0.112,0.112 H 1.32 C 1.688,2.736 1.977,2.631 2.185,2.42 2.393,2.209 2.496,1.92 2.496,1.552 V 0.664 C 2.496,0.291 2.393,0 2.185,-0.208 1.977,-0.416 1.688,-0.52 1.32,-0.52 H 0 c -0.054,0 -0.08,-0.024 -0.08,-0.072 v -1.704 c 0,-0.075 -0.037,-0.112 -0.112,-0.112"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,926.74907,421.74707)"
+       clip-path="url(#clipPath319)" />
+    <path
+       id="path320"
+       d="m 0,0 h 0.816 c 0.449,0 0.672,0.231 0.672,0.695 v 2.729 c 0,0.464 -0.223,0.695 -0.672,0.695 H 0 c -0.442,0 -0.664,-0.231 -0.664,-0.695 V 0.695 C -0.664,0.231 -0.442,0 0,0 m 0.889,-0.513 h -0.952 c -0.369,0 -0.658,0.105 -0.869,0.313 -0.211,0.208 -0.316,0.498 -0.316,0.872 v 2.775 c 0,0.373 0.105,0.664 0.316,0.872 0.211,0.208 0.5,0.313 0.869,0.313 h 0.952 c 0.367,0 0.657,-0.106 0.867,-0.317 0.211,-0.211 0.316,-0.5 0.316,-0.868 V 0.672 c 0,-0.368 -0.105,-0.657 -0.316,-0.868 -0.21,-0.211 -0.5,-0.317 -0.867,-0.317"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,933.3312,424.2744)"
+       clip-path="url(#clipPath321)" />
+    <path
+       id="path322"
+       d="M 0,0 V 0.256 C 0,0.33 0.037,0.367 0.112,0.367 h 0.36 c 0.075,0 0.112,-0.037 0.112,-0.111 V 0.048 c 0,-0.481 0.237,-0.72 0.712,-0.72 H 2 c 0.475,0 0.712,0.245 0.712,0.735 V 0.336 C 2.712,0.72 2.395,0.971 1.76,1.088 1.493,1.136 1.227,1.191 0.96,1.256 0.693,1.319 0.467,1.443 0.28,1.628 0.093,1.812 0,2.063 0,2.384 v 0.391 c 0,0.369 0.105,0.658 0.315,0.869 0.211,0.21 0.5,0.316 0.869,0.316 h 0.888 c 0.363,0 0.651,-0.106 0.864,-0.316 0.213,-0.211 0.32,-0.5 0.32,-0.869 v -0.2 C 3.256,2.496 3.221,2.456 3.151,2.456 H 2.784 C 2.715,2.456 2.68,2.496 2.68,2.575 V 2.72 c 0,0.485 -0.238,0.727 -0.712,0.727 H 1.288 C 0.813,3.447 0.576,3.194 0.576,2.688 V 2.367 C 0.576,2.096 0.755,1.909 1.112,1.808 1.271,1.765 1.448,1.727 1.64,1.691 1.832,1.657 2.025,1.611 2.22,1.556 2.414,1.5 2.592,1.431 2.752,1.348 2.912,1.265 3.041,1.14 3.14,0.972 3.238,0.804 3.288,0.6 3.288,0.359 V 0 c 0,-0.368 -0.107,-0.657 -0.32,-0.868 C 2.755,-1.079 2.467,-1.185 2.104,-1.185 h -0.92 c -0.363,0 -0.651,0.106 -0.864,0.317 C 0.106,-0.657 0,-0.368 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,937.79853,423.37853)"
+       clip-path="url(#clipPath323)" />
+    <path
+       id="path324"
+       d="M 0,0 V 0.32 C 0,0.4 0.032,0.459 0.097,0.496 L 1.024,1.032 C 1.109,1.08 1.179,1.104 1.232,1.104 h 0.336 c 0.075,0 0.113,-0.038 0.113,-0.112 v -4.92 c 0,-0.075 -0.038,-0.112 -0.113,-0.112 h -0.36 c -0.074,0 -0.111,0.037 -0.111,0.112 V 0.48 L 0.145,-0.063 C 0.048,-0.117 0,-0.096 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,943.66187,419.5712)"
+       clip-path="url(#clipPath325)" />
+    <path
+       id="path326"
+       d="m 0,0 h 1.359 c 0.516,0 0.774,0.258 0.774,0.774 v 0.801 c 0,0.522 -0.258,0.783 -0.774,0.783 H 0 c -0.06,0 -0.09,-0.027 -0.09,-0.081 V 0.081 C -0.09,0.027 -0.06,0 0,0 m -0.216,-2.853 h -0.405 c -0.084,0 -0.126,0.042 -0.126,0.126 v 5.535 c 0,0.084 0.042,0.126 0.126,0.126 h 2.07 C 1.863,2.934 2.19,2.815 2.43,2.579 2.67,2.341 2.79,2.016 2.79,1.602 V 0.783 C 2.79,0.447 2.709,0.169 2.547,-0.049 2.385,-0.269 2.16,-0.414 1.872,-0.486 V -0.522 L 2.916,-2.709 C 2.97,-2.805 2.939,-2.853 2.826,-2.853 H 2.421 c -0.102,0 -0.177,0.042 -0.225,0.126 L 1.188,-0.549 H 0 c -0.06,0 -0.09,-0.027 -0.09,-0.081 v -2.097 c 0,-0.084 -0.042,-0.126 -0.126,-0.126"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1020.3559,82.030267)"
+       clip-path="url(#clipPath327)" />
+    <path
+       id="path328"
+       d="m 0,0 h 0.918 c 0.504,0 0.756,0.261 0.756,0.783 v 3.069 c 0,0.522 -0.252,0.783 -0.756,0.783 H 0 c -0.498,0 -0.747,-0.261 -0.747,-0.783 V 0.783 C -0.747,0.261 -0.498,0 0,0 m 0.999,-0.576 h -1.071 c -0.414,0 -0.74,0.117 -0.977,0.351 -0.237,0.234 -0.355,0.561 -0.355,0.981 v 3.123 c 0,0.42 0.118,0.747 0.355,0.981 0.237,0.234 0.563,0.351 0.977,0.351 H 0.999 C 1.413,5.211 1.738,5.092 1.976,4.855 2.212,4.618 2.331,4.293 2.331,3.879 V 0.756 C 2.331,0.342 2.212,0.016 1.976,-0.221 1.738,-0.458 1.413,-0.576 0.999,-0.576"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1027.7583,85.066)"
+       clip-path="url(#clipPath329)" />
+    <path
+       id="path330"
+       d="m 0,0 h -2.889 c -0.084,0 -0.126,0.042 -0.126,0.126 v 5.535 c 0,0.084 0.042,0.126 0.126,0.126 h 0.406 c 0.084,0 0.126,-0.042 0.126,-0.126 V 0.675 c 0,-0.054 0.03,-0.081 0.089,-0.081 H 0 c 0.084,0 0.126,-0.045 0.126,-0.135 V 0.126 C 0.126,0.042 0.084,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1036.7973,85.834267)"
+       clip-path="url(#clipPath331)" />
+    <path
+       id="path332"
+       d="m 0,0 h -2.889 c -0.084,0 -0.126,0.042 -0.126,0.126 v 5.535 c 0,0.084 0.042,0.126 0.126,0.126 h 0.406 c 0.084,0 0.126,-0.042 0.126,-0.126 V 0.675 c 0,-0.054 0.03,-0.081 0.089,-0.081 H 0 c 0.084,0 0.126,-0.045 0.126,-0.135 V 0.126 C 0.126,0.042 0.084,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1042.5916,85.834267)"
+       clip-path="url(#clipPath333)" />
+    <path
+       id="path334"
+       d="M 0,0 H -2.826 C -2.91,0 -2.952,0.042 -2.952,0.126 v 5.535 c 0,0.084 0.042,0.126 0.126,0.126 H 0 c 0.084,0 0.126,-0.042 0.126,-0.126 V 5.337 C 0.126,5.253 0.084,5.211 0,5.211 h -2.205 c -0.06,0 -0.09,-0.027 -0.09,-0.081 V 3.312 c 0,-0.054 0.03,-0.081 0.09,-0.081 h 1.926 c 0.084,0 0.126,-0.042 0.126,-0.126 V 2.781 c 0,-0.084 -0.042,-0.126 -0.126,-0.126 h -1.926 c -0.06,0 -0.09,-0.027 -0.09,-0.081 V 0.657 c 0,-0.054 0.03,-0.081 0.09,-0.081 H 0 c 0.084,0 0.126,-0.042 0.126,-0.126 V 0.126 C 0.126,0.042 0.084,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1048.3025,85.834267)"
+       clip-path="url(#clipPath335)" />
+    <path
+       id="path336"
+       d="M 0,0 H -0.396 C -0.48,0 -0.522,0.042 -0.522,0.126 v 5.535 c 0,0.084 0.042,0.126 0.126,0.126 h 0.369 c 0.072,0 0.12,-0.024 0.143,-0.072 L 2.601,1.35 h 0.036 v 4.311 c 0,0.084 0.042,0.126 0.126,0.126 h 0.395 c 0.084,0 0.126,-0.042 0.126,-0.126 V 0.126 C 3.284,0.042 3.242,0 3.158,0 H 2.825 C 2.76,0 2.696,0.039 2.637,0.117 L 0.161,4.437 H 0.126 V 0.126 C 0.126,0.042 0.084,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1051.0004,85.834267)"
+       clip-path="url(#clipPath337)" />
+    <path
+       id="path338"
+       d="M 0,0 H -2.826 C -2.91,0 -2.952,0.042 -2.952,0.126 v 5.535 c 0,0.084 0.042,0.126 0.126,0.126 H 0 c 0.084,0 0.126,-0.042 0.126,-0.126 V 5.337 C 0.126,5.253 0.084,5.211 0,5.211 h -2.205 c -0.06,0 -0.09,-0.027 -0.09,-0.081 V 3.312 c 0,-0.054 0.03,-0.081 0.09,-0.081 h 1.926 c 0.084,0 0.126,-0.042 0.126,-0.126 V 2.781 c 0,-0.084 -0.042,-0.126 -0.126,-0.126 h -1.926 c -0.06,0 -0.09,-0.027 -0.09,-0.081 V 0.657 c 0,-0.054 0.03,-0.081 0.09,-0.081 H 0 c 0.084,0 0.126,-0.042 0.126,-0.126 V 0.126 C 0.126,0.042 0.084,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1093.0537,149.85773)"
+       clip-path="url(#clipPath339)" />
+    <path
+       id="path340"
+       d="m 0,0 v -5.535 c 0,-0.084 -0.042,-0.126 -0.126,-0.126 h -0.405 c -0.084,0 -0.126,0.042 -0.126,0.126 V 0 c 0,0.084 0.042,0.126 0.126,0.126 h 0.405 C -0.042,0.126 0,0.084 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1095.964,142.30947)"
+       clip-path="url(#clipPath341)" />
+    <path
+       id="path342"
+       d="M 0,0 H -0.396 C -0.48,0 -0.522,0.042 -0.522,0.126 v 5.535 c 0,0.084 0.042,0.126 0.126,0.126 h 0.369 c 0.072,0 0.12,-0.024 0.143,-0.072 L 2.601,1.35 h 0.036 v 4.311 c 0,0.084 0.042,0.126 0.126,0.126 h 0.395 c 0.084,0 0.126,-0.042 0.126,-0.126 V 0.126 C 3.284,0.042 3.242,0 3.158,0 H 2.825 C 2.76,0 2.696,0.039 2.637,0.117 L 0.161,4.437 H 0.126 V 0.126 C 0.126,0.042 0.084,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1098.6827,149.85773)"
+       clip-path="url(#clipPath343)" />
+    <path
+       id="path344"
+       d="m 0,0 h -0.405 c -0.084,0 -0.126,0.042 -0.126,0.126 v 5.535 c 0,0.084 0.042,0.126 0.126,0.126 H 2.394 C 2.478,5.787 2.52,5.745 2.52,5.661 V 5.337 C 2.52,5.253 2.478,5.211 2.394,5.211 H 0.216 c -0.06,0 -0.09,-0.027 -0.09,-0.081 V 3.168 c 0,-0.054 0.03,-0.081 0.09,-0.081 h 1.926 c 0.084,0 0.126,-0.042 0.126,-0.126 V 2.637 C 2.268,2.553 2.226,2.511 2.142,2.511 H 0.216 c -0.06,0 -0.09,-0.03 -0.09,-0.09 V 0.126 C 0.126,0.042 0.084,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1105.7647,149.85773)"
+       clip-path="url(#clipPath345)" />
+    <path
+       id="path346"
+       d="m 0,0 h -0.972 c -0.414,0 -0.739,0.117 -0.976,0.351 -0.238,0.234 -0.356,0.561 -0.356,0.981 v 3.123 c 0,0.42 0.118,0.747 0.356,0.981 0.237,0.234 0.562,0.351 0.976,0.351 H 0 c 0.414,0 0.738,-0.119 0.973,-0.355 0.233,-0.238 0.35,-0.563 0.35,-0.977 V 4.086 C 1.323,3.996 1.281,3.951 1.197,3.951 H 0.792 c -0.084,0 -0.126,0.045 -0.126,0.135 v 0.342 c 0,0.522 -0.249,0.783 -0.747,0.783 h -0.818 c -0.498,0 -0.747,-0.261 -0.747,-0.783 V 1.359 c 0,-0.522 0.249,-0.783 0.747,-0.783 h 0.818 c 0.498,0 0.747,0.261 0.747,0.783 v 1.008 c 0,0.06 -0.026,0.09 -0.081,0.09 h -0.891 c -0.084,0 -0.126,0.039 -0.126,0.117 v 0.333 c 0,0.084 0.042,0.126 0.126,0.126 h 1.45 c 0.119,0 0.179,-0.063 0.179,-0.189 V 1.332 C 1.323,0.912 1.206,0.585 0.973,0.351 0.738,0.117 0.414,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1113.7517,149.85773)"
+       clip-path="url(#clipPath347)" />
+    <path
+       id="path348"
+       d="M 0,0 V -1.25 L -2.022,0.772 0,2.794 V 1.543 H 5.983 V 0 Z m 6.983,2.043 c 0,0.277 -0.224,0.5 -0.5,0.5 H 1 V 4.001 C 1,4.204 0.878,4.386 0.691,4.463 0.506,4.542 0.29,4.498 0.146,4.355 l -3.229,-3.23 c -0.195,-0.195 -0.195,-0.511 0,-0.707 L 0.146,-2.811 C 0.242,-2.907 0.37,-2.958 0.5,-2.958 c 0.064,0 0.13,0.013 0.191,0.039 C 0.878,-2.842 1,-2.66 1,-2.458 V -1 h 5.483 c 0.272,0 0.49,0.217 0.497,0.487 H 6.983 V 2.041 H 6.982 c 0,10e-4 10e-4,0.002 10e-4,0.002"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1106.2101,122.9728)"
+       clip-path="url(#clipPath349)" />
+    <path
+       id="path350"
+       d="M 0,0 V -1.25 L -2.022,0.772 0,2.794 V 1.543 H 6.148 V 3.917 H 7.692 V 0 Z M 8.215,4.913 V 4.917 H 5.662 V 4.915 c -0.005,0 -0.009,0.002 -0.014,0.002 -0.276,0 -0.5,-0.223 -0.5,-0.5 V 2.543 H 1 V 4.001 C 1,4.204 0.878,4.386 0.691,4.463 0.506,4.542 0.29,4.498 0.146,4.355 l -3.229,-3.23 c -0.195,-0.195 -0.195,-0.511 0,-0.707 L 0.146,-2.811 C 0.242,-2.907 0.37,-2.958 0.5,-2.958 c 0.064,0 0.13,0.013 0.191,0.039 C 0.878,-2.842 1,-2.66 1,-2.458 V -1 H 8.692 V 4.417 C 8.692,4.685 8.48,4.9 8.215,4.913"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1103.9315,203.9488)"
+       clip-path="url(#clipPath351)" />
+    <path
+       id="path352"
+       d="M 0,0 V -3.691 H -1.543 V 0 H -2.794 L -0.771,2.022 1.251,0 Z m 2.812,-0.146 -3.23,3.229 c -0.195,0.195 -0.512,0.195 -0.707,0 L -4.354,-0.146 C -4.45,-0.242 -4.501,-0.37 -4.501,-0.5 c 0,-0.064 0.012,-0.13 0.038,-0.191 C -4.386,-0.878 -4.203,-1 -4.001,-1 h 1.458 v -3.191 c 0,-0.269 0.212,-0.484 0.478,-0.496 v -0.004 h 2.614 v 0.009 C 0.801,-4.656 1,-4.45 1,-4.191 V -1 h 1.458 c 0.202,0 0.385,0.122 0.462,0.309 0.078,0.185 0.034,0.401 -0.108,0.545"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1108.6013,341.4644)"
+       clip-path="url(#clipPath353)" />
+    <path
+       id="path356"
+       d="m 0,0 v 1.251 h -3.157 l 1.213,1.543 1.944,0 V 4.045 L 2.022,2.022 Z M 3.083,2.376 -0.146,5.605 C -0.242,5.701 -0.37,5.752 -0.5,5.752 -0.564,5.752 -0.63,5.74 -0.691,5.714 -0.878,5.637 -1,5.454 -1,5.252 V 3.794 h -1.191 c -0.17,0 -0.313,-0.09 -0.403,-0.22 L -2.6,3.578 -4.543,1.106 C -4.635,1.015 -4.691,0.89 -4.691,0.751 c 0,-0.276 0.223,-0.5 0.5,-0.5 H -1 v -1.458 c 0,-0.202 0.122,-0.385 0.309,-0.462 0.185,-0.078 0.401,-0.034 0.545,0.108 l 3.229,3.23 c 0.195,0.195 0.195,0.512 0,0.707"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,140.5948,207.04467)"
+       clip-path="url(#clipPath357)" />
+    <path
+       id="path358"
+       d="M 0,0 V -1.25 L -2.022,0.772 0,2.794 V 1.543 H 3.156 L 1.943,0 Z m 4.579,1.741 c 0.067,0.085 0.112,0.186 0.112,0.302 0,0.277 -0.223,0.5 -0.5,0.5 H 1 V 4.001 C 1,4.204 0.878,4.386 0.691,4.463 0.506,4.542 0.29,4.498 0.146,4.355 l -3.229,-3.23 c -0.195,-0.195 -0.195,-0.511 0,-0.707 L 0.146,-2.811 C 0.242,-2.907 0.37,-2.958 0.5,-2.958 c 0.064,0 0.13,0.013 0.191,0.039 C 0.878,-2.842 1,-2.66 1,-2.458 V -1 h 1.191 c 0.152,0 0.283,0.071 0.375,0.177 L 2.567,-0.824 4.541,1.687 C 4.547,1.693 4.55,1.7 4.555,1.705 l 0.027,0.034 z"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,130.7516,201.98547)"
+       clip-path="url(#clipPath359)" />
+    <path
+       id="path360"
+       d="m 0,0 h -0.405 c -0.084,0 -0.126,0.042 -0.126,0.126 v 5.535 c 0,0.084 0.042,0.126 0.126,0.126 H 2.394 C 2.478,5.787 2.52,5.745 2.52,5.661 V 5.337 C 2.52,5.253 2.478,5.211 2.394,5.211 H 0.216 c -0.06,0 -0.09,-0.027 -0.09,-0.081 V 3.168 c 0,-0.054 0.03,-0.081 0.09,-0.081 h 1.926 c 0.084,0 0.126,-0.042 0.126,-0.126 V 2.637 C 2.268,2.553 2.226,2.511 2.142,2.511 H 0.216 c -0.06,0 -0.09,-0.03 -0.09,-0.09 V 0.126 C 0.126,0.042 0.084,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,118.45227,85.834933)"
+       clip-path="url(#clipPath361)" />
+    <path
+       id="path362"
+       d="M 0,0 H -0.396 C -0.48,0 -0.522,0.042 -0.522,0.126 v 5.535 c 0,0.084 0.042,0.126 0.126,0.126 h 0.369 c 0.072,0 0.12,-0.024 0.143,-0.072 L 2.601,1.35 h 0.036 v 4.311 c 0,0.084 0.042,0.126 0.126,0.126 h 0.395 c 0.084,0 0.126,-0.042 0.126,-0.126 V 0.126 C 3.284,0.042 3.242,0 3.158,0 H 2.825 C 2.76,0 2.696,0.039 2.637,0.117 L 0.161,4.437 H 0.126 V 0.126 C 0.126,0.042 0.084,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,123.91187,85.834933)"
+       clip-path="url(#clipPath363)" />
+    <path
+       id="path364"
+       d="m 0,0 h -2.889 c -0.084,0 -0.126,0.042 -0.126,0.126 v 5.535 c 0,0.084 0.042,0.126 0.126,0.126 h 0.406 c 0.084,0 0.126,-0.042 0.126,-0.126 V 0.675 c 0,-0.054 0.03,-0.081 0.089,-0.081 H 0 c 0.084,0 0.126,-0.045 0.126,-0.135 V 0.126 C 0.126,0.042 0.084,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,136.65413,85.834933)"
+       clip-path="url(#clipPath365)" />
+    <path
+       id="path366"
+       d="m 0,0 h 0.918 c 0.504,0 0.756,0.261 0.756,0.783 v 3.069 c 0,0.522 -0.252,0.783 -0.756,0.783 H 0 c -0.498,0 -0.747,-0.261 -0.747,-0.783 V 0.783 C -0.747,0.261 -0.498,0 0,0 m 0.999,-0.576 h -1.071 c -0.414,0 -0.74,0.117 -0.977,0.351 -0.237,0.234 -0.355,0.561 -0.355,0.981 v 3.123 c 0,0.42 0.118,0.747 0.355,0.981 0.237,0.234 0.563,0.351 0.977,0.351 H 0.999 C 1.413,5.211 1.738,5.092 1.976,4.855 2.212,4.618 2.331,4.293 2.331,3.879 V 0.756 C 2.331,0.342 2.212,0.016 1.976,-0.221 1.738,-0.458 1.413,-0.576 0.999,-0.576"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,139.85987,85.066667)"
+       clip-path="url(#clipPath367)" />
+    <path
+       id="path368"
+       d="m 0,0 h -1.08 c -0.414,0 -0.739,0.117 -0.977,0.351 -0.237,0.234 -0.355,0.561 -0.355,0.981 v 3.123 c 0,0.42 0.118,0.747 0.355,0.981 0.238,0.234 0.563,0.351 0.977,0.351 H 0 C 0.414,5.787 0.739,5.67 0.977,5.436 1.213,5.202 1.332,4.875 1.332,4.455 V 4.014 C 1.332,3.93 1.29,3.888 1.206,3.888 H 0.801 c -0.084,0 -0.126,0.042 -0.126,0.126 v 0.414 c 0,0.522 -0.252,0.783 -0.756,0.783 h -0.927 c -0.498,0 -0.747,-0.261 -0.747,-0.783 V 1.359 c 0,-0.522 0.249,-0.783 0.747,-0.783 h 0.927 c 0.504,0 0.756,0.261 0.756,0.783 v 0.414 c 0,0.084 0.042,0.126 0.126,0.126 h 0.405 c 0.084,0 0.126,-0.042 0.126,-0.126 V 1.332 C 1.332,0.912 1.213,0.585 0.977,0.351 0.739,0.117 0.414,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,147.71653,85.834933)"
+       clip-path="url(#clipPath369)" />
+    <path
+       id="path370"
+       d="m 0,0 h -0.405 c -0.084,0 -0.126,0.042 -0.126,0.126 v 5.535 c 0,0.084 0.042,0.126 0.126,0.126 H 0 c 0.084,0 0.126,-0.042 0.126,-0.126 V 2.556 h 0.026 c 0.042,0.126 0.109,0.249 0.199,0.369 l 2.016,2.736 c 0.054,0.084 0.132,0.126 0.234,0.126 h 0.486 c 0.101,0 0.117,-0.045 0.045,-0.135 L 1.35,3.24 3.384,0.144 C 3.45,0.048 3.423,0 3.303,0 H 2.934 C 2.808,0 2.721,0.042 2.673,0.126 L 0.944,2.763 0.126,1.782 V 0.126 C 0.126,0.042 0.084,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,151.71013,85.834933)"
+       clip-path="url(#clipPath371)" />
+    <path
+       id="path372"
+       d="m 0,0 c 5.479,0 9.921,-4.444 9.921,-9.921 0,-5.48 -4.442,-9.923 -9.921,-9.923 -5.478,0 -9.921,4.443 -9.921,9.923 C -9.921,-4.444 -5.478,0 0,0 m 1.4,-6.715 c 0,0.31 -0.244,0.563 -0.543,0.563 -0.297,0 -0.538,-0.253 -0.538,-0.563 0,-0.313 0.241,-0.568 0.538,-0.568 0.299,0 0.543,0.255 0.543,0.568 m -1.695,0.175 c 0,0.461 -0.355,0.836 -0.79,0.836 -0.438,0 -0.795,-0.375 -0.795,-0.836 0,-0.461 0.357,-0.836 0.795,-0.836 0.435,0 0.79,0.375 0.79,0.836 m 6.18,-2.326 C 5.571,-5.206 3.399,-2.381 0,-2.381 c -3.4,0 -5.57,-2.825 -5.889,-6.485 l -1.924,-1.396 1.979,-1.023 c 0.192,-1.495 0.691,-2.828 1.48,-3.855 -0.483,-0.243 -0.776,-0.587 -0.776,-0.96 0,-0.755 1.185,-1.366 2.653,-1.366 1.127,0 2.092,0.364 2.477,0.871 0.385,-0.507 1.346,-0.871 2.473,-0.871 1.467,0 2.657,0.611 2.657,1.366 0,0.378 -0.297,0.713 -0.775,0.96 0.788,1.027 1.283,2.36 1.48,3.855 l 1.973,1.023 z m -10.148,-6.227 c -0.017,0.028 -0.034,0.053 -0.046,0.074 -0.272,0.511 -0.226,1.019 -0.226,1.56 0,2.304 0.168,4.288 1.974,5.164 -0.528,0.406 -0.884,1.169 -0.884,2.041 0,1.303 0.791,2.36 1.769,2.36 0.888,0 1.621,-0.876 1.747,-2.017 0.243,0.663 0.885,1.137 1.631,1.137 0.963,0 1.739,-0.78 1.739,-1.74 0,-0.772 -0.499,-1.421 -1.19,-1.651 2.1,-0.793 2.284,-2.863 2.284,-5.294 0,-0.541 0.042,-1.049 -0.23,-1.56 -0.009,-0.021 -0.026,-0.046 -0.046,-0.074 -0.47,0.222 -1.099,0.355 -1.786,0.355 -1.127,0 -2.088,-0.36 -2.473,-0.868 -0.385,0.508 -1.35,0.868 -2.477,0.868 -0.687,0 -1.312,-0.13 -1.786,-0.355 m 4.276,8.16 c -0.055,-0.244 -0.139,-0.469 -0.244,-0.675 l -1.056,-0.047 1.358,-1.948 1.182,2.058 -0.922,-0.037 c -0.147,0.187 -0.256,0.41 -0.318,0.649"
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,289.5956,398.66773)"
+       clip-path="url(#clipPath373)" />
+    <path
+       id="path374"
+       d="m 0,0 h -2.881 c -0.101,0 -0.152,0.051 -0.152,0.153 v 5.481 c 0,0.102 0.051,0.153 0.152,0.153 H 0 c 0.096,0 0.144,-0.051 0.144,-0.153 V 5.175 C 0.144,5.073 0.096,5.022 0,5.022 h -2.053 c -0.071,0 -0.107,-0.03 -0.107,-0.09 V 3.411 c 0,-0.06 0.036,-0.09 0.107,-0.09 h 1.738 c 0.108,0 0.162,-0.051 0.162,-0.153 V 2.709 c 0,-0.102 -0.054,-0.153 -0.162,-0.153 h -1.738 c -0.071,0 -0.107,-0.03 -0.107,-0.09 V 0.864 c 0,-0.066 0.036,-0.099 0.107,-0.099 H 0 c 0.096,0 0.144,-0.051 0.144,-0.153 V 0.153 C 0.144,0.051 0.096,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,131.98867,74.0244)"
+       clip-path="url(#clipPath375)" />
+    <path
+       id="path376"
+       d="m 0,0 v 0.234 c 0,0.102 0.051,0.153 0.153,0.153 h 0.576 c 0.102,0 0.153,-0.051 0.153,-0.153 V 0.072 c 0,-0.252 0.055,-0.433 0.167,-0.544 0.11,-0.111 0.295,-0.167 0.554,-0.167 h 0.621 c 0.257,0 0.443,0.059 0.557,0.176 0.115,0.117 0.171,0.307 0.171,0.571 V 0.315 C 2.952,0.507 2.879,0.659 2.731,0.77 2.585,0.881 2.403,0.953 2.188,0.986 1.971,1.019 1.734,1.065 1.477,1.125 1.218,1.185 0.981,1.254 0.766,1.332 0.549,1.41 0.367,1.557 0.221,1.773 0.073,1.989 0,2.265 0,2.601 V 2.979 C 0,3.417 0.125,3.761 0.374,4.01 0.623,4.259 0.966,4.383 1.404,4.383 H 2.358 C 2.802,4.383 3.148,4.259 3.397,4.01 3.646,3.761 3.771,3.417 3.771,2.979 V 2.781 C 3.771,2.679 3.72,2.628 3.618,2.628 H 3.042 C 2.94,2.628 2.89,2.679 2.89,2.781 V 2.898 C 2.89,3.156 2.834,3.341 2.723,3.452 2.611,3.563 2.427,3.618 2.169,3.618 H 1.603 C 1.344,3.618 1.159,3.56 1.049,3.443 0.937,3.326 0.882,3.126 0.882,2.844 V 2.565 C 0.882,2.295 1.077,2.112 1.467,2.016 1.642,1.974 1.832,1.938 2.039,1.908 2.246,1.878 2.454,1.833 2.664,1.773 2.874,1.713 3.066,1.634 3.24,1.535 3.414,1.436 3.555,1.286 3.663,1.084 3.771,0.884 3.825,0.639 3.825,0.351 V 0 C 3.825,-0.438 3.7,-0.781 3.452,-1.03 3.202,-1.279 2.859,-1.404 2.421,-1.404 H 1.413 C 0.976,-1.404 0.63,-1.279 0.378,-1.03 0.126,-0.781 0,-0.438 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,133.73613,72.152667)"
+       clip-path="url(#clipPath377)" />
+    <path
+       id="path378"
+       d="m 0,0 h -1.044 c -0.444,0 -0.787,0.123 -1.03,0.369 -0.243,0.246 -0.364,0.588 -0.364,1.026 v 2.997 c 0,0.444 0.121,0.788 0.364,1.03 0.243,0.244 0.586,0.365 1.03,0.365 H 0 c 0.438,0 0.78,-0.121 1.026,-0.365 0.246,-0.242 0.37,-0.586 0.37,-1.03 V 3.96 C 1.396,3.852 1.341,3.798 1.233,3.798 H 0.666 c -0.102,0 -0.153,0.054 -0.153,0.162 v 0.396 c 0,0.444 -0.216,0.666 -0.648,0.666 H -0.918 C -1.35,5.022 -1.565,4.8 -1.565,4.356 V 1.431 c 0,-0.444 0.215,-0.666 0.647,-0.666 h 0.783 c 0.432,0 0.648,0.222 0.648,0.666 v 0.396 c 0,0.108 0.051,0.162 0.153,0.162 h 0.567 c 0.108,0 0.163,-0.054 0.163,-0.162 V 1.395 C 1.396,0.957 1.272,0.615 1.026,0.369 0.78,0.123 0.438,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,143.7648,74.0244)"
+       clip-path="url(#clipPath379)" />
+    <path
+       id="path380"
+       d="M 0,0 H -0.567 C -0.669,0 -0.72,0.051 -0.72,0.153 v 5.481 c 0,0.102 0.051,0.153 0.153,0.153 h 2.826 c 0.102,0 0.153,-0.051 0.153,-0.153 V 5.175 C 2.412,5.073 2.361,5.022 2.259,5.022 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 3.231 c 0,-0.066 0.036,-0.099 0.108,-0.099 H 1.998 C 2.106,3.132 2.16,3.081 2.16,2.979 V 2.529 C 2.16,2.421 2.106,2.367 1.998,2.367 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 0.153 C 0.153,0.051 0.102,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,190.47573,80.026933)"
+       clip-path="url(#clipPath381)" />
+    <path
+       id="path382"
+       d="M 0,0 V 0.531 C 0,0.627 0.042,0.699 0.126,0.747 L 1.062,1.314 C 1.176,1.38 1.272,1.413 1.35,1.413 h 0.54 c 0.102,0 0.153,-0.051 0.153,-0.153 v -5.481 c 0,-0.102 -0.048,-0.153 -0.144,-0.153 H 1.314 c -0.102,0 -0.153,0.051 -0.153,0.153 V 0.477 L 0.18,-0.09 C 0.06,-0.144 0,-0.114 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,194.95747,74.194933)"
+       clip-path="url(#clipPath383)" />
+    <path
+       id="path384"
+       d="M 0,0 H -0.567 C -0.669,0 -0.72,0.051 -0.72,0.153 v 5.481 c 0,0.102 0.051,0.153 0.153,0.153 h 2.826 c 0.102,0 0.153,-0.051 0.153,-0.153 V 5.175 C 2.412,5.073 2.361,5.022 2.259,5.022 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 3.231 c 0,-0.066 0.036,-0.099 0.108,-0.099 H 1.998 C 2.106,3.132 2.16,3.081 2.16,2.979 V 2.529 C 2.16,2.421 2.106,2.367 1.998,2.367 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 0.153 C 0.153,0.051 0.102,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,258.87667,80.026933)"
+       clip-path="url(#clipPath385)" />
+    <path
+       id="path386"
+       d="M 0,0 V 0.828 C 0,1.2 0.159,1.512 0.478,1.764 L 2.179,3.15 C 2.466,3.378 2.61,3.642 2.61,3.942 v 0.297 c 0,0.432 -0.225,0.648 -0.674,0.648 H 1.494 C 1.267,4.887 1.102,4.836 0.999,4.734 0.897,4.632 0.847,4.467 0.847,4.239 V 3.906 C 0.847,3.798 0.795,3.744 0.693,3.744 H 0.117 c -0.102,0 -0.153,0.054 -0.153,0.162 v 0.351 c 0,0.438 0.123,0.777 0.369,1.017 0.246,0.24 0.591,0.36 1.035,0.36 H 2.07 c 0.438,0 0.781,-0.12 1.027,-0.36 C 3.342,5.034 3.465,4.695 3.465,4.257 V 3.888 C 3.465,3.42 3.282,3.036 2.916,2.736 L 1.188,1.323 C 1.05,1.209 0.981,1.074 0.981,0.918 V 0.63 h 2.34 C 3.43,0.63 3.483,0.579 3.483,0.477 V 0 c 0,-0.102 -0.053,-0.153 -0.162,-0.153 H 0.162 C 0.055,-0.153 0,-0.102 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,263.48747,79.8232)"
+       clip-path="url(#clipPath387)" />
+    <path
+       id="path388"
+       d="M 0,0 H -0.567 C -0.669,0 -0.72,0.051 -0.72,0.153 v 5.481 c 0,0.102 0.051,0.153 0.153,0.153 h 2.826 c 0.102,0 0.153,-0.051 0.153,-0.153 V 5.175 C 2.412,5.073 2.361,5.022 2.259,5.022 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 3.231 c 0,-0.066 0.036,-0.099 0.108,-0.099 H 1.998 C 2.106,3.132 2.16,3.081 2.16,2.979 V 2.529 C 2.16,2.421 2.106,2.367 1.998,2.367 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 0.153 C 0.153,0.051 0.102,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,328.0512,80.0244)"
+       clip-path="url(#clipPath389)" />
+    <path
+       id="path390"
+       d="m 0,0 h 0.495 c 0.443,0 0.666,0.219 0.666,0.657 v 0.468 c 0,0.432 -0.223,0.648 -0.666,0.648 H -0.036 C -0.259,1.773 -0.422,1.722 -0.526,1.62 -0.632,1.518 -0.685,1.353 -0.685,1.125 V 0.864 c 0,-0.102 -0.05,-0.153 -0.152,-0.153 h -0.576 c -0.103,0 -0.153,0.051 -0.153,0.153 v 0.279 c 0,0.438 0.123,0.777 0.369,1.017 0.246,0.24 0.591,0.36 1.035,0.36 H 0.621 C 1.064,2.52 1.409,2.4 1.655,2.16 1.901,1.92 2.024,1.581 2.024,1.143 V 0.648 C 2.024,0.12 1.785,-0.216 1.305,-0.36 1.785,-0.474 2.024,-0.81 2.024,-1.368 V -1.89 c 0,-0.438 -0.123,-0.777 -0.369,-1.017 -0.246,-0.24 -0.591,-0.36 -1.034,-0.36 h -0.783 c -0.444,0 -0.789,0.12 -1.035,0.36 -0.246,0.24 -0.369,0.579 -0.369,1.017 v 0.315 c 0,0.108 0.05,0.162 0.153,0.162 h 0.576 c 0.102,0 0.152,-0.054 0.152,-0.162 v -0.297 c 0,-0.222 0.053,-0.386 0.159,-0.491 0.104,-0.105 0.267,-0.157 0.49,-0.157 h 0.531 c 0.443,0 0.666,0.216 0.666,0.648 v 0.495 c 0,0.438 -0.223,0.657 -0.666,0.657 L 0,-0.72 c -0.103,0 -0.153,0.051 -0.153,0.153 v 0.405 C -0.153,-0.054 -0.103,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,334.69573,75.668267)"
+       clip-path="url(#clipPath391)" />
+    <path
+       id="path392"
+       d="M 0,0 H -0.567 C -0.669,0 -0.72,0.051 -0.72,0.153 v 5.481 c 0,0.102 0.051,0.153 0.153,0.153 h 2.826 c 0.102,0 0.153,-0.051 0.153,-0.153 V 5.175 C 2.412,5.073 2.361,5.022 2.259,5.022 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 3.231 c 0,-0.066 0.036,-0.099 0.108,-0.099 H 1.998 C 2.106,3.132 2.16,3.081 2.16,2.979 V 2.529 C 2.16,2.421 2.106,2.367 1.998,2.367 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 0.153 C 0.153,0.051 0.102,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,397.2648,80.026933)"
+       clip-path="url(#clipPath393)" />
+    <path
+       id="path394"
+       d="M 0,0 V 3.186 L -1.772,0 Z M 0.685,-1.872 H 0.153 C 0.052,-1.872 0,-1.821 0,-1.719 v 0.945 h -2.376 c -0.174,0 -0.261,0.087 -0.261,0.261 v 0.279 c 0,0.132 0.028,0.249 0.081,0.351 l 2.007,3.573 c 0.048,0.09 0.094,0.15 0.136,0.18 0.041,0.03 0.104,0.045 0.188,0.045 h 0.792 c 0.174,0 0.261,-0.087 0.261,-0.261 L 0.828,0 h 0.657 c 0.103,0 0.154,-0.051 0.154,-0.153 v -0.45 c 0,-0.114 -0.051,-0.171 -0.154,-0.171 H 0.828 v -0.945 c 0,-0.102 -0.048,-0.153 -0.143,-0.153"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,405.01213,77.530933)"
+       clip-path="url(#clipPath395)" />
+    <path
+       id="path396"
+       d="M 0,0 H -0.567 C -0.669,0 -0.72,0.051 -0.72,0.153 v 5.481 c 0,0.102 0.051,0.153 0.153,0.153 h 2.826 c 0.102,0 0.153,-0.051 0.153,-0.153 V 5.175 C 2.412,5.073 2.361,5.022 2.259,5.022 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 3.231 c 0,-0.066 0.036,-0.099 0.108,-0.099 H 1.998 C 2.106,3.132 2.16,3.081 2.16,2.979 V 2.529 C 2.16,2.421 2.106,2.367 1.998,2.367 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 0.153 C 0.153,0.051 0.102,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,466.6332,80.0244)"
+       clip-path="url(#clipPath397)" />
+    <path
+       id="path398"
+       d="M 0,0 H -0.559 C -0.673,0 -0.767,-0.021 -0.842,-0.063 -0.917,-0.105 -0.967,-0.15 -0.99,-0.198 -1.057,-0.336 -1.138,-0.405 -1.233,-0.405 h -0.568 c -0.101,0 -0.152,0.051 -0.152,0.153 v 2.826 c 0,0.102 0.051,0.153 0.152,0.153 h 3.052 c 0.107,0 0.162,-0.051 0.162,-0.153 V 2.061 C 1.413,1.959 1.358,1.908 1.251,1.908 H -1.071 V 0.27 c 0.101,0.294 0.353,0.441 0.756,0.441 h 0.531 c 0.431,0 0.762,-0.112 0.99,-0.337 0.228,-0.226 0.342,-0.557 0.342,-0.995 v -1.044 c 0,-0.438 -0.123,-0.78 -0.369,-1.026 C 0.933,-2.937 0.591,-3.06 0.152,-3.06 h -0.764 c -0.445,0 -0.787,0.123 -1.031,0.369 -0.243,0.246 -0.365,0.588 -0.365,1.026 v 0.234 c 0,0.108 0.052,0.162 0.154,0.162 h 0.567 c 0.101,0 0.152,-0.054 0.152,-0.162 v -0.225 c 0,-0.438 0.217,-0.657 0.649,-0.657 h 0.512 c 0.445,0 0.666,0.219 0.666,0.657 v 0.909 c 0,0.27 -0.052,0.462 -0.157,0.576 C 0.43,-0.057 0.252,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,473.92107,75.944267)"
+       clip-path="url(#clipPath399)" />
+    <path
+       id="path400"
+       d="M 0,0 H -0.567 C -0.669,0 -0.72,0.051 -0.72,0.153 v 5.481 c 0,0.102 0.051,0.153 0.153,0.153 h 2.826 c 0.102,0 0.153,-0.051 0.153,-0.153 V 5.175 C 2.412,5.073 2.361,5.022 2.259,5.022 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 3.231 c 0,-0.066 0.036,-0.099 0.108,-0.099 H 1.998 C 2.106,3.132 2.16,3.081 2.16,2.979 V 2.529 C 2.16,2.421 2.106,2.367 1.998,2.367 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 0.153 C 0.153,0.051 0.102,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,535.90933,80.0244)"
+       clip-path="url(#clipPath401)" />
+    <path
+       id="path402"
+       d="m 0,0 h 0.612 c 0.432,0 0.649,0.222 0.649,0.666 v 0.72 c 0,0.444 -0.217,0.666 -0.649,0.666 H -0.647 V 0.666 C -0.647,0.222 -0.432,0 0,0 m 0.738,-0.765 h -0.864 c -0.443,0 -0.789,0.123 -1.034,0.369 -0.246,0.246 -0.369,0.588 -0.369,1.026 v 2.997 c 0,0.444 0.123,0.788 0.369,1.03 0.245,0.243 0.591,0.365 1.034,0.365 h 1.791 c 0.103,0 0.153,-0.051 0.153,-0.153 V 4.401 C 1.818,4.305 1.768,4.257 1.665,4.257 H 0 c -0.432,0 -0.647,-0.222 -0.647,-0.666 V 2.817 h 1.385 c 0.445,0 0.789,-0.122 1.035,-0.365 0.247,-0.243 0.37,-0.586 0.37,-1.03 V 0.63 C 2.143,0.192 2.02,-0.15 1.773,-0.396 1.527,-0.642 1.183,-0.765 0.738,-0.765"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,542.54467,79.004133)"
+       clip-path="url(#clipPath403)" />
+    <path
+       id="path404"
+       d="M 0,0 H -0.567 C -0.669,0 -0.72,0.051 -0.72,0.153 v 5.481 c 0,0.102 0.051,0.153 0.153,0.153 h 2.826 c 0.102,0 0.153,-0.051 0.153,-0.153 V 5.175 C 2.412,5.073 2.361,5.022 2.259,5.022 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 3.231 c 0,-0.066 0.036,-0.099 0.108,-0.099 H 1.998 C 2.106,3.132 2.16,3.081 2.16,2.979 V 2.529 C 2.16,2.421 2.106,2.367 1.998,2.367 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 0.153 C 0.153,0.051 0.102,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,605.6736,80.026933)"
+       clip-path="url(#clipPath405)" />
+    <path
+       id="path406"
+       d="m 0,0 h -0.621 c -0.114,0 -0.142,0.057 -0.081,0.171 l 1.926,4.806 h -2.268 c -0.102,0 -0.153,0.054 -0.153,0.162 v 0.495 c 0,0.102 0.051,0.153 0.153,0.153 h 3.051 c 0.107,0 0.162,-0.051 0.162,-0.153 V 5.076 C 2.169,4.98 2.136,4.854 2.069,4.698 L 0.252,0.144 C 0.216,0.048 0.132,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,611.69573,80.026933)"
+       clip-path="url(#clipPath407)" />
+    <path
+       id="path408"
+       d="M 0,0 H -0.567 C -0.669,0 -0.72,0.051 -0.72,0.153 v 5.481 c 0,0.102 0.051,0.153 0.153,0.153 h 2.826 c 0.102,0 0.153,-0.051 0.153,-0.153 V 5.175 C 2.412,5.073 2.361,5.022 2.259,5.022 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 3.231 c 0,-0.066 0.036,-0.099 0.108,-0.099 H 1.998 C 2.106,3.132 2.16,3.081 2.16,2.979 V 2.529 C 2.16,2.421 2.106,2.367 1.998,2.367 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 0.153 C 0.153,0.051 0.102,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,674.38453,80.026933)"
+       clip-path="url(#clipPath409)" />
+    <path
+       id="path410"
+       d="m 0,0 h 0.711 c 0.222,0 0.386,0.051 0.49,0.153 0.106,0.102 0.158,0.264 0.158,0.486 V 1.125 C 1.359,1.575 1.143,1.8 0.711,1.8 H 0 C -0.432,1.8 -0.648,1.575 -0.648,1.125 V 0.639 c 0,-0.222 0.052,-0.384 0.158,-0.486 C -0.386,0.051 -0.222,0 0,0 m 0,2.502 h 0.711 c 0.432,0 0.648,0.225 0.648,0.675 V 3.618 C 1.359,3.84 1.307,4.002 1.201,4.104 1.097,4.206 0.933,4.257 0.711,4.257 H 0 C -0.222,4.257 -0.386,4.206 -0.49,4.104 -0.596,4.002 -0.648,3.84 -0.648,3.618 V 3.177 c 0,-0.45 0.216,-0.675 0.648,-0.675 m 0.837,-3.267 h -0.954 c -0.445,0 -0.789,0.114 -1.035,0.342 -0.246,0.228 -0.369,0.561 -0.369,0.999 v 0.486 c 0,0.552 0.207,0.912 0.621,1.08 -0.414,0.168 -0.621,0.531 -0.621,1.089 V 3.69 c 0,0.432 0.123,0.762 0.369,0.99 0.246,0.228 0.59,0.342 1.035,0.342 H 0.837 C 1.281,5.022 1.625,4.908 1.867,4.68 2.11,4.452 2.232,4.122 2.232,3.69 V 3.231 C 2.232,2.955 2.177,2.721 2.065,2.529 1.954,2.337 1.806,2.208 1.62,2.142 2.028,1.98 2.232,1.617 2.232,1.053 V 0.576 C 2.232,0.138 2.11,-0.195 1.867,-0.423 1.625,-0.651 1.281,-0.765 0.837,-0.765"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,681.04467,79.0068)"
+       clip-path="url(#clipPath411)" />
+    <path
+       id="path412"
+       d="M 0,0 H -0.567 C -0.669,0 -0.72,0.051 -0.72,0.153 v 5.481 c 0,0.102 0.051,0.153 0.153,0.153 h 2.826 c 0.102,0 0.153,-0.051 0.153,-0.153 V 5.175 C 2.412,5.073 2.361,5.022 2.259,5.022 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 3.231 c 0,-0.066 0.036,-0.099 0.108,-0.099 H 1.998 C 2.106,3.132 2.16,3.081 2.16,2.979 V 2.529 C 2.16,2.421 2.106,2.367 1.998,2.367 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 0.153 C 0.153,0.051 0.102,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,743.74907,80.0244)"
+       clip-path="url(#clipPath413)" />
+    <path
+       id="path414"
+       d="m 0,0 h 1.261 v 1.422 c 0,0.444 -0.22,0.666 -0.657,0.666 H 0 c -0.432,0 -0.647,-0.222 -0.647,-0.666 V 0.657 C -0.647,0.219 -0.432,0 0,0 m 0.729,-2.934 h -1.827 c -0.114,0 -0.171,0.051 -0.171,0.153 v 0.468 c 0,0.096 0.057,0.144 0.171,0.144 h 1.702 c 0.431,0 0.647,0.222 0.647,0.666 v 0.729 h -1.386 c -0.444,0 -0.789,0.122 -1.035,0.364 -0.246,0.243 -0.369,0.584 -0.369,1.022 v 0.846 c 0,0.444 0.123,0.788 0.369,1.03 0.246,0.243 0.591,0.365 1.035,0.365 h 0.864 c 0.444,0 0.79,-0.122 1.036,-0.365 C 2.01,2.246 2.133,1.902 2.133,1.458 V -1.539 C 2.133,-1.977 2.01,-2.319 1.765,-2.565 1.519,-2.811 1.173,-2.934 0.729,-2.934"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,750.35853,76.112267)"
+       clip-path="url(#clipPath415)" />
+    <path
+       id="path416"
+       d="M 0,0 H -0.567 C -0.669,0 -0.72,0.051 -0.72,0.153 v 5.481 c 0,0.102 0.051,0.153 0.153,0.153 h 2.826 c 0.102,0 0.153,-0.051 0.153,-0.153 V 5.175 C 2.412,5.073 2.361,5.022 2.259,5.022 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 3.231 c 0,-0.066 0.036,-0.099 0.108,-0.099 H 1.998 C 2.106,3.132 2.16,3.081 2.16,2.979 V 2.529 C 2.16,2.421 2.106,2.367 1.998,2.367 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 0.153 C 0.153,0.051 0.102,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,810.822,80.0244)"
+       clip-path="url(#clipPath417)" />
+    <path
+       id="path418"
+       d="M 0,0 V 0.531 C 0,0.627 0.042,0.699 0.126,0.747 L 1.062,1.314 C 1.176,1.38 1.272,1.413 1.35,1.413 h 0.54 c 0.102,0 0.153,-0.051 0.153,-0.153 v -5.481 c 0,-0.102 -0.048,-0.153 -0.144,-0.153 H 1.314 c -0.102,0 -0.153,0.051 -0.153,0.153 V 0.477 L 0.18,-0.09 C 0.06,-0.144 0,-0.114 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,815.30373,74.1924)"
+       clip-path="url(#clipPath419)" />
+    <path
+       id="path420"
+       d="m 0,0 h 0.64 c 0.431,0 0.647,0.222 0.647,0.666 v 2.925 c 0,0.444 -0.216,0.666 -0.647,0.666 H 0 c -0.432,0 -0.647,-0.222 -0.647,-0.666 V 0.666 C -0.647,0.222 -0.432,0 0,0 m 0.766,-0.765 h -0.901 c -0.444,0 -0.789,0.123 -1.035,0.369 -0.246,0.246 -0.368,0.588 -0.368,1.026 v 2.997 c 0,0.444 0.122,0.788 0.368,1.03 0.246,0.243 0.591,0.365 1.035,0.365 H 0.766 C 1.203,5.022 1.545,4.9 1.791,4.657 2.037,4.415 2.16,4.071 2.16,3.627 V 0.63 C 2.16,0.192 2.037,-0.15 1.791,-0.396 1.545,-0.642 1.203,-0.765 0.766,-0.765"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,821.80907,79.004133)"
+       clip-path="url(#clipPath421)" />
+    <path
+       id="path422"
+       d="M 0,0 H -0.567 C -0.669,0 -0.72,0.051 -0.72,0.153 v 5.481 c 0,0.102 0.051,0.153 0.153,0.153 h 2.826 c 0.102,0 0.153,-0.051 0.153,-0.153 V 5.175 C 2.412,5.073 2.361,5.022 2.259,5.022 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 3.231 c 0,-0.066 0.036,-0.099 0.108,-0.099 H 1.998 C 2.106,3.132 2.16,3.081 2.16,2.979 V 2.529 C 2.16,2.421 2.106,2.367 1.998,2.367 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 0.153 C 0.153,0.051 0.102,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,881.23213,80.0244)"
+       clip-path="url(#clipPath423)" />
+    <path
+       id="path424"
+       d="M 0,0 V 0.531 C 0,0.627 0.042,0.699 0.126,0.747 L 1.062,1.314 C 1.176,1.38 1.272,1.413 1.35,1.413 h 0.54 c 0.102,0 0.153,-0.051 0.153,-0.153 v -5.481 c 0,-0.102 -0.048,-0.153 -0.144,-0.153 H 1.314 c -0.102,0 -0.153,0.051 -0.153,0.153 V 0.477 L 0.18,-0.09 C 0.06,-0.144 0,-0.114 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,885.714,74.1924)"
+       clip-path="url(#clipPath425)" />
+    <path
+       id="path426"
+       d="M 0,0 V 0.531 C 0,0.627 0.042,0.699 0.126,0.747 L 1.062,1.314 C 1.176,1.38 1.272,1.413 1.35,1.413 h 0.54 c 0.102,0 0.153,-0.051 0.153,-0.153 v -5.481 c 0,-0.102 -0.048,-0.153 -0.144,-0.153 H 1.314 c -0.102,0 -0.153,0.051 -0.153,0.153 V 0.477 L 0.18,-0.09 C 0.06,-0.144 0,-0.114 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,889.95613,74.1924)"
+       clip-path="url(#clipPath427)" />
+    <path
+       id="path428"
+       d="M 0,0 H -0.567 C -0.669,0 -0.72,0.051 -0.72,0.153 v 5.481 c 0,0.102 0.051,0.153 0.153,0.153 h 2.826 c 0.102,0 0.153,-0.051 0.153,-0.153 V 5.175 C 2.412,5.073 2.361,5.022 2.259,5.022 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 3.231 c 0,-0.066 0.036,-0.099 0.108,-0.099 H 1.998 C 2.106,3.132 2.16,3.081 2.16,2.979 V 2.529 C 2.16,2.421 2.106,2.367 1.998,2.367 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 0.153 C 0.153,0.051 0.102,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,949.60973,80.026933)"
+       clip-path="url(#clipPath429)" />
+    <path
+       id="path430"
+       d="M 0,0 V 0.531 C 0,0.627 0.042,0.699 0.126,0.747 L 1.062,1.314 C 1.176,1.38 1.272,1.413 1.35,1.413 h 0.54 c 0.102,0 0.153,-0.051 0.153,-0.153 v -5.481 c 0,-0.102 -0.048,-0.153 -0.144,-0.153 H 1.314 c -0.102,0 -0.153,0.051 -0.153,0.153 V 0.477 L 0.18,-0.09 C 0.06,-0.144 0,-0.114 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,954.0916,74.194933)"
+       clip-path="url(#clipPath431)" />
+    <path
+       id="path432"
+       d="M 0,0 V 0.828 C 0,1.2 0.159,1.512 0.478,1.764 L 2.179,3.15 C 2.466,3.378 2.61,3.642 2.61,3.942 v 0.297 c 0,0.432 -0.225,0.648 -0.674,0.648 H 1.494 C 1.267,4.887 1.102,4.836 0.999,4.734 0.897,4.632 0.847,4.467 0.847,4.239 V 3.906 C 0.847,3.798 0.795,3.744 0.693,3.744 H 0.117 c -0.102,0 -0.153,0.054 -0.153,0.162 v 0.351 c 0,0.438 0.123,0.777 0.369,1.017 0.246,0.24 0.591,0.36 1.035,0.36 H 2.07 c 0.438,0 0.781,-0.12 1.027,-0.36 C 3.342,5.034 3.465,4.695 3.465,4.257 V 3.888 C 3.465,3.42 3.282,3.036 2.916,2.736 L 1.188,1.323 C 1.05,1.209 0.981,1.074 0.981,0.918 V 0.63 h 2.34 C 3.43,0.63 3.483,0.579 3.483,0.477 V 0 c 0,-0.102 -0.053,-0.153 -0.162,-0.153 H 0.162 C 0.055,-0.153 0,-0.102 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,958.50827,79.8232)"
+       clip-path="url(#clipPath433)" />
+    <path
+       id="path434"
+       d="m 0,0 h -2.881 c -0.101,0 -0.152,0.051 -0.152,0.153 v 5.481 c 0,0.102 0.051,0.153 0.152,0.153 H 0 c 0.096,0 0.144,-0.051 0.144,-0.153 V 5.175 C 0.144,5.073 0.096,5.022 0,5.022 h -2.053 c -0.071,0 -0.107,-0.03 -0.107,-0.09 V 3.411 c 0,-0.06 0.036,-0.09 0.107,-0.09 h 1.738 c 0.108,0 0.162,-0.051 0.162,-0.153 V 2.709 c 0,-0.102 -0.054,-0.153 -0.162,-0.153 h -1.738 c -0.071,0 -0.107,-0.03 -0.107,-0.09 V 0.864 c 0,-0.066 0.036,-0.099 0.107,-0.099 H 0 c 0.096,0 0.144,-0.051 0.144,-0.153 V 0.153 C 0.144,0.051 0.096,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1099.4288,80.026933)"
+       clip-path="url(#clipPath435)" />
+    <path
+       id="path436"
+       d="M 0,0 H -0.559 C -0.66,0 -0.711,0.051 -0.711,0.153 v 5.481 c 0,0.102 0.051,0.153 0.152,0.153 h 0.505 c 0.096,0 0.161,-0.033 0.198,-0.099 L 2.322,1.773 h 0.035 v 3.861 c 0,0.102 0.052,0.153 0.154,0.153 h 0.557 c 0.103,0 0.154,-0.051 0.154,-0.153 V 0.153 C 3.222,0.051 3.171,0 3.068,0 H 2.583 C 2.486,0 2.409,0.048 2.349,0.144 L 0.188,4.014 H 0.153 V 0.153 C 0.153,0.051 0.102,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1102.2569,80.026933)"
+       clip-path="url(#clipPath437)" />
+    <path
+       id="path438"
+       d="m 0,0 h -0.567 c -0.108,0 -0.162,0.051 -0.162,0.153 v 4.779 c 0,0.06 -0.031,0.09 -0.09,0.09 h -1.134 c -0.109,0 -0.162,0.051 -0.162,0.153 v 0.459 c 0,0.102 0.053,0.153 0.162,0.153 h 3.339 c 0.108,0 0.162,-0.051 0.162,-0.153 V 5.175 C 1.548,5.073 1.494,5.022 1.386,5.022 H 0.252 c -0.066,0 -0.1,-0.03 -0.1,-0.09 V 0.153 C 0.152,0.051 0.102,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1110.8103,80.026933)"
+       clip-path="url(#clipPath439)" />
+    <path
+       id="path440"
+       d="M 0,0 H -0.567 C -0.669,0 -0.72,0.051 -0.72,0.153 v 5.481 c 0,0.102 0.051,0.153 0.153,0.153 h 2.826 c 0.102,0 0.153,-0.051 0.153,-0.153 V 5.175 C 2.412,5.073 2.361,5.022 2.259,5.022 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 3.231 c 0,-0.066 0.036,-0.099 0.108,-0.099 H 1.998 C 2.106,3.132 2.16,3.081 2.16,2.979 V 2.529 C 2.16,2.421 2.106,2.367 1.998,2.367 H 0.261 c -0.072,0 -0.108,-0.03 -0.108,-0.09 V 0.153 C 0.153,0.051 0.102,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1115.2583,80.026933)"
+       clip-path="url(#clipPath441)" />
+    <path
+       id="path442"
+       d="m 0,0 h 1.27 c 0.431,0 0.647,0.222 0.647,0.666 v 2.925 c 0,0.444 -0.216,0.666 -0.647,0.666 H 0 c -0.066,0 -0.099,-0.03 -0.099,-0.09 V 0.099 C -0.099,0.033 -0.066,0 0,0 m -0.972,-0.612 v 5.481 c 0,0.102 0.051,0.153 0.153,0.153 H 1.396 C 1.833,5.022 2.177,4.9 2.426,4.657 2.675,4.415 2.799,4.071 2.799,3.627 V 0.63 C 2.799,0.192 2.675,-0.15 2.426,-0.396 2.177,-0.642 1.833,-0.765 1.396,-0.765 h -2.215 c -0.102,0 -0.153,0.051 -0.153,0.153"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1022.7881,73.006133)"
+       clip-path="url(#clipPath443)" />
+    <path
+       id="path444"
+       d="M 0,0 H 1.144 C 1.587,0 1.81,0.219 1.81,0.657 v 0.756 c 0,0.444 -0.223,0.666 -0.666,0.666 H 0 c -0.066,0 -0.099,-0.03 -0.099,-0.09 V 0.09 C -0.099,0.03 -0.066,0 0,0 m -0.252,-2.943 h -0.567 c -0.102,0 -0.153,0.051 -0.153,0.153 v 5.481 c 0,0.102 0.051,0.153 0.153,0.153 H 1.287 C 1.725,2.844 2.068,2.72 2.317,2.471 2.566,2.222 2.691,1.878 2.691,1.44 V 0.684 c 0,-0.69 -0.285,-1.125 -0.855,-1.305 v -0.036 l 0.999,-2.106 c 0.066,-0.12 0.027,-0.18 -0.117,-0.18 H 2.16 c -0.144,0 -0.237,0.051 -0.279,0.153 L 0.918,-0.72 H 0.009 c -0.071,0 -0.108,-0.03 -0.108,-0.09 v -1.98 c 0,-0.102 -0.051,-0.153 -0.153,-0.153"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1029.5785,70.102533)"
+       clip-path="url(#clipPath445)" />
+    <path
+       id="path446"
+       d="m 0,0 h 0.567 c 0.109,0 0.162,-0.048 0.162,-0.144 v -4.248 c 0,-0.438 -0.125,-0.78 -0.374,-1.026 -0.249,-0.246 -0.591,-0.369 -1.03,-0.369 h -0.999 c -0.437,0 -0.78,0.123 -1.025,0.369 -0.246,0.246 -0.369,0.588 -0.369,1.026 v 4.239 c 0,0.102 0.05,0.153 0.152,0.153 h 0.567 c 0.102,0 0.154,-0.051 0.154,-0.153 v -4.203 c 0,-0.444 0.216,-0.666 0.647,-0.666 h 0.738 c 0.438,0 0.658,0.222 0.658,0.666 v 4.203 C -0.152,-0.051 -0.102,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1038.9652,66.310133)"
+       clip-path="url(#clipPath447)" />
+    <path
+       id="path448"
+       d="m 0,0 h -1.044 c -0.444,0 -0.787,0.123 -1.03,0.369 -0.243,0.246 -0.364,0.588 -0.364,1.026 v 2.997 c 0,0.444 0.121,0.788 0.364,1.03 0.243,0.244 0.586,0.365 1.03,0.365 H 0 c 0.438,0 0.78,-0.121 1.026,-0.365 0.246,-0.242 0.37,-0.586 0.37,-1.03 V 3.96 C 1.396,3.852 1.341,3.798 1.233,3.798 H 0.666 c -0.102,0 -0.153,0.054 -0.153,0.162 v 0.396 c 0,0.444 -0.216,0.666 -0.648,0.666 H -0.918 C -1.35,5.022 -1.565,4.8 -1.565,4.356 V 1.431 c 0,-0.444 0.215,-0.666 0.647,-0.666 h 0.783 c 0.432,0 0.648,0.222 0.648,0.666 v 0.396 c 0,0.108 0.051,0.162 0.153,0.162 h 0.567 c 0.108,0 0.163,-0.054 0.163,-0.162 V 1.395 C 1.396,0.957 1.272,0.615 1.026,0.369 0.78,0.123 0.438,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1044.8963,74.026267)"
+       clip-path="url(#clipPath449)" />
+    <path
+       id="path450"
+       d="M 0,0 H -0.567 C -0.669,0 -0.72,0.051 -0.72,0.153 v 5.481 c 0,0.102 0.051,0.153 0.153,0.153 H 0 c 0.102,0 0.153,-0.051 0.153,-0.153 V 2.781 H 0.18 c 0.06,0.162 0.138,0.312 0.234,0.45 L 2.133,5.634 C 2.199,5.736 2.295,5.787 2.421,5.787 H 3.087 C 3.213,5.787 3.234,5.73 3.15,5.616 L 1.396,3.231 3.375,0.18 C 3.447,0.06 3.411,0 3.267,0 H 2.763 C 2.601,0 2.487,0.051 2.421,0.153 L 0.864,2.592 0.153,1.755 V 0.153 C 0.153,0.051 0.102,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,1049.3859,74.026267)"
+       clip-path="url(#clipPath451)" />
+    <path
+       id="path452"
+       d="M 0,0 C 0,0.222 -0.18,0.404 -0.402,0.404 H -7.51 c -0.221,0 -0.402,-0.182 -0.402,-0.404 0,-0.222 0.181,-0.404 0.402,-0.404 h 7.108 C -0.18,-0.404 0,-0.222 0,0 m 0.002,-3.171 c 0,0.222 -0.18,0.403 -0.402,0.403 h -7.108 c -0.221,0 -0.402,-0.181 -0.402,-0.403 0,-0.223 0.181,-0.404 0.402,-0.404 H -0.4 c 0.222,0 0.402,0.181 0.402,0.404 M -0.4,-6.745 h -7.108 c -0.221,0 -0.402,0.181 -0.402,0.403 0,0.223 0.181,0.404 0.402,0.404 H -0.4 c 0.222,0 0.402,-0.181 0.402,-0.404 0,-0.222 -0.18,-0.403 -0.402,-0.403"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,869.31613,416.3056)"
+       clip-path="url(#clipPath453)" />
+    <path
+       id="path454"
+       d="m 0,0 c -0.064,0 -0.126,0.017 -0.181,0.048 -0.124,0.071 -0.202,0.207 -0.202,0.354 v 3.002 c 0,0.148 0.076,0.286 0.202,0.355 0.114,0.067 0.257,0.064 0.371,-0.005 L 2.757,2.219 C 2.931,2.109 2.983,1.878 2.873,1.705 2.842,1.657 2.804,1.616 2.757,1.588 L 0.19,0.052 C 0.131,0.019 0.067,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,143.99933,115.6968)"
+       clip-path="url(#clipPath455)" />
+    <path
+       id="path456"
+       d="m 0,0 v 3.026 c 0,0.209 0.171,0.381 0.381,0.381 0.209,0 0.381,-0.172 0.381,-0.381 V 0 C 0.762,-0.21 0.59,-0.381 0.381,-0.381 0.171,-0.381 0,-0.21 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,148.41467,115.17613)"
+       clip-path="url(#clipPath457)" />
+    <path
+       id="path458"
+       d="m 0,0 v 3.026 c 0,0.209 0.171,0.381 0.381,0.381 0.209,0 0.381,-0.172 0.381,-0.381 V 0 C 0.762,-0.21 0.59,-0.381 0.381,-0.381 0.171,-0.381 0,-0.21 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,150.44613,115.17613)"
+       clip-path="url(#clipPath459)" />
+    <path
+       id="path460"
+       d="m 0,0 c 0.064,0 0.126,-0.017 0.181,-0.048 0.124,-0.071 0.202,-0.207 0.202,-0.354 v -3.002 c 0,-0.148 -0.076,-0.286 -0.202,-0.355 -0.114,-0.067 -0.257,-0.064 -0.371,0.005 l -2.567,1.535 c -0.174,0.11 -0.226,0.341 -0.116,0.514 0.031,0.048 0.069,0.089 0.116,0.117 l 2.567,1.536 C -0.131,-0.019 -0.067,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,221.7736,110.618)"
+       clip-path="url(#clipPath461)" />
+    <path
+       id="path462"
+       d="m 0,0 v -3.026 c 0,-0.209 -0.171,-0.381 -0.381,-0.381 -0.209,0 -0.381,0.172 -0.381,0.381 V 0 c 0,0.21 0.172,0.381 0.381,0.381 C -0.171,0.381 0,0.21 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,217.35827,111.13853)"
+       clip-path="url(#clipPath463)" />
+    <path
+       id="path464"
+       d="m 0,0 c -0.064,0 -0.126,0.017 -0.181,0.048 -0.124,0.071 -0.202,0.207 -0.202,0.354 v 3.002 c 0,0.148 0.076,0.286 0.202,0.355 0.114,0.067 0.257,0.064 0.371,-0.005 L 2.757,2.219 C 2.931,2.109 2.983,1.878 2.873,1.705 2.843,1.657 2.804,1.616 2.757,1.588 L 0.19,0.052 C 0.131,0.019 0.067,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,288.6984,115.6968)"
+       clip-path="url(#clipPath465)" />
+    <path
+       id="path466"
+       d="m 0,0 v 3.026 c 0,0.209 0.171,0.381 0.381,0.381 0.209,0 0.381,-0.172 0.381,-0.381 V 0 C 0.762,-0.21 0.59,-0.381 0.381,-0.381 0.171,-0.381 0,-0.21 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,293.11373,115.17613)"
+       clip-path="url(#clipPath467)" />
+    <path
+       id="path468"
+       d="m 0,0 c -0.29,0 -0.524,-0.233 -0.524,-0.524 v -0.904 c 0,-0.291 0.234,-0.524 0.524,-0.524 0.29,0 0.524,0.233 0.524,0.524 v 0.904 C 0.524,-0.233 0.29,0 0,0 M 2.697,1.112 C 2.566,1.112 2.433,1.062 2.331,0.964 2.124,0.762 2.119,0.431 2.321,0.224 L 2.89,-0.345 C 2.988,-0.443 3.121,-0.5 3.259,-0.5 c 0.138,0 0.272,0.055 0.372,0.152 0.204,0.205 0.204,0.536 0,0.741 L 3.062,0.962 c -0.1,0.1 -0.231,0.15 -0.365,0.15 m -5.385,0.009 c -0.135,0 -0.271,-0.052 -0.376,-0.157 L -3.633,0.395 C -3.73,0.298 -3.785,0.164 -3.785,0.024 c 0,-0.291 0.233,-0.524 0.524,-0.524 0.138,0 0.271,0.055 0.369,0.155 l 0.568,0.569 0.01,0.009 c 0.202,0.207 0.198,0.538 -0.01,0.741 -0.102,0.097 -0.233,0.147 -0.364,0.147 m -1.121,2.688 h -0.905 c -0.29,0 -0.523,-0.233 -0.523,-0.524 0,-0.29 0.233,-0.523 0.523,-0.523 h 0.905 c 0.29,0 0.524,0.233 0.524,0.523 0,0.291 -0.234,0.524 -0.524,0.524 m 8.523,0 H 3.809 c -0.29,0 -0.524,-0.233 -0.524,-0.524 0,-0.29 0.234,-0.523 0.524,-0.523 h 0.905 c 0.29,0 0.523,0.233 0.523,0.523 0,0.291 -0.233,0.524 -0.523,0.524 M 0,5.714 C -1.34,5.714 -2.428,4.626 -2.428,3.285 -2.428,1.945 -1.34,0.857 0,0.857 1.34,0.859 2.426,1.945 2.428,3.285 2.428,4.626 1.34,5.714 0,5.714 M 3.259,7.068 C 3.128,7.068 2.995,7.018 2.895,6.921 L 2.326,6.352 C 2.228,6.254 2.174,6.121 2.174,5.983 c 0,-0.291 0.233,-0.524 0.523,-0.524 0.138,0 0.272,0.055 0.369,0.152 L 3.635,6.18 c 0.198,0.203 0.198,0.529 0,0.731 -0.104,0.102 -0.24,0.157 -0.376,0.157 m -6.518,0 C -3.39,7.068 -3.523,7.018 -3.626,6.921 -3.833,6.718 -3.838,6.387 -3.635,6.18 l 0.569,-0.569 c 0.097,-0.097 0.231,-0.152 0.369,-0.152 0.138,0 0.271,0.055 0.369,0.152 0.204,0.205 0.204,0.536 0,0.741 L -2.897,6.921 C -2.995,7.018 -3.126,7.068 -3.259,7.068 M 0,8.523 c -0.29,0 -0.524,-0.234 -0.524,-0.524 V 7.094 c 0,-0.29 0.234,-0.523 0.524,-0.523 0.29,0 0.524,0.233 0.524,0.523 V 7.999 C 0.524,8.289 0.29,8.523 0,8.523 M 0,4.952 C 0.919,4.952 1.666,4.204 1.666,3.285 1.666,2.366 0.917,1.619 0,1.619 c -0.919,0 -1.666,0.747 -1.666,1.666 0,0.919 0.747,1.667 1.666,1.667"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,286.43413,80.397067)"
+       clip-path="url(#clipPath469)" />
+    <path
+       id="path470"
+       d="m 0,0 c -1.34,0 -2.428,-1.088 -2.428,-2.428 0,-1.341 1.088,-2.429 2.428,-2.429 1.34,0.003 2.426,1.088 2.428,2.429 C 2.428,-1.088 1.34,0 0,0 m 0,-0.762 c 0.919,0 1.666,-0.747 1.666,-1.666 0,-0.919 -0.749,-1.667 -1.666,-1.667 -0.919,0 -1.666,0.748 -1.666,1.667 0,0.919 0.747,1.666 1.666,1.666"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,217.154,72.779067)"
+       clip-path="url(#clipPath471)" />
+    <path
+       id="path472"
+       d="m 0,0 c 0.289,0 0.524,-0.234 0.524,-0.524 0,-0.289 -0.235,-0.523 -0.524,-0.523 -0.289,0 -0.524,0.234 -0.524,0.523 C -0.524,-0.234 -0.289,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,217.154,70.2396)"
+       clip-path="url(#clipPath473)" />
+    <path
+       id="path474"
+       d="m 0,0 c 0.289,0 0.524,-0.234 0.524,-0.524 0,-0.289 -0.235,-0.524 -0.524,-0.524 -0.289,0 -0.524,0.235 -0.524,0.524 C -0.524,-0.234 -0.289,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,217.154,80.397067)"
+       clip-path="url(#clipPath475)" />
+    <path
+       id="path476"
+       d="m 0,0 c 0.289,0 0.524,-0.234 0.524,-0.524 0,-0.289 -0.235,-0.523 -0.524,-0.523 -0.289,0 -0.524,0.234 -0.524,0.523 C -0.524,-0.234 -0.289,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,222.2328,75.3184)"
+       clip-path="url(#clipPath477)" />
+    <path
+       id="path478"
+       d="m 0,0 c 0.289,0 0.524,-0.234 0.524,-0.524 0,-0.289 -0.235,-0.523 -0.524,-0.523 -0.289,0 -0.524,0.234 -0.524,0.523 C -0.524,-0.234 -0.289,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,212.0752,75.3184)"
+       clip-path="url(#clipPath479)" />
+    <path
+       id="path480"
+       d="m 0,0 c 0.289,0 0.524,-0.234 0.524,-0.524 0,-0.289 -0.235,-0.523 -0.524,-0.523 -0.289,0 -0.524,0.234 -0.524,0.523 C -0.524,-0.234 -0.289,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,213.5544,71.722)"
+       clip-path="url(#clipPath481)" />
+    <path
+       id="path482"
+       d="m 0,0 c 0.289,0 0.524,-0.234 0.524,-0.524 0,-0.289 -0.235,-0.523 -0.524,-0.523 -0.289,0 -0.524,0.234 -0.524,0.523 C -0.524,-0.234 -0.289,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,220.7472,71.722)"
+       clip-path="url(#clipPath483)" />
+    <path
+       id="path484"
+       d="m 0,0 c 0.289,0 0.524,-0.234 0.524,-0.524 0,-0.289 -0.235,-0.523 -0.524,-0.523 -0.289,0 -0.524,0.234 -0.524,0.523 C -0.524,-0.234 -0.289,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,220.7472,78.902133)"
+       clip-path="url(#clipPath485)" />
+    <path
+       id="path486"
+       d="m 0,0 c 0.289,0 0.524,-0.234 0.524,-0.524 0,-0.289 -0.235,-0.523 -0.524,-0.523 -0.289,0 -0.524,0.234 -0.524,0.523 C -0.524,-0.234 -0.289,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,213.57027,78.902133)"
+       clip-path="url(#clipPath487)" />
+    <path
+       id="path488"
+       d="m 0,0 h -0.526 c -0.174,0 -0.317,0.143 -0.317,0.317 0,0.045 0.01,0.09 0.029,0.131 L 0.459,3.259 -1.452,3.3 -2.15,2.454 C -2.283,2.288 -2.388,2.214 -2.659,2.214 H -3.016 C -3.131,2.209 -3.24,2.262 -3.307,2.354 -3.352,2.419 -3.402,2.523 -3.354,2.678 l 0.39,1.4 c 0.002,0.012 0.007,0.022 0.012,0.033 v 0.003 c -0.005,0.009 -0.007,0.021 -0.012,0.033 l -0.39,1.412 c -0.041,0.15 0.004,0.255 0.05,0.316 0.064,0.086 0.164,0.134 0.269,0.134 h 0.373 c 0.203,0 0.398,-0.091 0.515,-0.236 L -1.464,4.94 0.459,4.968 -0.817,7.775 c -0.071,0.16 -0.002,0.348 0.158,0.419 0.04,0.019 0.085,0.029 0.13,0.029 H 0.002 C 0.152,8.22 0.295,8.149 0.383,8.03 L 2.854,5.026 3.997,5.057 C 4.08,5.061 4.311,5.064 4.364,5.064 5.456,5.064 6.109,4.709 6.109,4.114 6.109,3.928 6.035,3.581 5.535,3.359 5.24,3.228 4.845,3.164 4.366,3.164 4.314,3.164 4.08,3.166 4,3.171 L 2.857,3.202 0.381,0.198 C 0.288,0.071 0.148,0.002 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,978.82,81.495467)"
+       clip-path="url(#clipPath489)" />
+    <path
+       id="path490"
+       d="m 0,0 c 0.031,0.083 0.031,0.176 -0.002,0.264 -0.036,0.091 -0.1,0.16 -0.181,0.2 -0.093,0.05 -0.207,0.06 -0.312,0.019 C -0.583,0.45 -0.65,0.386 -0.693,0.309 L -3.09,-4.154 c -0.11,-0.191 -0.136,-0.429 -0.05,-0.65 0.15,-0.393 0.59,-0.588 0.983,-0.438 0.222,0.086 0.381,0.262 0.45,0.471 z"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,358.95147,72.826667)"
+       clip-path="url(#clipPath491)" />
+    <path
+       id="path492"
+       d="m 0,0 h -0.005 c -0.209,0 -0.381,0.171 -0.381,0.381 0,2.704 2.2,4.904 4.904,4.904 0.096,0 0.193,-0.002 0.291,-0.009 C 5.018,5.264 5.18,5.083 5.166,4.873 5.154,4.664 4.973,4.504 4.764,4.516 4.683,4.521 4.599,4.523 4.518,4.523 2.362,4.523 0.586,2.869 0.393,0.762 0.393,0.762 0.381,0.59 0.381,0.381 0.381,0.169 0.21,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,349.68907,79.375067)"
+       clip-path="url(#clipPath493)" />
+    <path
+       id="path494"
+       d="m 0,0 h -0.762 c -0.209,0 -0.381,0.171 -0.381,0.381 0,0.209 0.172,0.381 0.381,0.381 h 0.364 c -0.088,0.976 -0.514,1.878 -1.221,2.573 -0.15,0.148 -0.152,0.388 -0.005,0.538 0.148,0.15 0.388,0.153 0.538,0.005 C -0.14,2.95 0.381,1.707 0.381,0.381 0.381,0.169 0.21,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,361.7448,79.375067)"
+       clip-path="url(#clipPath495)" />
+    <path
+       id="path496"
+       d="M 0,0 C -0.21,0 -0.381,0.171 -0.381,0.381 -0.381,2.005 0.774,3.4 2.366,3.7 2.573,3.738 2.773,3.602 2.812,3.395 2.85,3.188 2.714,2.988 2.507,2.95 1.274,2.716 0.379,1.635 0.379,0.379 0.381,0.171 0.21,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,351.71747,79.375067)"
+       clip-path="url(#clipPath497)" />
+    <path
+       id="path498"
+       d="m 0,0 h -8.723 c -0.209,0 -0.381,-0.171 -0.381,-0.381 0,-0.209 0.172,-0.381 0.381,-0.381 H 0 c 0.209,0 0.381,0.172 0.381,0.381 C 0.381,-0.171 0.209,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,777.28827,80.5336)"
+       clip-path="url(#clipPath499)" />
+    <path
+       id="path500"
+       d="m 0,0 c 0,-0.105 -0.086,-0.19 -0.19,-0.19 h -7.58 c -0.105,0 -0.191,0.085 -0.191,0.19 v 4.871 c 0,0.105 0.086,0.19 0.191,0.19 h 7.58 C -0.086,5.061 0,4.976 0,4.871 Z m -0.19,5.823 h -7.58 c -0.527,0 -0.953,-0.426 -0.953,-0.952 V 0 c 0,-0.526 0.426,-0.952 0.953,-0.952 h 7.58 c 0.526,0 0.952,0.426 0.952,0.952 v 4.871 c 0,0.526 -0.426,0.952 -0.952,0.952"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,776.7804,78.248267)"
+       clip-path="url(#clipPath501)" />
+    <path
+       id="path502"
+       d="M 0,0 C -0.148,0.148 -0.39,0.148 -0.538,0 L -1.112,-0.574 -1.686,0 c -0.147,0.148 -0.39,0.148 -0.538,0 -0.147,-0.148 -0.147,-0.39 0,-0.538 l 0.574,-0.574 -0.574,-0.574 c -0.147,-0.147 -0.147,-0.39 0,-0.538 0.074,-0.073 0.172,-0.111 0.269,-0.111 0.098,0 0.196,0.038 0.269,0.111 l 0.574,0.574 0.574,-0.574 c 0.074,-0.073 0.171,-0.111 0.269,-0.111 0.098,0 0.195,0.038 0.269,0.111 0.148,0.148 0.148,0.391 0,0.538 L -0.574,-1.112 0,-0.538 C 0.15,-0.39 0.15,-0.148 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,772.95547,73.518667)"
+       clip-path="url(#clipPath503)" />
+    <path
+       id="path504"
+       d="m 0,0 c -0.21,0 -0.381,0.171 -0.381,0.381 0,0.067 0.017,0.133 0.05,0.19 0.45,0.784 0.712,1.441 0.712,2.476 0,1.052 -0.26,1.705 -0.71,2.474 C -0.433,5.704 -0.367,5.937 -0.186,6.04 -0.007,6.142 0.221,6.08 0.328,5.904 0.831,5.045 1.143,4.266 1.143,3.047 1.143,1.847 0.831,1.064 0.331,0.19 0.262,0.071 0.136,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,705.74827,80.079733)"
+       clip-path="url(#clipPath505)" />
+    <path
+       id="path506"
+       d="m 0,0 c -0.209,0 -0.381,0.171 -0.381,0.381 0,0.074 0.022,0.145 0.062,0.207 0.65,0.995 1.081,1.988 1.081,3.602 0,1.583 -0.433,2.585 -1.083,3.604 C -0.436,7.973 -0.383,8.209 -0.205,8.32 -0.026,8.435 0.209,8.382 0.321,8.204 1.043,7.073 1.524,5.959 1.524,4.19 1.524,2.647 1.174,1.486 0.319,0.174 0.248,0.064 0.129,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,707.27187,81.603333)"
+       clip-path="url(#clipPath507)" />
+    <path
+       id="path508"
+       d="m 0,0 h 0.314 c 0.317,0 0.572,-0.255 0.572,-0.571 v -2.667 c 0,-0.316 -0.255,-0.571 -0.572,-0.571 H 0 c -0.317,0 -0.571,0.255 -0.571,0.571 v 2.667 C -0.571,-0.257 -0.317,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,695.84467,73.477333)"
+       clip-path="url(#clipPath509)" />
+    <path
+       id="path510"
+       d="m 0,0 v -6.483 c 0,-0.121 -0.038,-0.24 -0.112,-0.338 -0.188,-0.254 -0.545,-0.309 -0.8,-0.121 l -0.016,0.012 -1.969,1.614 c -0.134,0.11 -0.21,0.271 -0.21,0.443 v 3.264 c 0,0.171 0.076,0.333 0.21,0.442 l 1.969,1.615 0.016,0.011 C -0.657,0.648 -0.3,0.593 -0.112,0.338 -0.038,0.24 0,0.121 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,702.19307,71.693467)"
+       clip-path="url(#clipPath511)" />
+    <path
+       id="path512"
+       d="m 0,0 c -0.209,0 -0.381,0.171 -0.381,0.381 0,0.059 0.014,0.117 0.041,0.171 C -0.114,1.002 0,1.457 0,1.905 0,2.366 -0.112,2.807 -0.338,3.254 -0.431,3.442 -0.352,3.671 -0.162,3.764 0.021,3.854 0.245,3.78 0.34,3.6 0.624,3.042 0.762,2.488 0.762,1.902 0.762,1.336 0.619,0.764 0.34,0.207 0.276,0.081 0.143,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,704.22453,78.556133)"
+       clip-path="url(#clipPath513)" />
+    <path
+       id="path514"
+       d="m 0,0 c -0.21,0 -0.381,0.171 -0.381,0.381 0,0.059 0.014,0.117 0.041,0.171 C -0.114,1.002 0,1.457 0,1.905 0,2.366 -0.112,2.807 -0.338,3.254 -0.431,3.442 -0.352,3.671 -0.162,3.764 0.021,3.854 0.245,3.78 0.34,3.6 0.624,3.042 0.762,2.488 0.762,1.902 0.762,1.336 0.619,0.764 0.34,0.207 0.276,0.081 0.145,0 0,0 m -1.524,5.147 v -6.483 c 0,-0.121 -0.038,-0.24 -0.112,-0.338 -0.188,-0.254 -0.545,-0.309 -0.799,-0.121 l -0.017,0.012 -1.969,1.614 C -4.554,-0.06 -4.63,0.102 -4.63,0.274 v 3.264 c 0,0.171 0.076,0.333 0.209,0.442 l 1.969,1.615 0.017,0.011 c 0.254,0.189 0.611,0.134 0.799,-0.121 0.074,-0.098 0.112,-0.217 0.112,-0.338 M -6.285,3.809 h 0.317 c 0.316,0 0.571,-0.255 0.571,-0.571 V 0.571 C -5.397,0.255 -5.652,0 -5.968,0 h -0.317 c -0.317,0 -0.571,0.255 -0.571,0.571 v 2.667 c 0,0.314 0.254,0.571 0.571,0.571"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,636.896,78.556133)"
+       clip-path="url(#clipPath515)" />
+    <path
+       id="path516"
+       d="m 0,0 h -0.314 c -0.314,0 -0.572,-0.257 -0.572,-0.571 v -2.667 c 0,-0.316 0.255,-0.571 0.572,-0.571 H 0 c 0.317,0 0.571,0.255 0.571,0.571 v 2.667 C 0.571,-0.255 0.317,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,559.04053,73.477333)"
+       clip-path="url(#clipPath517)" />
+    <path
+       id="path518"
+       d="m 0,0 -0.017,-0.012 -1.968,-1.614 c -0.134,-0.11 -0.21,-0.271 -0.21,-0.443 v -3.264 c 0,-0.171 0.076,-0.333 0.21,-0.442 L -0.017,-7.39 0,-7.401 c 0.255,-0.189 0.612,-0.134 0.8,0.121 0.074,0.098 0.112,0.217 0.112,0.338 v 6.483 C 0.914,-0.338 0.874,-0.219 0.8,-0.121 0.612,0.133 0.255,0.188 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,563.75413,71.0808)"
+       clip-path="url(#clipPath519)" />
+    <path
+       id="path520"
+       d="m 0,0 0.574,0.574 c 0.147,0.147 0.147,0.39 0,0.538 -0.148,0.147 -0.391,0.147 -0.538,0 L -0.538,0.538 -1.112,1.112 c -0.147,0.147 -0.39,0.147 -0.538,0 -0.147,-0.148 -0.147,-0.391 0,-0.538 L -1.076,0 -1.65,-0.574 c -0.147,-0.147 -0.147,-0.39 0,-0.538 0.074,-0.074 0.172,-0.112 0.269,-0.112 0.098,0 0.195,0.038 0.269,0.112 l 0.574,0.574 0.574,-0.574 c 0.074,-0.074 0.171,-0.112 0.269,-0.112 0.097,0 0.195,0.038 0.269,0.112 0.147,0.148 0.147,0.391 0,0.538 z"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,568.8424,76.016667)"
+       clip-path="url(#clipPath521)" />
+    <path
+       id="path522"
+       d="m 0,0 c -0.017,-0.007 -0.031,-0.017 -0.048,-0.026 l -1.43,-1.007 c -0.148,-0.105 -0.236,-0.276 -0.236,-0.455 v -1.374 c 0,-0.183 0.088,-0.349 0.236,-0.454 l 1.428,-1.005 c 0.017,-0.009 0.031,-0.019 0.048,-0.026 0.073,-0.031 0.147,-0.048 0.226,-0.048 0.307,0 0.552,0.248 0.554,0.555 v 3.333 c 0,0.079 -0.016,0.157 -0.047,0.226 C 0.607,-0.002 0.281,0.124 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,844.248,73.096533)"
+       clip-path="url(#clipPath523)" />
+    <path
+       id="path524"
+       d="m 0,0 h -2.597 c -0.676,-0.002 -1.229,-0.536 -1.229,-1.193 v -2.661 c 0,-0.66 0.553,-1.193 1.229,-1.193 h 2.587 c 0.681,0 1.229,0.533 1.231,1.19 v 2.671 C 1.219,-0.531 0.676,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,839.3152,72.629867)"
+       clip-path="url(#clipPath525)" />
+    <path
+       id="path526"
+       d="m 0,0 0.574,0.574 c 0.147,0.147 0.147,0.39 0,0.538 -0.148,0.147 -0.391,0.147 -0.538,0 L -0.538,0.538 -1.112,1.112 c -0.147,0.147 -0.39,0.147 -0.538,0 -0.147,-0.148 -0.147,-0.391 0,-0.538 L -1.076,0 -1.65,-0.574 c -0.147,-0.147 -0.147,-0.39 0,-0.538 0.074,-0.074 0.172,-0.112 0.269,-0.112 0.098,0 0.195,0.038 0.269,0.112 l 0.574,0.574 0.574,-0.574 c 0.073,-0.074 0.171,-0.112 0.269,-0.112 0.097,0 0.195,0.038 0.269,0.112 0.147,0.148 0.147,0.391 0,0.538 z"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,849.15533,76.016667)"
+       clip-path="url(#clipPath527)" />
+    <path
+       id="path528"
+       d="m 0,0 c -0.29,0 -0.524,0.233 -0.524,0.524 v 1.381 c 0,0.29 0.234,0.523 0.524,0.523 0.29,0 0.524,-0.233 0.524,-0.523 V 0.524 C 0.524,0.233 0.29,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,422.98773,401.282)"
+       clip-path="url(#clipPath529)" />
+    <path
+       id="path530"
+       d="m 0,0 c -0.29,0 -0.524,0.236 -0.524,0.524 0,0.138 0.055,0.271 0.153,0.369 L 0.674,1.938 C 0.881,2.14 1.212,2.135 1.414,1.928 1.612,1.726 1.612,1.4 1.414,1.197 L 0.369,0.152 C 0.274,0.057 0.14,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,426.57773,402.77067)"
+       clip-path="url(#clipPath531)" />
+    <path
+       id="path532"
+       d="m 0,0 h -7.728 c -0.29,0 -0.523,0.233 -0.523,0.524 0,0.29 0.233,0.524 0.523,0.524 H 0 C 0.29,1.048 0.524,0.814 0.524,0.524 0.524,0.233 0.29,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,427.96173,405.564)"
+       clip-path="url(#clipPath533)" />
+    <path
+       id="path534"
+       d="m 0,0 c -0.138,0 -0.271,0.055 -0.371,0.152 l -1.045,1.045 c -0.203,0.208 -0.198,0.539 0.009,0.741 0.202,0.197 0.529,0.197 0.731,0 L 0.369,0.893 C 0.574,0.688 0.574,0.357 0.369,0.152 0.271,0.057 0.138,0 0,0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,419.39773,402.77067)"
+       clip-path="url(#clipPath535)" />
+    <path
+       id="path536"
+       d="M 0,0 H -3.221 C -3.326,0 -3.409,0.086 -3.409,0.188 V 0.997 H 0.188 V 0.188 C 0.19,0.086 0.105,0 0,0 M -7.77,0.19 V 1 h 3.597 V 0.19 c 0,-0.104 -0.086,-0.188 -0.188,-0.188 H -7.58 C -7.685,0 -7.77,0.086 -7.77,0.19 m 0.19,5.824 H 0 c 0.105,0 0.19,-0.086 0.19,-0.191 V 1.762 H -7.582 -7.77 v 4.061 c 0,0.105 0.085,0.191 0.19,0.191 M 0,6.775 h -7.58 c -0.526,0 -0.952,-0.426 -0.952,-0.952 V 0.19 c 0,-0.526 0.426,-0.952 0.952,-0.952 H -3.79 0 c 0.526,0 0.952,0.426 0.952,0.952 V 5.823 C 0.952,6.349 0.526,6.775 0,6.775"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,916.41827,80.025733)"
+       clip-path="url(#clipPath537)" />
+    <g
+       aria-label="MOD 4"
+       id="text6809"
+       style="font-weight:bold;font-size:10.6667px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue Bold';text-align:center;letter-spacing:0.66px;text-anchor:middle;stroke-width:2.83465"
+       transform="translate(-0.02662687,-1.1630793e-5)">
+      <path
+         d="m 782.27001,398.6852 h 1.19467 q 0.18133,0 0.18133,0.18133 v 6.49602 q 0,0.18133 -0.18133,0.18133 h -0.66134 q -0.18133,0 -0.18133,-0.18133 v -5.38668 h -0.0427 l -1.38667,3.90401 q -0.064,0.17067 -0.23467,0.17067 h -0.68267 q -0.16,0 -0.224,-0.17067 l -1.41867,-3.91468 h -0.0427 v 5.39735 q 0,0.10667 -0.0427,0.14933 -0.032,0.032 -0.13867,0.032 h -0.65067 q -0.18133,0 -0.18133,-0.18133 v -6.49602 q 0,-0.18133 0.18133,-0.18133 h 1.19467 q 0.11734,0 0.17067,0.11733 l 1.46134,4.11735 h 0.0533 l 1.472,-4.11735 q 0.0213,-0.11733 0.16001,-0.11733 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39352" />
+      <path
+         d="m 787.55934,404.63721 h 0.928 q 0.77867,0 0.77867,-0.78933 v -3.46668 q 0,-0.78933 -0.77867,-0.78933 h -0.928 q -0.76801,0 -0.76801,0.78933 v 3.46668 q 0,0.78933 0.76801,0.78933 z m 1.088,0.90667 H 787.41 q -0.78933,0 -1.22667,-0.43733 -0.42667,-0.43734 -0.42667,-1.216 v -3.55202 q 0,-0.78933 0.42667,-1.216 0.43734,-0.43733 1.22667,-0.43733 h 1.23734 q 0.78933,0 1.22667,0.43733 0.43733,0.42667 0.43733,1.216 v 3.55202 q 0,0.77866 -0.43733,1.216 -0.43734,0.43733 -1.22667,0.43733 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39354" />
+      <path
+         d="m 793.56333,404.63721 h 1.50401 q 0.768,0 0.768,-0.78933 v -3.46668 q 0,-0.78933 -0.768,-0.78933 h -1.50401 q -0.11733,0 -0.11733,0.10666 v 4.82135 q 0,0.11733 0.11733,0.11733 z m -1.152,0.72534 v -6.49602 q 0,-0.18133 0.18133,-0.18133 h 2.62401 q 0.77867,0 1.216,0.43733 0.44801,0.42667 0.44801,1.216 v 3.55202 q 0,0.77866 -0.44801,1.216 -0.43733,0.43733 -1.216,0.43733 h -2.62401 q -0.18133,0 -0.18133,-0.18133 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39356" />
+      <path
+         d="m 804.942,403.32521 v -3.77601 l -2.10134,3.77601 z m 0.81067,2.21867 h -0.62933 q -0.18134,0 -0.18134,-0.18133 v -1.12 h -2.81601 q -0.30933,0 -0.30933,-0.30934 v -0.33067 q 0,-0.23466 0.096,-0.416 l 2.37867,-4.23468 q 0.0853,-0.16 0.16,-0.21333 0.0747,-0.0533 0.224,-0.0533 h 0.93867 q 0.30934,0 0.30934,0.30933 v 4.33068 h 0.77867 q 0.18133,0 0.18133,0.18133 v 0.53334 q 0,0.20267 -0.18133,0.20267 h -0.77867 v 1.12 q 0,0.18133 -0.17067,0.18133 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39358" />
+    </g>
+    <g
+       aria-label="MOD 3"
+       id="text6809-9"
+       style="font-weight:bold;font-size:10.6667px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue Bold';letter-spacing:0.66px;stroke-width:2.83465">
+      <path
+         d="m 134.71588,258.85188 h 1.19467 q 0.18134,0 0.18134,0.18134 v 6.49602 q 0,0.18133 -0.18134,0.18133 h -0.66133 q -0.18134,0 -0.18134,-0.18133 v -5.38669 h -0.0427 l -1.38667,3.90402 q -0.064,0.17066 -0.23467,0.17066 h -0.68267 q -0.16,0 -0.224,-0.17066 l -1.41867,-3.91468 h -0.0427 v 5.39735 q 0,0.10666 -0.0427,0.14933 -0.032,0.032 -0.13866,0.032 h -0.65067 q -0.18133,0 -0.18133,-0.18133 v -6.49602 q 0,-0.18134 0.18133,-0.18134 h 1.19467 q 0.11733,0 0.17067,0.11734 l 1.46133,4.11734 h 0.0533 l 1.472,-4.11734 q 0.0213,-0.11734 0.16,-0.11734 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39343" />
+      <path
+         d="m 140.00521,264.8039 h 0.92801 q 0.77867,0 0.77867,-0.78933 v -3.46668 q 0,-0.78934 -0.77867,-0.78934 h -0.92801 q -0.768,0 -0.768,0.78934 v 3.46668 q 0,0.78933 0.768,0.78933 z m 1.08801,0.90667 h -1.23734 q -0.78934,0 -1.22667,-0.43733 -0.42667,-0.43734 -0.42667,-1.21601 v -3.55201 q 0,-0.78933 0.42667,-1.216 0.43733,-0.43734 1.22667,-0.43734 h 1.23734 q 0.78933,0 1.22667,0.43734 0.43733,0.42667 0.43733,1.216 v 3.55201 q 0,0.77867 -0.43733,1.21601 -0.43734,0.43733 -1.22667,0.43733 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39345" />
+      <path
+         d="m 146.00921,264.8039 h 1.504 q 0.76801,0 0.76801,-0.78933 v -3.46668 q 0,-0.78934 -0.76801,-0.78934 h -1.504 q -0.11733,0 -0.11733,0.10667 v 4.82135 q 0,0.11733 0.11733,0.11733 z m -1.152,0.72534 v -6.49602 q 0,-0.18134 0.18133,-0.18134 h 2.62401 q 0.77867,0 1.216,0.43734 0.448,0.42667 0.448,1.216 v 3.55201 q 0,0.77867 -0.448,1.21601 -0.43733,0.43733 -1.216,0.43733 h -2.62401 q -0.18133,0 -0.18133,-0.18133 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39347" />
+      <path
+         d="m 156.21454,261.83856 h 0.58667 q 0.78934,0 0.78934,-0.77867 v -0.55467 q 0,-0.768 -0.78934,-0.768 h -0.62933 q -0.39467,0 -0.58667,0.18133 -0.18134,0.18134 -0.18134,0.58667 v 0.30934 q 0,0.18133 -0.18133,0.18133 h -0.68267 q -0.18133,0 -0.18133,-0.18133 v -0.33067 q 0,-0.77867 0.43733,-1.20534 0.43734,-0.42667 1.22667,-0.42667 h 0.92801 q 0.78933,0 1.22667,0.42667 0.43733,0.42667 0.43733,1.20534 v 0.58667 q 0,0.93867 -0.85334,1.19467 0.85334,0.20266 0.85334,1.19467 v 0.61867 q 0,0.77867 -0.43733,1.20533 -0.43734,0.42667 -1.22667,0.42667 h -0.92801 q -0.78933,0 -1.22667,-0.42667 -0.43733,-0.42666 -0.43733,-1.20533 v -0.37334 q 0,-0.192 0.18133,-0.192 h 0.68267 q 0.18133,0 0.18133,0.192 v 0.352 q 0,0.39467 0.18134,0.58667 0.192,0.18134 0.58667,0.18134 h 0.62933 q 0.78934,0 0.78934,-0.76801 v -0.58667 q 0,-0.77866 -0.78934,-0.77866 h -0.58667 q -0.18133,0 -0.18133,-0.18134 v -0.48 q 0,-0.192 0.18133,-0.192 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39349" />
+    </g>
+    <g
+       aria-label="MOD 4"
+       id="text6809-9-0"
+       style="font-weight:bold;font-size:10.6667px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue Bold';text-align:center;letter-spacing:0.66px;text-anchor:middle;stroke-width:2.83465">
+      <path
+         d="m 207.76334,328.75053 h 1.19467 q 0.18133,0 0.18133,0.18134 v 6.49602 q 0,0.18133 -0.18133,0.18133 h -0.66134 q -0.18133,0 -0.18133,-0.18133 v -5.38669 h -0.0427 l -1.38667,3.90402 q -0.064,0.17066 -0.23467,0.17066 h -0.68267 q -0.16,0 -0.224,-0.17066 l -1.41867,-3.91468 h -0.0427 v 5.39735 q 0,0.10667 -0.0427,0.14933 -0.032,0.032 -0.13867,0.032 h -0.65067 q -0.18133,0 -0.18133,-0.18133 v -6.49602 q 0,-0.18134 0.18133,-0.18134 h 1.19467 q 0.11734,0 0.17067,0.11734 l 1.46134,4.11734 h 0.0533 l 1.47201,-4.11734 q 0.0213,-0.11734 0.16,-0.11734 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39334" />
+      <path
+         d="m 213.05267,334.70255 h 0.928 q 0.77867,0 0.77867,-0.78933 v -3.46668 q 0,-0.78934 -0.77867,-0.78934 h -0.928 q -0.76801,0 -0.76801,0.78934 v 3.46668 q 0,0.78933 0.76801,0.78933 z m 1.088,0.90667 h -1.23734 q -0.78933,0 -1.22667,-0.43733 -0.42667,-0.43734 -0.42667,-1.21601 v -3.55201 q 0,-0.78933 0.42667,-1.216 0.43734,-0.43734 1.22667,-0.43734 h 1.23734 q 0.78934,0 1.22667,0.43734 0.43734,0.42667 0.43734,1.216 v 3.55201 q 0,0.77867 -0.43734,1.21601 -0.43733,0.43733 -1.22667,0.43733 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39336" />
+      <path
+         d="m 219.05666,334.70255 h 1.50401 q 0.768,0 0.768,-0.78933 v -3.46668 q 0,-0.78934 -0.768,-0.78934 h -1.50401 q -0.11733,0 -0.11733,0.10667 v 4.82135 q 0,0.11733 0.11733,0.11733 z m -1.152,0.72534 v -6.49602 q 0,-0.18134 0.18133,-0.18134 H 220.71 q 0.77867,0 1.21601,0.43734 0.448,0.42667 0.448,1.216 v 3.55201 q 0,0.77867 -0.448,1.21601 -0.43734,0.43733 -1.21601,0.43733 h -2.62401 q -0.18133,0 -0.18133,-0.18133 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39338" />
+      <path
+         d="m 230.43533,333.39055 v -3.77601 l -2.10134,3.77601 z m 0.81067,2.21867 h -0.62933 q -0.18134,0 -0.18134,-0.18133 v -1.12001 h -2.816 q -0.30934,0 -0.30934,-0.30933 v -0.33067 q 0,-0.23466 0.096,-0.416 l 2.37868,-4.23468 q 0.0853,-0.16 0.16,-0.21333 0.0747,-0.0533 0.224,-0.0533 h 0.93867 q 0.30933,0 0.30933,0.30934 v 4.33068 h 0.77867 q 0.18133,0 0.18133,0.18133 v 0.53334 q 0,0.20266 -0.18133,0.20266 h -0.77867 v 1.12001 q 0,0.18133 -0.17067,0.18133 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39340" />
+    </g>
+    <g
+       aria-label="STRG"
+       id="text6809-9-0-9"
+       style="font-weight:bold;font-size:10.6667px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue Bold';text-align:center;letter-spacing:0.66px;text-anchor:middle;stroke-width:2.83465">
+      <path
+         d="m 129.97237,403.87988 v -0.27734 q 0,-0.18133 0.18133,-0.18133 h 0.68267 q 0.18133,0 0.18133,0.18133 v 0.19201 q 0,0.448 0.192,0.65066 0.20267,0.192 0.66134,0.192 h 0.736 q 0.45867,0 0.66134,-0.20266 0.20266,-0.21334 0.20266,-0.68267 v -0.24534 q 0,-0.34133 -0.26666,-0.53333 -0.256,-0.20267 -0.64001,-0.256 -0.384,-0.064 -0.84267,-0.17067 -0.45866,-0.10667 -0.84266,-0.24533 -0.38401,-0.13867 -0.65067,-0.52267 -0.256,-0.384 -0.256,-0.98134 v -0.448 q 0,-0.77867 0.43733,-1.216 0.448,-0.448 1.22667,-0.448 h 1.13067 q 0.78934,0 1.22667,0.448 0.448,0.43733 0.448,1.216 v 0.23467 q 0,0.18133 -0.18133,0.18133 h -0.68267 q -0.18133,0 -0.18133,-0.18133 v -0.13867 q 0,-0.45867 -0.20267,-0.65067 -0.192,-0.20266 -0.65067,-0.20266 h -0.672 q -0.45867,0 -0.66134,0.21333 -0.192,0.20267 -0.192,0.704 v 0.33067 q 0,0.48 0.69334,0.65067 0.30933,0.0747 0.672,0.128 0.37333,0.0533 0.74667,0.16 0.37333,0.10667 0.68267,0.288 0.30933,0.17067 0.50133,0.53333 0.192,0.35201 0.192,0.86401 v 0.416 q 0,0.77867 -0.448,1.22667 -0.43733,0.43733 -1.216,0.43733 h -1.19467 q -0.77867,0 -1.22667,-0.43733 -0.448,-0.448 -0.448,-1.22667 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39325" />
+      <path
+         d="m 138.48304,405.54388 h -0.672 q -0.192,0 -0.192,-0.18133 v -5.66402 q 0,-0.10666 -0.10667,-0.10666 h -1.344 q -0.192,0 -0.192,-0.18134 v -0.544 q 0,-0.18133 0.192,-0.18133 h 3.95734 q 0.192,0 0.192,0.18133 v 0.544 q 0,0.18134 -0.192,0.18134 h -1.344 q -0.11734,0 -0.11734,0.10666 v 5.66402 q 0,0.18133 -0.18133,0.18133 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39327" />
+      <path
+         d="m 142.74836,405.54388 h -0.672 q -0.18133,0 -0.18133,-0.18133 v -6.49602 q 0,-0.18133 0.18133,-0.18133 h 2.49601 q 0.77867,0 1.216,0.448 0.44801,0.43733 0.44801,1.216 v 0.896 q 0,1.22667 -1.01334,1.54668 v 0.0427 l 1.184,2.49601 q 0.11734,0.21333 -0.13866,0.21333 h -0.66134 q -0.256,0 -0.33067,-0.18133 l -1.14133,-2.45334 h -1.07734 q -0.128,0 -0.128,0.10667 v 2.34667 q 0,0.18133 -0.18134,0.18133 z m 0.29867,-3.48801 h 1.35467 q 0.78934,0 0.78934,-0.77867 v -0.896 q 0,-0.78933 -0.78934,-0.78933 h -1.35467 q -0.11733,0 -0.11733,0.10666 v 2.25068 q 0,0.10666 0.11733,0.10666 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39329" />
+      <path
+         d="m 151.02439,405.54388 h -1.14134 q -0.78933,0 -1.22667,-0.43733 -0.42667,-0.43734 -0.42667,-1.216 v -3.55202 q 0,-0.78933 0.42667,-1.216 0.43734,-0.43733 1.22667,-0.43733 h 1.14134 q 0.78933,0 1.216,0.43733 0.43734,0.42667 0.43734,1.216 v 0.38401 q 0,0.192 -0.18134,0.192 h -0.672 q -0.18133,0 -0.18133,-0.192 v -0.34134 q 0,-0.78933 -0.76801,-0.78933 h -0.84266 q -0.76801,0 -0.76801,0.78933 v 3.46668 q 0,0.78933 0.76801,0.78933 h 0.84266 q 0.76801,0 0.76801,-0.78933 v -0.96 q 0,-0.10667 -0.11734,-0.10667 h -0.864 q -0.18133,0 -0.18133,-0.18134 v -0.544 q 0,-0.18133 0.18133,-0.18133 h 1.79201 q 0.224,0 0.224,0.224 v 1.79201 q 0,0.77866 -0.43734,1.216 -0.43733,0.43733 -1.216,0.43733 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39331" />
+    </g>
+    <g
+       aria-label="FN"
+       id="text6809-9-0-9-5"
+       style="font-weight:bold;font-size:10.6667px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue Bold';text-align:center;letter-spacing:0.66px;text-anchor:middle;stroke-width:2.83465">
+      <path
+         d="m 213.49465,405.54388 h -0.672 q -0.18134,0 -0.18134,-0.18133 v -6.49602 q 0,-0.18133 0.18134,-0.18133 h 3.34934 q 0.18134,0 0.18134,0.18133 v 0.544 q 0,0.18134 -0.18134,0.18134 h -2.36801 q -0.128,0 -0.128,0.10666 v 2.01601 q 0,0.11733 0.128,0.11733 h 2.05868 q 0.192,0 0.192,0.18134 v 0.53333 q 0,0.192 -0.192,0.192 h -2.05868 q -0.128,0 -0.128,0.10667 v 2.51734 q 0,0.18133 -0.18133,0.18133 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39320" />
+      <path
+         d="m 218.98665,405.54388 h -0.66134 q -0.18133,0 -0.18133,-0.18133 v -6.49602 q 0,-0.18133 0.18133,-0.18133 h 0.59734 q 0.17067,0 0.23467,0.11733 l 2.58134,4.64001 h 0.0427 v -4.57601 q 0,-0.18133 0.18133,-0.18133 h 0.66133 q 0.18134,0 0.18134,0.18133 v 6.49602 q 0,0.18133 -0.18134,0.18133 h -0.576 q -0.17066,0 -0.27733,-0.17066 l -2.56001,-4.58668 h -0.0427 v 4.57601 q 0,0.18133 -0.18133,0.18133 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39322" />
+    </g>
+    <g
+       aria-label="ALT"
+       id="text6809-9-0-9-5-2"
+       style="font-weight:bold;font-size:10.6667px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue Bold';text-align:center;letter-spacing:0.66px;text-anchor:middle;stroke-width:2.83465">
+      <path
+         d="m 354.18606,405.54388 h -0.768 q -0.14934,0 -0.10667,-0.18133 l 1.85601,-6.49602 q 0.0533,-0.18133 0.256,-0.18133 h 1.06667 q 0.21333,0 0.256,0.18133 l 1.85601,6.49602 q 0.0427,0.18133 -0.11734,0.18133 h -0.75733 q -0.096,0 -0.13867,-0.032 -0.032,-0.0427 -0.0533,-0.14933 l -0.40534,-1.38667 h -2.34667 l -0.40534,1.38667 q -0.0427,0.18133 -0.192,0.18133 z m 1.74934,-5.83468 -0.93867,3.41334 h 1.93067 l -0.94933,-3.41334 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39313" />
+      <path
+         d="m 363.95541,405.54388 h -3.45601 q -0.18134,0 -0.18134,-0.18133 v -6.49602 q 0,-0.18133 0.18134,-0.18133 h 0.672 q 0.18133,0 0.18133,0.18133 v 5.64268 q 0,0.10667 0.128,0.10667 h 2.47468 q 0.18133,0 0.18133,0.192 v 0.55467 q 0,0.18133 -0.18133,0.18133 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39315" />
+      <path
+         d="m 367.6554,405.54388 h -0.672 q -0.192,0 -0.192,-0.18133 v -5.66402 q 0,-0.10666 -0.10667,-0.10666 h -1.344 q -0.192,0 -0.192,-0.18134 v -0.544 q 0,-0.18133 0.192,-0.18133 h 3.95735 q 0.192,0 0.192,0.18133 v 0.544 q 0,0.18134 -0.192,0.18134 h -1.34401 q -0.11733,0 -0.11733,0.10666 v 5.66402 q 0,0.18133 -0.18134,0.18133 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39317" />
+    </g>
+    <g
+       aria-label="MOD 3"
+       id="text6809-9-5"
+       style="font-weight:bold;font-size:10.6667px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue Bold';letter-spacing:0.66px;stroke-width:2.83465">
+      <path
+         d="m 1033.978,258.85188 h 1.1947 q 0.1813,0 0.1813,0.18134 v 6.49602 q 0,0.18133 -0.1813,0.18133 h -0.6614 q -0.1813,0 -0.1813,-0.18133 v -5.38669 h -0.043 l -1.3866,3.90402 q -0.064,0.17066 -0.2347,0.17066 h -0.6827 q -0.16,0 -0.224,-0.17066 l -1.4186,-3.91468 h -0.043 v 5.39735 q 0,0.10666 -0.043,0.14933 -0.032,0.032 -0.1386,0.032 h -0.6507 q -0.1813,0 -0.1813,-0.18133 v -6.49602 q 0,-0.18134 0.1813,-0.18134 h 1.1947 q 0.1173,0 0.1706,0.11734 l 1.4614,4.11734 h 0.053 l 1.472,-4.11734 q 0.021,-0.11734 0.16,-0.11734 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39304" />
+      <path
+         d="m 1039.2673,264.8039 h 0.928 q 0.7787,0 0.7787,-0.78933 v -3.46668 q 0,-0.78934 -0.7787,-0.78934 h -0.928 q -0.768,0 -0.768,0.78934 v 3.46668 q 0,0.78933 0.768,0.78933 z m 1.088,0.90667 h -1.2373 q -0.7893,0 -1.2267,-0.43733 -0.4266,-0.43734 -0.4266,-1.21601 v -3.55201 q 0,-0.78933 0.4266,-1.216 0.4374,-0.43734 1.2267,-0.43734 h 1.2373 q 0.7894,0 1.2267,0.43734 0.4373,0.42667 0.4373,1.216 v 3.55201 q 0,0.77867 -0.4373,1.21601 -0.4373,0.43733 -1.2267,0.43733 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39306" />
+      <path
+         d="m 1045.2713,264.8039 h 1.504 q 0.768,0 0.768,-0.78933 v -3.46668 q 0,-0.78934 -0.768,-0.78934 h -1.504 q -0.1173,0 -0.1173,0.10667 v 4.82135 q 0,0.11733 0.1173,0.11733 z m -1.152,0.72534 v -6.49602 q 0,-0.18134 0.1814,-0.18134 h 2.624 q 0.7786,0 1.216,0.43734 0.448,0.42667 0.448,1.216 v 3.55201 q 0,0.77867 -0.448,1.21601 -0.4374,0.43733 -1.216,0.43733 h -2.624 q -0.1814,0 -0.1814,-0.18133 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39308" />
+      <path
+         d="m 1055.4767,261.83856 h 0.5866 q 0.7894,0 0.7894,-0.77867 v -0.55467 q 0,-0.768 -0.7894,-0.768 h -0.6293 q -0.3947,0 -0.5867,0.18133 -0.1813,0.18134 -0.1813,0.58667 v 0.30934 q 0,0.18133 -0.1813,0.18133 h -0.6827 q -0.1813,0 -0.1813,-0.18133 v -0.33067 q 0,-0.77867 0.4373,-1.20534 0.4373,-0.42667 1.2267,-0.42667 h 0.928 q 0.7893,0 1.2266,0.42667 0.4374,0.42667 0.4374,1.20534 v 0.58667 q 0,0.93867 -0.8534,1.19467 0.8534,0.20266 0.8534,1.19467 v 0.61867 q 0,0.77867 -0.4374,1.20533 -0.4373,0.42667 -1.2266,0.42667 h -0.928 q -0.7894,0 -1.2267,-0.42667 -0.4373,-0.42666 -0.4373,-1.20533 v -0.37334 q 0,-0.192 0.1813,-0.192 h 0.6827 q 0.1813,0 0.1813,0.192 v 0.352 q 0,0.39467 0.1813,0.58667 0.192,0.18134 0.5867,0.18134 h 0.6293 q 0.7894,0 0.7894,-0.76801 v -0.58667 q 0,-0.77866 -0.7894,-0.77866 h -0.5866 q -0.1814,0 -0.1814,-0.18134 v -0.48 q 0,-0.192 0.1814,-0.192 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39310" />
+    </g>
+    <g
+       aria-label="ˇ"
+       id="text17107"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';text-align:center;text-anchor:middle;stroke-width:2.83465">
+      <path
+         d="m 122.43896,140.9208 q -0.22533,0 -0.34666,-0.17333 l -1.092,-1.85466 q -0.12133,-0.208 0.0867,-0.208 h 0.58933 q 0.17333,0 0.24267,0.13866 l 0.81466,1.52533 0.81467,-1.52533 q 0.0693,-0.13866 0.24266,-0.13866 h 0.60667 q 0.208,0 0.0867,0.208 l -1.09199,1.85466 q -0.12134,0.17333 -0.364,0.17333 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium'"
+         id="path39301" />
+    </g>
+    <g
+       aria-label="↻"
+       id="text17107-3"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';text-align:end;text-anchor:end;stroke-width:2.83465">
+      <path
+         d="m 142.88155,140.02734 q 1.40495,1.64193 1.40495,3.81705 0,2.42903 -1.74349,4.16406 -1.73502,1.72656 -4.15559,1.72656 -2.42057,0 -4.15559,-1.73503 -1.73502,-1.74348 -1.73502,-4.15559 0,-2.39517 1.64192,-4.09634 l -1.625,-0.72787 4.0371,-1.07486 -1.07486,4.04556 -0.74479,-1.65039 q -1.40495,1.48112 -1.40495,3.5039 0,2.08203 1.48958,3.57161 1.48958,1.48958 3.57161,1.48958 2.08203,0 3.57161,-1.48958 1.48958,-1.48958 1.48958,-3.57161 0,-1.87044 -1.21029,-3.29231 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium'"
+         id="path39298" />
+    </g>
+    <g
+       aria-label="°"
+       id="text17107-3-8"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 186.95933,141.77028 h -0.832 q -0.84933,0 -0.84933,-0.84933 v -1.68133 q 0,-0.81467 0.84933,-0.81467 h 0.832 q 0.39867,0 0.624,0.22533 0.24267,0.208 0.24267,0.58934 v 1.68133 q 0,0.39866 -0.24267,0.62399 -0.22533,0.22534 -0.624,0.22534 z m -0.29466,-0.58933 q 0.29466,0 0.39866,-0.104 0.104,-0.104 0.104,-0.39867 v -1.12666 q 0,-0.312 -0.104,-0.39867 -0.104,-0.104 -0.39866,-0.104 h -0.22534 q -0.312,0 -0.416,0.104 -0.0867,0.0867 -0.0867,0.39867 v 1.12666 q 0,0.29467 0.0867,0.39867 0.104,0.104 0.416,0.104 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium'"
+         id="path39295" />
+    </g>
+    <g
+       aria-label="1"
+       id="text17107-3-8-5"
+       style="font-weight:600;font-size:10px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 212.71335,139.94359 v -0.4 q 0,-0.15 0.12,-0.22 l 1.16,-0.67 q 0.16,-0.09 0.26,-0.09 h 0.42 q 0.14,0 0.14,0.14 v 6.15 q 0,0.14 -0.14,0.14 h -0.45 q -0.14,0 -0.14,-0.14 v -5.51 l -1.19,0.68 q -0.18,0.1 -0.18,-0.08 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium'"
+         id="path39292" />
+    </g>
+    <g
+       aria-label="§"
+       id="text17107-3-8-2"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 261.35731,145.3316 q 0,-0.52 -0.27733,-0.78 -0.27733,-0.27733 -0.84933,-0.39867 l -1.38666,-0.26 q -0.69334,-0.17333 -1.092,-0.468 v 1.144 q 0,1.00533 1.10933,1.248 l 1.38666,0.26 q 0.728,0.13867 1.10933,0.416 z m -1.35199,5.23465 h -3.016 q -0.24266,0 -0.24266,-0.24266 v -0.64133 q 0,-0.22534 0.24266,-0.22534 h 2.94666 q 0.78,0 1.05733,-0.32933 0.27734,-0.32933 0.27734,-0.86667 0,-0.55466 -0.29467,-0.79733 -0.29466,-0.24266 -0.95333,-0.38133 l -1.73333,-0.32933 q -1.716,-0.34667 -1.716,-2.11466 v -2.99867 q 0,-1.00533 0.572,-1.61199 0.58933,-0.60667 1.83733,-0.60667 h 2.82533 q 0.24267,0 0.24267,0.24267 v 0.64133 q 0,0.22533 -0.24267,0.22533 h -2.79066 q -1.17867,0 -1.17867,1.16133 0,0.50267 0.26,0.78 0.26,0.26 0.97067,0.39867 l 1.73333,0.32933 q 1.73333,0.34667 1.73333,2.06266 v 2.964 q 0,2.33999 -2.53066,2.33999 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium'"
+         id="path39289" />
+    </g>
+    <g
+       aria-label="»"
+       id="text17107-3-8-2-2"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 402.83131,143.44254 v -0.572 q 0,-0.13867 0.0693,-0.17333 0.0867,-0.052 0.19067,0.052 l 2.44399,2.21866 q 0.24267,0.208 0.24267,0.45066 v 0.45067 q 0,0.26 -0.24267,0.468 l -2.44399,2.21866 q -0.104,0.104 -0.19067,0.052 -0.0693,-0.052 -0.0693,-0.19066 v -0.572 q 0,-0.208 0.208,-0.34667 l 1.99333,-1.85466 -1.99333,-1.85467 q -0.208,-0.13866 -0.208,-0.34666 z m -2.6,0 v -0.572 q 0,-0.13867 0.0693,-0.17333 0.0693,-0.052 0.19066,0.052 l 2.42666,2.21866 q 0.24267,0.208 0.24267,0.45066 v 0.45067 q 0,0.27733 -0.24267,0.468 l -2.42666,2.21866 q -0.12133,0.104 -0.19066,0.0693 -0.0693,-0.052 -0.0693,-0.20799 v -0.572 q 0,-0.19067 0.19067,-0.34667 l 1.99333,-1.85466 -1.99333,-1.85467 q -0.19067,-0.156 -0.19067,-0.34666 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium'"
+         id="path39286" />
+    </g>
+    <g
+       aria-label="›"
+       id="text17107-3-8-2-2-8"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 427.25396,143.52028 v -0.64133 q 0,-0.13867 0.0693,-0.17334 0.0693,-0.052 0.19066,0.052 l 2.42666,2.21867 q 0.24267,0.208 0.24267,0.45066 v 0.45067 q 0,0.27733 -0.24267,0.468 l -2.42666,2.21866 q -0.12133,0.104 -0.19066,0.0693 -0.0693,-0.052 -0.0693,-0.208 v -0.624 q 0,-0.19066 0.19067,-0.364 l 1.92399,-1.78533 -1.92399,-1.78532 q -0.19067,-0.156 -0.19067,-0.34667 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39283" />
+    </g>
+    <g
+       aria-label="«"
+       id="text17107-3-8-2-2-1"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 477.61931,147.8452 v 0.572 q 0,0.15599 -0.0867,0.20799 -0.0693,0.0347 -0.19066,-0.0693 l -2.42667,-2.21866 q -0.24266,-0.208 -0.24266,-0.468 v -0.45067 q 0,-0.24266 0.24266,-0.45066 l 2.42667,-2.21866 q 0.12133,-0.104 0.19066,-0.052 0.0867,0.0347 0.0867,0.17333 v 0.572 q 0,0.208 -0.208,0.34666 l -1.99333,1.85467 1.99333,1.85466 q 0.208,0.13867 0.208,0.34667 z m -2.61733,0 v 0.572 q 0,0.15599 -0.0693,0.20799 -0.0693,0.0347 -0.19067,-0.0693 l -2.42666,-2.21866 q -0.24267,-0.19067 -0.24267,-0.468 v -0.45067 q 0,-0.24266 0.24267,-0.45066 l 2.42666,-2.21866 q 0.12133,-0.104 0.19067,-0.052 0.0693,0.0347 0.0693,0.17333 v 0.572 q 0,0.19066 -0.19067,0.34666 l -1.99333,1.85467 1.99333,1.85466 q 0.19067,0.156 0.19067,0.34667 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium'"
+         id="path39280" />
+    </g>
+    <g
+       aria-label="‹"
+       id="text17107-3-8-2-2-8-4"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 502.02463,147.8016 v 0.624 q 0,0.156 -0.0693,0.208 -0.0693,0.0347 -0.19067,-0.0693 l -2.42666,-2.21866 q -0.24267,-0.19067 -0.24267,-0.468 v -0.45067 q 0,-0.24266 0.24267,-0.45066 l 2.42666,-2.21867 q 0.12133,-0.104 0.19067,-0.052 0.0693,0.0347 0.0693,0.17334 v 0.64133 q 0,0.19067 -0.19067,0.34667 l -1.90666,1.78532 1.90666,1.78533 q 0.19067,0.17334 0.19067,0.364 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39277" />
+    </g>
+    <g
+       aria-label="$"
+       id="text17107-3-8-2-2-1-6"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 547.68065,151.78826 h -0.58933 q -0.24266,0 -0.24266,-0.24266 v -1.456 h -0.416 q -1.16133,0 -1.85467,-0.69333 -0.67599,-0.69333 -0.67599,-1.872 v -0.48533 q 0,-0.24267 0.22533,-0.24267 h 0.79733 q 0.22533,0 0.22533,0.24267 v 0.38133 q 0,1.56 1.54267,1.56 h 1.09199 q 1.54267,0 1.54267,-1.59467 v -0.81466 q 0,-0.81467 -0.45067,-1.144 -0.45066,-0.32933 -1.36933,-0.364 l -0.95333,-0.0173 q -1.248,-0.052 -1.95866,-0.60667 -0.71067,-0.55466 -0.71067,-1.99333 v -0.95333 q 0,-1.19599 0.676,-1.87199 0.69333,-0.69334 1.872,-0.69334 h 0.416 v -1.47333 q 0,-0.24266 0.24266,-0.24266 h 0.58933 q 0.24267,0 0.24267,0.24266 v 1.47333 h 0.12133 q 1.12667,0 1.80267,0.69334 0.676,0.69333 0.676,1.87199 v 0.43334 q 0,0.25999 -0.24267,0.25999 h -0.78 q -0.24266,0 -0.24266,-0.25999 v -0.32934 q 0,-1.55999 -1.54267,-1.55999 h -1.02266 q -1.54267,0 -1.54267,1.62933 v 0.81466 q 0,0.78 0.43334,1.092 0.45066,0.29467 1.36933,0.32933 l 1.07466,0.0347 q 1.17867,0.052 1.872,0.624 0.69333,0.572 0.69333,1.95866 v 1.00533 q 0,1.196 -0.69333,1.88933 -0.676,0.676 -1.85467,0.676 h -0.12133 v 1.456 q 0,0.24266 -0.24267,0.24266 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium'"
+         id="path39274" />
+    </g>
+    <g
+       aria-label="¢"
+       id="text17107-3-8-2-2-8-4-1"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 572.32867,151.67534 h -0.624 q -0.22533,0 -0.22533,-0.24267 v -1.33466 h -0.45067 q -1.14399,0 -1.80266,-0.69333 -0.65866,-0.69334 -0.65866,-1.872 v -3.70933 q 0,-1.17866 0.65866,-1.87199 0.65867,-0.69334 1.80266,-0.69334 h 0.45067 v -1.50799 q 0,-0.24267 0.22533,-0.24267 h 0.624 q 0.22534,0 0.22534,0.22533 v 1.52533 h 1.23066 q 0.38133,0 0.38133,0.24267 v 0.64133 q 0,0.22534 -0.26,0.22534 h -2.63466 q -1.43866,0 -1.43866,1.50799 v 3.60533 q 0,1.508 1.43866,1.508 h 2.63466 q 0.26,0 0.26,0.22533 v 0.64133 q 0,0.24267 -0.26,0.24267 h -1.35199 V 151.45 q 0,0.22534 -0.22534,0.22534 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39271" />
+    </g>
+    <g
+       aria-label="€"
+       id="text17107-3-8-2-2-1-6-6"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 620.12594,150.0896 h -1.12666 q -1.196,0 -1.88933,-0.65867 -0.676,-0.67599 -0.676,-1.87199 v -1.47333 h -0.95333 q -0.26,0 -0.26,-0.26 v -0.39867 q 0,-0.26 0.26,-0.26 h 0.95333 v -1.23066 h -0.95333 q -0.26,0 -0.26,-0.26 v -0.39867 q 0,-0.26 0.26,-0.26 h 0.95333 v -1.54266 q 0,-1.196 0.676,-1.85466 0.69333,-0.676 1.88933,-0.676 h 1.12666 q 1.196,0 1.872,0.676 0.69333,0.65866 0.69333,1.85466 v 0.43333 q 0,0.24267 -0.24266,0.24267 h -0.78 q -0.24267,0 -0.24267,-0.24267 v -0.416 q 0,-1.47333 -1.456,-1.47333 h -0.81466 q -1.47333,0 -1.47333,1.47333 v 1.52533 h 2.40933 q 0.26,0 0.26,0.26 v 0.39867 q 0,0.26 -0.26,0.26 h -2.40933 v 1.23066 h 2.40933 q 0.26,0 0.26,0.26 v 0.39867 q 0,0.26 -0.26,0.26 h -2.40933 v 1.45599 q 0,1.47334 1.47333,1.47334 h 0.81466 q 1.456,0 1.456,-1.47334 v -0.41599 q 0,-0.24267 0.24267,-0.24267 h 0.78 q 0.24266,0 0.24266,0.24267 v 0.43333 q 0,1.196 -0.69333,1.87199 -0.676,0.65867 -1.872,0.65867 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium'"
+         id="path39268" />
+    </g>
+    <g
+       aria-label="¥"
+       id="text17107-3-8-2-2-8-4-1-3"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 642.58996,150.09801 h -0.78 q -0.24267,0 -0.24267,-0.24267 v -2.61733 h -2.85999 q -0.26,0 -0.26,-0.26 v -0.39866 q 0,-0.26 0.26,-0.26 h 2.82533 v -0.468 l -0.53734,-1.12667 h -2.28799 q -0.26,0 -0.26,-0.24266 v -0.416 q 0,-0.26 0.26,-0.26 h 1.83733 l -2.288,-4.61066 q -0.104,-0.24266 0.13867,-0.24266 h 1.02266 q 0.156,0 0.26,0.24266 l 2.47867,5.35599 h 0.0693 l 2.49599,-5.35599 q 0.104,-0.24266 0.27734,-0.24266 h 1.00533 q 0.26,0 0.13866,0.24266 l -2.27066,4.61066 h 1.82 q 0.26,0 0.26,0.26 v 0.416 q 0,0.24266 -0.26,0.24266 h -2.27066 l -0.55467,1.12667 v 0.468 h 2.82533 q 0.26,0 0.26,0.26 v 0.39866 q 0,0.26 -0.26,0.26 h -2.86 v 2.61733 q 0,0.24267 -0.24266,0.24267 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39265" />
+    </g>
+    <g
+       aria-label="…"
+       id="text17107-3-8-2-2-8-4-1-3-0"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 243.74602,217.70694 v 2.09733 q 0,0.24267 -0.22533,0.24267 h -0.884 q -0.22534,0 -0.22534,-0.26 v -2.08 q 0,-0.22533 0.22534,-0.22533 h 0.884 q 0.22533,0 0.22533,0.22533 z m 3.50132,0 v 2.09733 q 0,0.24267 -0.22533,0.24267 h -0.884 q -0.22533,0 -0.22533,-0.26 v -2.08 q 0,-0.22533 0.22533,-0.22533 h 0.884 q 0.22533,0 0.22533,0.22533 z m 3.44933,0 v 2.09733 q 0,0.24267 -0.22533,0.24267 h -0.884 q -0.22533,0 -0.22533,-0.26 v -2.08 q 0,-0.22533 0.22533,-0.22533 h 0.884 q 0.22533,0 0.22533,0.22533 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39262" />
+    </g>
+    <g
+       aria-label="„"
+       id="text17107-3-8-2-2-1-6-63"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 688.77402,148.04427 v 1.00533 q 0,0.34667 -0.26,1.12667 l -0.572,1.64666 q -0.0693,0.12133 -0.22533,0.12133 -0.156,0 -0.156,-0.208 v -3.67466 q 0,-0.24266 0.22533,-0.24266 h 0.74533 q 0.24267,0 0.24267,0.22533 z m 2.652,0 v 1.00533 q 0,0.39867 -0.24267,1.12667 l -0.58933,1.64666 q -0.052,0.12133 -0.19067,0.12133 -0.19067,0 -0.19067,-0.208 v -3.67466 q 0,-0.24266 0.24267,-0.24266 h 0.74533 q 0.22534,0 0.22534,0.22533 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium'"
+         id="path39259" />
+    </g>
+    <g
+       aria-label="‚"
+       id="text17107-3-8-2-2-8-4-1-4"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 717.53004,148.05268 v 0.988 q 0,0.364 -0.26,1.14399 l -0.572,1.62933 q -0.0867,0.13867 -0.208,0.13867 -0.17333,0 -0.17333,-0.208 v -3.69199 q 0,-0.22534 0.22533,-0.22534 h 0.74533 q 0.24267,0 0.24267,0.22534 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39256" />
+    </g>
+    <g
+       aria-label="“"
+       id="text17107-3-8-2-2-1-6-7"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 761.87132,142.84428 v -0.988 q 0,-0.45066 0.26,-1.144 l 0.572,-1.62933 q 0.052,-0.13866 0.19066,-0.13866 0.19067,0 0.19067,0.208 v 3.69199 q 0,0.22533 -0.22534,0.22533 h -0.76266 q -0.22533,0 -0.22533,-0.22533 z m -2.66933,0 v -0.988 q 0,-0.364 0.26,-1.144 l 0.572,-1.62933 q 0.0867,-0.13866 0.208,-0.13866 0.17333,0 0.17333,0.208 v 3.69199 q 0,0.22533 -0.22533,0.22533 h -0.74534 q -0.24266,0 -0.24266,-0.22533 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium'"
+         id="path39253" />
+    </g>
+    <g
+       aria-label="‘"
+       id="text17107-3-8-2-2-8-4-1-0"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 788.06198,142.85269 v -0.988 q 0,-0.364 0.26,-1.144 l 0.572,-1.62933 q 0.0867,-0.13866 0.208,-0.13866 0.17333,0 0.17333,0.208 v 3.69199 q 0,0.22533 -0.22533,0.22533 h -0.74533 q -0.24267,0 -0.24267,-0.22533 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39250" />
+    </g>
+    <g
+       aria-label="ℓ"
+       id="text17107-3-8-2-9"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 327.90628,146.50958 1.49804,-1.98892 v -3.85091 q 0,-1.91275 0.51628,-2.55598 0.52474,-0.65169 1.46419,-0.65169 0.8125,0 1.33724,0.55013 0.52473,0.55012 0.52473,1.47265 0,0.77864 -0.50781,1.90429 -0.50781,1.11719 -1.90429,3.0638 v 3.51236 q 0,0.75325 0.11849,0.93945 0.12695,0.17774 0.35547,0.17774 0.22005,0 0.50781,-0.13542 0.28776,-0.14388 1.17643,-0.77018 v 1.37109 q -0.46549,0.3724 -0.94792,0.55013 -0.47395,0.1862 -0.95637,0.1862 -0.77865,0 -1.23568,-0.48242 -0.44857,-0.48243 -0.44857,-1.55729 v -1.9043 l -0.66861,0.82943 z m 2.92838,-4.0371 q 0.82943,-1.43033 1.02409,-1.972 0.20312,-0.54166 0.20312,-1.00716 0,-0.2539 -0.0592,-0.45703 -0.0508,-0.20312 -0.16081,-0.347 -0.0846,-0.10157 -0.19466,-0.15235 -0.10156,-0.0592 -0.22852,-0.0592 -0.12695,0 -0.23698,0.0508 -0.10156,0.0508 -0.15234,0.16927 -0.0931,0.17773 -0.14388,0.64323 -0.0508,0.46549 -0.0508,1.21028 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium'"
+         id="path39247" />
+    </g>
+    <g
+       aria-label="”"
+       id="text17107-3-8-2-2-1-6-5"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 832.25529,139.16962 v 1.00533 q 0,0.39867 -0.24267,1.12667 l -0.58933,1.64666 q -0.052,0.12133 -0.19067,0.12133 -0.19067,0 -0.19067,-0.208 v -3.67466 q 0,-0.24266 0.24267,-0.24266 h 0.74533 q 0.22534,0 0.22534,0.22533 z m 2.66932,0 v 1.00533 q 0,0.43333 -0.26,1.12667 l -0.57199,1.64666 q -0.052,0.12133 -0.22534,0.12133 -0.156,0 -0.156,-0.208 v -3.67466 q 0,-0.24266 0.22534,-0.24266 h 0.76266 q 0.22533,0 0.22533,0.22533 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium'"
+         id="path39244" />
+    </g>
+    <g
+       aria-label="’"
+       id="text17107-3-8-2-2-8-4-1-1"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 861.11528,139.17803 v 1.00533 q 0,0.39867 -0.24267,1.12666 l -0.58933,1.64667 q -0.052,0.12133 -0.19067,0.12133 -0.19066,0 -0.19066,-0.208 v -3.67466 q 0,-0.24266 0.24266,-0.24266 h 0.74533 q 0.22534,0 0.22534,0.22533 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39241" />
+    </g>
+    <g
+       aria-label="—"
+       id="text17107-3-8-2-2-1-6-60"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 902.62064,144.71628 v -0.45067 q 0,-0.24267 0.24267,-0.24267 h 7.92131 q 0.24267,0 0.24267,0.24267 v 0.45067 q 0,0.24266 -0.24267,0.24266 h -7.92131 q -0.24267,0 -0.24267,-0.24266 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium'"
+         id="path39238" />
+    </g>
+    <g
+       aria-label="¸"
+       id="text17107-3-8-2-2-1-6-0"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 975.76731,150.90426 q 1.31733,0 1.31733,1.10934 v 0.24266 q 0,1.092 -1.47333,1.092 h -0.53733 q -0.22533,0 -0.22533,-0.22533 v -0.24267 q 0,-0.22533 0.22533,-0.22533 h 0.416 q 0.48533,0 0.676,-0.12134 0.19067,-0.10399 0.19067,-0.38133 v -0.0347 q 0,-0.312 -0.19067,-0.43334 -0.17333,-0.104 -0.676,-0.104 h -0.27733 q -0.312,0 -0.416,-0.26 -0.104,-0.26 0.104,-0.50266 l 0.95333,-1.07467 h 0.936 l -1.02267,1.092 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium'"
+         id="path39235" />
+    </g>
+    <g
+       aria-label="˚"
+       id="text17107-3-8-2-2-8-4-1-48"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 1002.1313,138.67536 v 0.624 q 0,0.38133 0.156,0.52 0.156,0.13867 0.5373,0.13867 h 0.2427 q 0.3813,0 0.5373,-0.13867 0.1733,-0.13867 0.1733,-0.52 v -0.624 q 0,-0.38133 -0.156,-0.52 -0.156,-0.13866 -0.5373,-0.13866 h -0.26 q -0.3813,0 -0.5373,0.13866 -0.156,0.13867 -0.156,0.52 z m -0.572,0.76267 v -0.936 q 0,-1.00533 1.092,-1.00533 h 0.5893 q 1.1093,0 1.1093,1.00533 v 0.936 q 0,1.02266 -1.1093,1.02266 h -0.5893 q -1.092,0 -1.092,-1.02266 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39232" />
+    </g>
+    <g
+       aria-label="_"
+       id="text17107-3-8-2-2-8-4-1-3-0-1"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 323.31663,221.83227 h -5.96265 q -0.24267,0 -0.24267,-0.24267 v -0.312 q 0,-0.24267 0.24267,-0.24267 h 5.96265 q 0.24267,0 0.24267,0.24267 v 0.312 q 0,0.24267 -0.24267,0.24267 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39229" />
+    </g>
+    <g
+       aria-label="["
+       id="text17107-3-8-2-2-8-4-1-3-0-0"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 393.93266,221.78027 h -2.35733 q -0.24267,0 -0.24267,-0.24267 v -12.39331 q 0,-0.24267 0.24267,-0.24267 h 2.35733 q 0.24267,0 0.24267,0.24267 v 0.43333 q 0,0.24267 -0.24267,0.24267 h -1.352 q -0.17333,0 -0.17333,0.17333 v 10.69465 q 0,0.17333 0.17333,0.17333 h 1.352 q 0.24267,0 0.24267,0.24267 v 0.45066 q 0,0.22534 -0.24267,0.22534 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39226" />
+    </g>
+    <g
+       aria-label="]"
+       id="text17107-3-8-2-2-8-4-1-3-0-14"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 463.04202,221.54559 v -0.45066 q 0,-0.24267 0.24267,-0.24267 h 1.35199 q 0.17334,0 0.17334,-0.17333 v -10.69465 q 0,-0.17333 -0.17334,-0.17333 h -1.35199 q -0.24267,0 -0.24267,-0.24267 v -0.43333 q 0,-0.24266 0.24267,-0.24266 h 2.35732 q 0.22534,0 0.22534,0.24266 v 12.39331 q 0,0.24267 -0.22534,0.24267 h -2.35732 q -0.24267,0 -0.24267,-0.22534 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39223" />
+    </g>
+    <g
+       aria-label="^"
+       id="text17107-3-8-2-2-8-4-1-3-0-06"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 532.50737,213.72828 h -0.69333 q -0.32934,0 -0.17334,-0.27734 l 2.21867,-4.21199 q 0.15599,-0.34666 0.51999,-0.34666 h 0.90134 q 0.36399,0 0.51999,0.34666 l 2.21867,4.21199 q 0.156,0.27734 -0.17334,0.27734 h -0.69333 q -0.208,0 -0.34666,-0.24267 l -1.976,-3.79599 -1.976,3.79599 q -0.13866,0.24267 -0.34666,0.24267 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39220" />
+    </g>
+    <g
+       aria-label="!"
+       id="text17107-3-8-2-2-8-4-1-3-0-5"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 607.99401,211.14561 v -2.01066 q 0,-0.24266 0.24267,-0.24266 h 0.91866 q 0.24267,0 0.24267,0.24266 v 2.01066 q 0,1.64667 -0.104,3.20667 -0.104,1.55999 -0.13867,1.76799 -0.0347,0.208 -0.22533,0.208 h -0.468 q -0.22533,0 -0.24266,-0.26 -0.0693,-0.676 -0.156,-2.37466 -0.0693,-1.69866 -0.0693,-2.548 z m 1.36933,6.55199 v 2.09733 q 0,0.24267 -0.24266,0.24267 h -0.832 q -0.22533,0 -0.22533,-0.26 v -2.08 q 0,-0.22533 0.22533,-0.22533 h 0.832 q 0.24266,0 0.24266,0.22533 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39217" />
+    </g>
+    <g
+       aria-label="&lt;"
+       id="text17107-3-8-2-2-8-4-1-3-0-00"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 681.44463,211.61361 v 0.624 q 0,0.26 -0.22534,0.32934 l -5.56398,1.85466 5.56398,1.87199 q 0.22534,0.0347 0.22534,0.312 v 0.64134 q 0,0.27733 -0.29467,0.17333 l -6.27465,-2.27066 q -0.29467,-0.12134 -0.29467,-0.416 v -0.60667 q 0,-0.312 0.29467,-0.416 l 6.27465,-2.27066 q 0.29467,-0.104 0.29467,0.17333 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39214" />
+    </g>
+    <g
+       aria-label="&gt;"
+       id="text17107-3-8-2-2-8-4-1-3-0-4"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 746.22866,212.23761 v -0.624 q 0,-0.27733 0.29466,-0.17333 l 6.27466,2.27066 q 0.29466,0.104 0.29466,0.416 v 0.60667 q 0,0.29466 -0.29466,0.416 l -6.27466,2.27066 q -0.29466,0.104 -0.29466,-0.17333 v -0.64134 q 0,-0.27733 0.22533,-0.312 l 5.56399,-1.87199 -5.56399,-1.85466 q -0.22533,-0.0693 -0.22533,-0.32934 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39211" />
+    </g>
+    <g
+       aria-label="="
+       id="text17107-3-8-2-2-8-4-1-3-0-44"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 818.32069,212.34161 h 6.32665 q 0.27733,0 0.27733,0.26 v 0.53733 q 0,0.26 -0.27733,0.26 h -6.32665 q -0.26,0 -0.26,-0.26 v -0.53733 q 0,-0.26 0.26,-0.26 z m 0,3.20666 h 6.32665 q 0.27733,0 0.27733,0.26 v 0.52 q 0,0.26 -0.27733,0.26 h -6.32665 q -0.26,0 -0.26,-0.26 v -0.52 q 0,-0.26 0.26,-0.26 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39208" />
+    </g>
+    <g
+       aria-label="&amp;"
+       id="text17107-3-8-2-2-8-4-1-3-0-7"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 891.35667,218.91093 h 1.144 q 1.16133,0 1.33466,-1.03999 l -2.72133,-3.172 q -1.24799,0.0693 -1.24799,1.54267 v 1.21333 q 0,1.45599 1.49066,1.45599 z m 1.144,1.12667 h -1.3 q -1.196,0 -1.872,-0.65867 -0.67599,-0.676 -0.67599,-1.87199 v -1.33467 q 0,-0.86666 0.45066,-1.508 0.45067,-0.65866 1.352,-0.71066 -0.76267,-0.91867 -0.76267,-2.028 v -0.50266 q 0,-1.196 0.71067,-1.85467 0.71066,-0.67599 1.90666,-0.67599 h 0.468 q 1.196,0 1.872,0.67599 0.676,0.65867 0.676,1.85467 v 0.728 q 0,0.26 -0.22534,0.26 h -0.78 q -0.24266,0 -0.24266,-0.26 v -0.71067 q 0,-1.47333 -1.38667,-1.47333 H 892.414 q -1.43866,0 -1.43866,1.47333 v 0.50267 q 0,0.84933 0.76266,1.69866 l 1.00533,1.16133 h 4.056 q 0.26,0 0.26,0.24267 v 0.64133 q 0,0.22533 -0.26,0.22533 h -3.12 l 3.36266,3.93466 q 0.052,0.052 0.0347,0.12133 -0.0173,0.0693 -0.104,0.0693 h -1.00533 q -0.24267,0 -0.39867,-0.17334 l -0.936,-1.09199 q -0.43333,1.26533 -2.13199,1.26533 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39205" />
+    </g>
+    <g
+       aria-label="ſ"
+       id="text17107-3-8-2-2-8-4-1-3-0-9"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 971.1606,208.40871 h -0.0846 q -0.26237,-0.0762 -0.68555,-0.15234 -0.42318,-0.0846 -0.74479,-0.0846 -1.02409,0 -1.46419,0.45703 -0.43164,0.44856 -0.43164,1.63346 v 9.77537 h -1.59114 v -9.76691 q 0,-1.64192 0.82096,-2.56445 0.82096,-0.92252 2.43749,-0.92252 0.53321,0 0.95638,0.0508 0.43164,0.0508 0.78711,0.11849 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39202" />
+    </g>
+    <g
+       aria-label="\"
+       id="text17107-3-8-2-2-8-4-1-3-0-75"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 263.82867,278.80028 h 0.74533 q 0.208,0 0.32933,0.25999 0.24267,0.64134 1.924,5.32133 1.68133,4.66266 1.92399,5.28665 0.104,0.27734 -0.19066,0.27734 h -0.728 q -0.208,0 -0.32933,-0.26 l -3.848,-10.59065 q -0.104,-0.29466 0.17334,-0.29466 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39199" />
+    </g>
+    <g
+       aria-label="#"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-58"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 304.50735,351.43762 q 0.24267,0 0.24267,0.24266 v 0.572 q 0,0.24267 -0.24267,0.24267 h -1.73333 l -0.95333,3.55333 h 1.612 q 0.24266,0 0.24266,0.24266 v 0.572 q 0,0.24267 -0.24266,0.24267 h -1.90667 l -0.65866,2.47866 q -0.0693,0.26 -0.29467,0.26 h -0.58933 q -0.24267,0 -0.17333,-0.312 l 0.65866,-2.42666 h -2.91199 l -0.65867,2.47866 q -0.0693,0.26 -0.312,0.26 h -0.55466 q -0.27734,0 -0.17334,-0.312 l 0.65867,-2.42666 h -1.52533 q -0.24267,0 -0.24267,-0.24267 v -0.572 q 0,-0.24266 0.24267,-0.24266 h 1.80266 l 0.95333,-3.55333 h -1.68133 q -0.26,0 -0.26,-0.24267 v -0.572 q 0,-0.24266 0.26,-0.24266 h 1.976 l 0.65866,-2.47866 q 0.052,-0.26 0.27734,-0.26 h 0.55466 q 0.312,0 0.208,0.312 l -0.65866,2.42666 h 2.91199 l 0.65867,-2.47866 q 0.0867,-0.26 0.32933,-0.26 h 0.52 q 0.27733,0 0.208,0.312 l -0.65867,2.42666 z m -3.76133,4.61066 0.95334,-3.55333 h -2.89467 l -0.95333,3.55333 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39196" />
+    </g>
+    <g
+       aria-label="/"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-3"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 336.414,289.94559 h -0.71067 q -0.312,0 -0.208,-0.27734 0.27733,-0.69333 1.95866,-5.37332 1.69867,-4.69732 1.90667,-5.23466 0.104,-0.25999 0.32933,-0.25999 h 0.728 q 0.29466,0 0.17333,0.29466 l -3.84799,10.59065 q -0.0867,0.26 -0.32933,0.26 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39193" />
+    </g>
+    <g
+       aria-label="{"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-9"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 411.95267,278.80028 h 0.0867 q 0.24267,0 0.24267,0.24266 v 0.468 q 0,0.24267 -0.24267,0.24267 h -0.052 q -0.64133,0 -0.88399,0.364 -0.24267,0.364 -0.24267,1.14399 v 2.32267 q 0,1.35199 -0.988,1.68133 0.988,0.27733 0.988,1.66399 v 2.32267 q 0,0.77999 0.24267,1.14399 0.24266,0.364 0.88399,0.364 h 0.052 q 0.24267,0 0.24267,0.24267 v 0.468 q 0,0.24266 -0.24267,0.24266 h -0.0867 q -2.14933,0 -2.14933,-2.56532 v -2.132 q 0,-1.196 -0.97067,-1.196 -0.24266,0 -0.24266,-0.24266 v -0.624 q 0,-0.24267 0.24266,-0.24267 0.97067,0 0.97067,-1.21333 v -2.132 q 0,-2.56532 2.14933,-2.56532 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39190" />
+    </g>
+    <g
+       aria-label="}"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-1"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 482.89933,281.3563 v 2.13199 q 0,1.21333 0.97066,1.21333 0.24267,0 0.24267,0.24267 v 0.624 q 0,0.24266 -0.24267,0.24266 -0.97066,0 -0.97066,1.196 v 2.132 q 0,2.56533 -2.14933,2.56533 h -0.0867 q -0.24267,0 -0.24267,-0.24267 v -0.468 q 0,-0.24267 0.24267,-0.24267 h 0.052 q 0.624,0 0.86667,-0.36399 0.26,-0.364 0.26,-1.144 v -2.32266 q 0,-1.38667 0.98799,-1.664 -0.98799,-0.32933 -0.98799,-1.68133 v -2.32266 q 0,-0.78 -0.26,-1.144 -0.24267,-0.364 -0.86667,-0.364 h -0.052 q -0.24267,0 -0.24267,-0.24267 v -0.468 q 0,-0.24266 0.24267,-0.24266 h 0.0867 q 2.14933,0 2.14933,2.56533 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39187" />
+    </g>
+    <g
+       aria-label="*"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-7"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 552.93669,279.25897 v -0.24267 q 0,-0.22533 0.22534,-0.22533 h 0.52 q 0.24266,0 0.24266,0.22533 v 0.24267 q 0,1.16133 -0.48533,2.02799 0.988,-0.86666 1.768,-1.10933 l 0.24266,-0.0693 q 0.22533,-0.0693 0.29467,0.13866 l 0.156,0.50267 q 0.0867,0.22533 -0.156,0.29467 l -0.22534,0.0693 q -1.10933,0.364 -2.07999,0.17333 0.0173,0.0173 0.22533,0.13867 0.208,0.12133 0.416,0.26 0.676,0.48533 1.10933,1.144 0.12134,0.17333 -0.052,0.312 l -0.43333,0.312 q -0.19067,0.104 -0.32933,-0.052 l -0.12134,-0.19067 q -0.71066,-0.936 -0.81466,-1.924 0,0.0867 -0.13867,0.53734 -0.26,0.88399 -0.64133,1.40399 l -0.13867,0.208 q -0.12133,0.17333 -0.32933,0.0347 l -0.416,-0.312 q -0.19066,-0.104 -0.052,-0.32933 l 0.13867,-0.17334 q 0.58933,-0.83199 1.57733,-1.36933 -1.352,0.0867 -2.08,-0.13866 l -0.24266,-0.0693 q -0.22534,-0.0867 -0.13867,-0.29466 l 0.17333,-0.50267 q 0.052,-0.208 0.29467,-0.13866 1.26533,0.43333 1.99333,1.14399 0,-0.0173 -0.0693,-0.156 -0.0693,-0.156 -0.13867,-0.34666 -0.052,-0.19067 -0.13867,-0.416 -0.156,-0.50267 -0.156,-1.10933 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39184" />
+    </g>
+    <g
+       aria-label="?"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-6"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 625.32065,287.59628 v 2.09733 q 0,0.24267 -0.22533,0.24267 h -0.884 q -0.22533,0 -0.22533,-0.26 v -2.08 q 0,-0.22533 0.22533,-0.22533 h 0.884 q 0.22533,0 0.22533,0.22533 z m -0.0347,-2.20133 v 0.58934 q 0,0.24266 -0.24266,0.24266 h -0.728 q -0.24267,0 -0.24267,-0.24266 v -0.55467 q 0,-0.676 0.19067,-1.04 0.208,-0.38133 0.76266,-0.84933 l 0.728,-0.624 q 0.64134,-0.53733 0.64134,-1.19599 v -0.364 q 0,-1.47333 -1.49067,-1.47333 h -0.58933 q -1.456,0 -1.456,1.47333 v 0.62399 q 0,0.24267 -0.24266,0.24267 h -0.78 q -0.22534,0 -0.22534,-0.24267 v -0.64133 q 0,-1.19599 0.676,-1.85466 0.676,-0.676 1.872,-0.676 h 0.90133 q 1.196,0 1.872,0.676 0.69333,0.65867 0.69333,1.85466 v 0.45067 q 0,0.90133 -0.81467,1.57733 l -0.90133,0.76266 q -0.39866,0.34667 -0.52,0.58934 -0.104,0.24266 -0.104,0.67599 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39181" />
+    </g>
+    <g
+       aria-label="("
+       id="text17107-3-8-2-2-8-4-1-3-0-75-8"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 699.20466,279.7443 h -0.052 q -0.79733,0 -1.23066,0.50266 -0.43334,0.50267 -0.43334,1.43867 v 7.12398 q 0,0.936 0.43334,1.43867 0.43333,0.50266 1.24799,0.50266 h 0.0347 q 0.24267,0 0.24267,0.22534 v 0.53733 q 0,0.19067 -0.24267,0.19067 h -0.052 q -1.26533,0 -1.99333,-0.76267 -0.728,-0.76266 -0.728,-2.23599 v -6.91599 q 0,-1.47333 0.728,-2.236 0.728,-0.76266 1.99333,-0.76266 h 0.0693 q 0.22534,0 0.22534,0.19066 v 0.53734 q 0,0.22533 -0.24267,0.22533 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39178" />
+    </g>
+    <g
+       aria-label=")"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-63"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 768.20068,291.51361 v -0.53733 q 0,-0.22534 0.22533,-0.22534 h 0.052 q 0.78,0 1.21333,-0.50266 0.45067,-0.50267 0.45067,-1.43867 v -7.12398 q 0,-0.936 -0.45067,-1.43867 -0.43333,-0.50266 -1.21333,-0.50266 h -0.052 q -0.22533,0 -0.22533,-0.22533 v -0.53734 q 0,-0.19066 0.22533,-0.19066 h 0.052 q 1.26533,0 1.99333,0.76266 0.74533,0.76267 0.74533,2.236 v 6.91599 q 0,1.47333 -0.74533,2.23599 -0.728,0.76267 -1.99333,0.76267 h -0.052 q -0.22533,0 -0.22533,-0.19067 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39175" />
+    </g>
+    <g
+       aria-label="-"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-54"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 843.20466,284.92696 h -3.536 q -0.24266,0 -0.24266,-0.24267 v -0.572 q 0,-0.24267 0.24266,-0.24267 h 3.536 q 0.24266,0 0.24266,0.24267 v 0.572 q 0,0.24267 -0.24266,0.24267 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39172" />
+    </g>
+    <g
+       aria-label=":"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-94"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 914.97535,281.32163 v 2.09733 q 0,0.24266 -0.22533,0.24266 h -0.884 q -0.22533,0 -0.22533,-0.25999 v -2.06267 q 0,-0.24266 0.22533,-0.24266 h 0.884 q 0.22533,0 0.22533,0.22533 z m 0,6.27465 v 2.09733 q 0,0.24267 -0.22533,0.24267 h -0.884 q -0.22533,0 -0.22533,-0.26 v -2.08 q 0,-0.22533 0.22533,-0.22533 h 0.884 q 0.22533,0 0.22533,0.22533 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39169" />
+    </g>
+    <g
+       aria-label="/"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-5"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 1036.5326,220.0376 h -0.7107 q -0.312,0 -0.208,-0.27734 0.2773,-0.69333 1.9587,-5.37332 1.6986,-4.69732 1.9066,-5.23465 0.104,-0.26 0.3294,-0.26 h 0.7279 q 0.2947,0 0.1734,0.29466 l -3.848,10.59065 q -0.087,0.26 -0.3293,0.26 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39166" />
+    </g>
+    <g
+       aria-label="˜"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-5-4"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 1010.7233,208.71895 v -0.65866 q 0,-0.19067 0.1387,-0.19067 h 0.3813 q 0.156,0 0.156,0.19067 v 0.45066 q 0,0.48534 0.087,0.65867 0.087,0.17333 0.2947,0.17333 0.2253,0 0.3293,-0.13866 0.1214,-0.13867 0.3294,-0.60667 0.2253,-0.468 0.4333,-0.624 0.208,-0.156 0.7107,-0.156 0.9533,0 0.9533,1.33467 v 0.69333 q 0,0.19066 -0.1387,0.19066 h -0.3813 q -0.156,0 -0.156,-0.19066 v -0.468 q 0,-0.50267 -0.087,-0.676 -0.087,-0.17333 -0.2773,-0.17333 -0.1733,0 -0.2427,0.0173 -0.052,0.0173 -0.1386,0.12133 -0.069,0.104 -0.104,0.19067 -0.035,0.0693 -0.208,0.468 -0.1734,0.39866 -0.3987,0.572 -0.2253,0.156 -0.728,0.156 -0.9533,0 -0.9533,-1.33467 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium'"
+         id="path39163" />
+    </g>
+    <g
+       aria-label="@"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-34"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 983.53667,290.94161 h -3.13732 q -1.80267,0 -3.08533,-1.16133 -1.28266,-1.16133 -1.28266,-3.11999 v -2.86 q 0,-1.924 1.24799,-3.11999 1.248,-1.196 2.98133,-1.196 h 3.43199 q 1.26534,0 2.04533,0.76266 0.78,0.74534 0.78,1.94133 v 3.98666 q 0,1.04 -0.64133,1.68133 -0.64133,0.64134 -1.68133,0.64134 h -0.676 q -0.32933,0 -0.55466,-0.17334 -0.22534,-0.19066 -0.22534,-0.50266 v -0.26 h -0.0693 q -0.43333,0.91866 -1.80266,0.91866 -1.05733,0 -1.69867,-0.65866 -0.64133,-0.65867 -0.64133,-1.83733 v -1.456 q 0,-1.196 0.65867,-1.872 0.65866,-0.69333 1.76799,-0.69333 h 2.61733 q 0.24267,0 0.24267,0.24267 v 5.28665 q 0,0.17334 0.24266,0.17334 h 0.0867 q 1.52533,0 1.52533,-1.57733 v -3.83066 q 0,-0.936 -0.55466,-1.43867 -0.55467,-0.52 -1.49067,-0.52 h -3.31066 q -1.47333,0 -2.46133,0.97067 -0.97066,0.97066 -0.97066,2.58266 v 2.72133 q 0,1.612 1.00533,2.58266 1.00533,0.97067 2.49599,0.97067 h 3.15466 q 0.24267,0 0.24267,0.22533 v 0.34666 q 0,0.24267 -0.24267,0.24267 z m -0.79733,-5.04399 v -2.77333 q 0,-0.17333 -0.17333,-0.17333 h -1.456 q -1.45599,0 -1.45599,1.508 v 1.52533 q 0,1.50799 1.45599,1.50799 h 0.0347 q 0.78,0 1.17866,-0.416 0.416,-0.41599 0.416,-1.17866 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39160" />
+    </g>
+    <g
+       aria-label="$"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-37"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 373.37266,361.54293 h -0.58933 q -0.24267,0 -0.24267,-0.24266 v -1.456 h -0.416 q -1.16133,0 -1.85466,-0.69333 -0.676,-0.69334 -0.676,-1.872 v -0.48533 q 0,-0.24267 0.22533,-0.24267 h 0.79734 q 0.22533,0 0.22533,0.24267 v 0.38133 q 0,1.56 1.54266,1.56 h 1.092 q 1.54266,0 1.54266,-1.59467 v -0.81466 q 0,-0.81467 -0.45066,-1.144 -0.45067,-0.32933 -1.36933,-0.364 l -0.95333,-0.0173 q -1.248,-0.052 -1.95867,-0.60667 -0.71066,-0.55466 -0.71066,-1.99333 v -0.95333 q 0,-1.196 0.676,-1.87199 0.69333,-0.69334 1.87199,-0.69334 h 0.416 v -1.47333 q 0,-0.24266 0.24267,-0.24266 h 0.58933 q 0.24267,0 0.24267,0.24266 v 1.47333 h 0.12133 q 1.12666,0 1.80266,0.69334 0.676,0.69333 0.676,1.87199 v 0.43333 q 0,0.26 -0.24266,0.26 h -0.78 q -0.24267,0 -0.24267,-0.26 v -0.32933 q 0,-1.55999 -1.54266,-1.55999 h -1.02267 q -1.54266,0 -1.54266,1.62933 v 0.81466 q 0,0.78 0.43333,1.092 0.45067,0.29466 1.36933,0.32933 l 1.07467,0.0347 q 1.17866,0.052 1.87199,0.624 0.69333,0.572 0.69333,1.95866 v 1.00533 q 0,1.196 -0.69333,1.88933 -0.676,0.676 -1.85466,0.676 h -0.12133 v 1.456 q 0,0.24266 -0.24267,0.24266 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39157" />
+    </g>
+    <g
+       aria-label="|"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-4"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 447.88335,348.94162 v 10.65998 q 0,0.24267 -0.24267,0.24267 h -0.468 q -0.22533,0 -0.22533,-0.24267 v -10.65998 q 0,-0.24266 0.22533,-0.24266 h 0.468 q 0.24267,0 0.24267,0.24266 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39154" />
+    </g>
+    <g
+       aria-label="~"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-71"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 518.07397,355.00828 q -0.65867,0 -1.82,-0.26 -1.144,-0.26 -1.61199,-0.26 -0.468,0 -0.988,0.208 -0.52,0.208 -0.572,0.208 -0.19067,0 -0.19067,-0.208 v -0.52 q 0,-0.26 0.364,-0.43333 0.64133,-0.26 1.28267,-0.26 0.65866,0 1.78533,0.27733 1.12666,0.26 1.62933,0.26 0.51999,0 1.03999,-0.208 0.52,-0.22533 0.572,-0.22533 0.17334,0 0.17334,0.208 v 0.53733 q 0,0.26 -0.364,0.416 -0.64134,0.26 -1.3,0.26 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39151" />
+    </g>
+    <g
+       aria-label="`"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-95"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 591.55934,349.88562 h -0.572 q -0.208,0 -0.34667,-0.17334 l -1.50799,-1.81999 q -0.0693,-0.104 -0.0347,-0.17334 0.0347,-0.0693 0.13867,-0.0693 h 1.05733 q 0.24266,0 0.364,0.22533 l 1.00533,1.768 q 0.13867,0.24267 -0.104,0.24267 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39148" />
+    </g>
+    <g
+       aria-label="+"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-73"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 660.55534,353.73361 h 2.59999 q 0.26,0 0.26,0.26 v 0.55466 q 0,0.24267 -0.26,0.24267 h -2.59999 v 2.63466 q 0,0.27733 -0.26,0.27733 h -0.58933 q -0.26,0 -0.26,-0.27733 v -2.63466 h -2.61733 q -0.26,0 -0.26,-0.24267 v -0.55466 q 0,-0.26 0.26,-0.26 h 2.61733 v -2.61733 q 0,-0.27733 0.26,-0.27733 h 0.58933 q 0.26,0 0.26,0.27733 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39145" />
+    </g>
+    <g
+       aria-label="%"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-0"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 733.46864,355.46694 h -0.32933 q -0.65867,0 -0.90134,0.27733 -0.24266,0.26 -0.24266,0.936 v 1.12666 q 0,0.65867 0.24266,0.936 0.24267,0.27734 0.90134,0.27734 h 0.32933 q 0.64133,0 0.884,-0.27734 0.24266,-0.27733 0.24266,-0.936 v -1.12666 q 0,-0.676 -0.24266,-0.936 -0.24267,-0.27733 -0.884,-0.27733 z m -0.48533,-0.81467 h 0.60666 q 1.94133,0 1.94133,1.976 v 1.21333 q 0,1.99333 -1.94133,1.99333 h -0.60666 q -1.94133,0 -1.94133,-1.99333 v -1.21333 q 0,-1.976 1.94133,-1.976 z m -5.85866,-5.19999 h -0.32933 q -0.64133,0 -0.884,0.27734 -0.24267,0.26 -0.24267,0.91866 v 1.144 q 0,0.676 0.24267,0.95333 0.24267,0.26 0.884,0.26 h 0.32933 q 0.64133,0 0.884,-0.27733 0.24267,-0.27734 0.24267,-0.936 v -1.144 q 0,-0.65866 -0.24267,-0.91866 -0.24267,-0.27734 -0.884,-0.27734 z m -0.468,-0.81466 h 0.60667 q 1.94133,0 1.94133,1.976 v 1.21333 q 0,1.97599 -1.94133,1.97599 h -0.60667 q -1.94133,0 -1.94133,-1.97599 v -1.21333 q 0,-1.976 1.94133,-1.976 z m 1.38667,11.19731 h -0.50267 q -0.27733,0 -0.156,-0.27733 0.24267,-0.64133 2.236,-5.30399 2.01066,-4.67999 2.25332,-5.30399 0.12134,-0.26 0.312,-0.26 h 0.50267 q 0.27733,0 0.156,0.29466 l -4.47199,10.59065 q -0.104,0.26 -0.32933,0.26 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39142" />
+    </g>
+    <g
+       aria-label=";"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-48"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 950.83137,357.49493 v 1.36934 q 0,0.38133 -0.26,1.00533 l -0.69333,1.62933 q -0.0867,0.13866 -0.208,0.13866 -0.17334,0 -0.17334,-0.22533 v -3.91733 q 0,-0.22533 0.22534,-0.22533 h 0.88399 q 0.22534,0 0.22534,0.22533 z m 0,-6.27465 v 2.09733 q 0,0.24267 -0.22534,0.24267 h -0.88399 q -0.22534,0 -0.22534,-0.26 v -2.06267 q 0,-0.24266 0.22534,-0.24266 h 0.88399 q 0.22534,0 0.22534,0.22533 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39139" />
+    </g>
+    <g
+       aria-label="&quot;"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-48-7-8"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 803.9633,352.39894 h -0.13866 q -0.22534,0 -0.26,-0.27733 l -0.27734,-3.18933 q 0,-0.24266 0.22534,-0.24266 h 0.76266 q 0.24267,0 0.208,0.24266 l -0.26,3.20667 q -0.0173,0.25999 -0.26,0.25999 z m 2.72133,0 h -0.156 q -0.208,0 -0.24266,-0.27733 l -0.27734,-3.18933 q 0,-0.24266 0.22534,-0.24266 h 0.76266 q 0.24267,0 0.208,0.24266 l -0.26,3.20667 q -0.0347,0.25999 -0.26,0.25999 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39136" />
+    </g>
+    <g
+       aria-label="–"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-48-7-8-5"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 782.31531,354.70427 h -5.14799 q -0.24266,0 -0.24266,-0.24266 v -0.45067 q 0,-0.24266 0.24266,-0.24266 h 5.14799 q 0.24267,0 0.24267,0.24266 v 0.45067 q 0,0.24266 -0.24267,0.24266 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium'"
+         id="path39133" />
+    </g>
+    <g
+       aria-label="'"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-48-7-8-9"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 878.42733,352.12161 h -0.17334 q -0.22533,0 -0.24266,-0.22533 l -0.26,-2.72133 q -0.0173,-0.22533 0.22533,-0.22533 h 0.728 q 0.24266,0 0.22533,0.22533 l -0.24267,2.72133 q -0.0693,0.22533 -0.25999,0.22533 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium';text-align:end;text-anchor:end"
+         id="path39130" />
+    </g>
+    <g
+       aria-label="•"
+       id="text17107-3-8-2-2-8-4-1-3-0-75-48-7-8-5-1"
+       style="font-weight:600;font-size:17.3333px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';stroke-width:2.83465">
+      <path
+         d="m 851.42333,353.38694 v 1.82 q 0,0.624 -0.624,0.624 H 850.054 q -0.624,0 -0.624,-0.624 v -1.82 q 0,-0.624 0.624,-0.624 h 0.74533 q 0.624,0 0.624,0.624 z"
+         style="font-weight:500;-inkscape-font-specification:'Rajdhani Medium'"
+         id="path39127" />
+    </g>
+    <g
+       id="text25422"
+       style="font-weight:600;font-size:26.6667px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';fill:#0000ff;stroke-width:2.83465" />
+    <g
+       aria-label="STRG"
+       id="text6809-9-0-9-0"
+       style="font-weight:bold;font-size:10.6667px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue Bold';text-align:center;letter-spacing:0.66px;text-anchor:middle;stroke-width:2.83465">
+      <path
+         d="m 852.6593,403.87988 v -0.27734 q 0,-0.18133 0.18134,-0.18133 h 0.68266 q 0.18134,0 0.18134,0.18133 v 0.19201 q 0,0.448 0.192,0.65066 0.20267,0.192 0.66133,0.192 h 0.73601 q 0.45866,0 0.66133,-0.20266 0.20267,-0.21334 0.20267,-0.68267 v -0.24534 q 0,-0.34133 -0.26667,-0.53333 -0.256,-0.20267 -0.64,-0.256 -0.384,-0.064 -0.84267,-0.17067 -0.45867,-0.10667 -0.84267,-0.24533 -0.384,-0.13867 -0.65067,-0.52267 -0.256,-0.384 -0.256,-0.98134 v -0.448 q 0,-0.77867 0.43734,-1.216 0.448,-0.448 1.22667,-0.448 h 1.13067 q 0.78933,0 1.22667,0.448 0.448,0.43733 0.448,1.216 v 0.23467 q 0,0.18133 -0.18134,0.18133 h -0.68266 q -0.18134,0 -0.18134,-0.18133 v -0.13867 q 0,-0.45867 -0.20267,-0.65067 -0.192,-0.20266 -0.65066,-0.20266 h -0.67201 q -0.45866,0 -0.66133,0.21333 -0.192,0.20267 -0.192,0.704 v 0.33067 q 0,0.48 0.69333,0.65067 0.30934,0.0747 0.67201,0.128 0.37333,0.0533 0.74666,0.16 0.37334,0.10667 0.68267,0.288 0.30934,0.17067 0.50134,0.53333 0.192,0.35201 0.192,0.86401 v 0.416 q 0,0.77867 -0.448,1.22667 -0.43734,0.43733 -1.21601,0.43733 h -1.19467 q -0.77867,0 -1.22667,-0.43733 -0.448,-0.448 -0.448,-1.22667 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39117" />
+      <path
+         d="m 861.16998,405.54388 h -0.67201 q -0.192,0 -0.192,-0.18133 v -5.66402 q 0,-0.10666 -0.10666,-0.10666 h -1.34401 q -0.192,0 -0.192,-0.18134 v -0.544 q 0,-0.18133 0.192,-0.18133 h 3.95735 q 0.192,0 0.192,0.18133 v 0.544 q 0,0.18134 -0.192,0.18134 h -1.34401 q -0.11733,0 -0.11733,0.10666 v 5.66402 q 0,0.18133 -0.18133,0.18133 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39119" />
+      <path
+         d="m 865.4353,405.54388 h -0.672 q -0.18134,0 -0.18134,-0.18133 v -6.49602 q 0,-0.18133 0.18134,-0.18133 h 2.49601 q 0.77867,0 1.216,0.448 0.448,0.43733 0.448,1.216 v 0.896 q 0,1.22667 -1.01334,1.54668 v 0.0427 l 1.18401,2.49601 q 0.11733,0.21333 -0.13867,0.21333 h -0.66133 q -0.256,0 -0.33067,-0.18133 l -1.14134,-2.45334 h -1.07734 q -0.128,0 -0.128,0.10667 v 2.34667 q 0,0.18133 -0.18133,0.18133 z m 0.29867,-3.48801 h 1.35467 q 0.78933,0 0.78933,-0.77867 v -0.896 q 0,-0.78933 -0.78933,-0.78933 h -1.35467 q -0.11734,0 -0.11734,0.10666 v 2.25068 q 0,0.10666 0.11734,0.10666 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39121" />
+      <path
+         d="m 873.71132,405.54388 h -1.14133 q -0.78934,0 -1.22667,-0.43733 -0.42667,-0.43734 -0.42667,-1.216 v -3.55202 q 0,-0.78933 0.42667,-1.216 0.43733,-0.43733 1.22667,-0.43733 h 1.14133 q 0.78934,0 1.21601,0.43733 0.43733,0.42667 0.43733,1.216 v 0.38401 q 0,0.192 -0.18133,0.192 h -0.672 q -0.18134,0 -0.18134,-0.192 v -0.34134 q 0,-0.78933 -0.768,-0.78933 h -0.84267 q -0.768,0 -0.768,0.78933 v 3.46668 q 0,0.78933 0.768,0.78933 h 0.84267 q 0.768,0 0.768,-0.78933 v -0.96 q 0,-0.10667 -0.11733,-0.10667 h -0.864 q -0.18134,0 -0.18134,-0.18134 v -0.544 q 0,-0.18133 0.18134,-0.18133 h 1.792 q 0.224,0 0.224,0.224 v 1.79201 q 0,0.77866 -0.43733,1.216 -0.43734,0.43733 -1.21601,0.43733 z"
+         style="font-weight:600;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold'"
+         id="path39123" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Adds a new template for German [NEO2 keyboard layout](https://en.wikipedia.org/wiki/Neo_(keyboard_layout)) on InfinityBook Pro 14, Gen9 and 10. It only shows key labels up to layer 3 to maintain a clean look.